### PR TITLE
add missing commands to config.yaml, add event filter to dev:module:obse...

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -69,6 +69,8 @@ commands:
     - N98\Magento\Command\Installer\InstallCommand
     - N98\Magento\Command\ScriptCommand
     - N98\Magento\Command\ShellCommand
+    - N98\Magento\Command\Developer\Module\ListCommand
+    - N98\Magento\Command\Developer\Module\Observer\ListCommand
 
   disabled:
     - dummy


### PR DESCRIPTION
All new commands are now in config.yaml, I think. Minor update to `dev:module:observer:list` (#83) so you can quickly find registered observers for specific event.