### PR TITLE
[#157] Changed moduleFolder to moduleDirectory

### DIFF
--- a/src/N98/Magento/Command/Developer/Module/Create/SubCommand/CreateComposerFile.php
+++ b/src/N98/Magento/Command/Developer/Module/Create/SubCommand/CreateComposerFile.php
@@ -14,7 +14,7 @@ class CreateComposerFile extends AbstractSubCommand
         if ($this->config->getBool('isModmanMode')) {
             $outFile = $this->config->getString('modmanRootFolder') . '/composer.json';
         } else {
-            $outFile = $this->config->getString('moduleFolder') . '/composer.json';
+            $outFile = $this->config->getString('moduleDirectory') . '/composer.json';
         }
 
         \file_put_contents(


### PR DESCRIPTION
As per #157 the `CreateModuleFolders` class defines the config string as `moduleDirectory`:

```
$this->config->setString('moduleDirectory', $moduleDir);
```

Updated in the `CreateComposerFile.php` class.