### PR TITLE
Update Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: trusty
+
 language: php
 
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,7 @@ matrix:
       env: MAGENTO_VERSION="magento-ce-2.0.0-rc" DB=mysql INSTALL_SAMPLE_DATA=0
 
 before_install:
+  - phpenv config-rm xdebug.ini
   - travis_retry composer self-update
 
 install:

--- a/build/travis/mysql-5.6-install.sh
+++ b/build/travis/mysql-5.6-install.sh
@@ -7,6 +7,6 @@ sudo apt-get remove --purge mysql-common mysql-server-5.5 mysql-server-core-5.5 
 sudo apt-get autoremove;
 sudo apt-get autoclean;
 sudo apt-add-repository ppa:ondrej/mysql-5.6 -y;
-sudo apt-get update;
-sudo apt-get install mysql-server-5.6 mysql-client-5.6;
+sudo apt-get update -qq;
+sudo apt-get install -qq mysql-server-5.6 mysql-client-5.6 mysql-client-core-5.6;
 mysql -uroot -e 'SET @@global.sql_mode = NO_ENGINE_SUBSTITUTION; CREATE DATABASE magento_travis;';


### PR DESCRIPTION
Installing of Mysql 5.6 for Magento 2 failed recently. Fix for that in this PR.

Additionally composer moans about xdebug being enabled and rightly so! As xdebug is not used any longer for the build, it's safe to disable which is done with this PR.