### PR TITLE
[#132] Ported Giftcard commands

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -75,6 +75,10 @@ commands:
     - N98\Magento\Command\Developer\TemplateHintsCommand
     - N98\Magento\Command\Developer\Theme\ListCommand
     - N98\Magento\Command\Generation\FlushCommand
+    - N98\Magento\Command\GiftCard\Pool\GenerateCommand
+    - N98\Magento\Command\GiftCard\CreateCommand
+    - N98\Magento\Command\GiftCard\InfoCommand
+    - N98\Magento\Command\GiftCard\RemoveCommand
     - N98\Magento\Command\OpenBrowserCommand
     - N98\Magento\Command\Script\Repository\ListCommand
     - N98\Magento\Command\Script\Repository\RunCommand

--- a/readme.rst
+++ b/readme.rst
@@ -279,6 +279,40 @@ Enable Magento cache
 If no code is specified, all cache types will be enabled.
 Run `cache:list` command to see all codes.
 
+Generate Gift Card Pool
+"""""""""""""""""
+
+Generates a new gift card pool.
+
+.. code-block:: sh
+
+   $ n98-magerun2.phar giftcard:pool:generate
+
+Create a Gift Card
+"""""""""""""""""
+
+.. code-block:: sh
+
+   $ n98-magerun2.phar giftcard:create [--website[="..."]] [--expires[="..."]] [amount]
+
+You may specify a website ID or use the default. You may also optionally add an expiration date to the gift card
+using the `--expires` option. Dates should be in `YYYY-MM-DD` format.
+
+View Gift Card Information
+"""""""""""""""""
+
+.. code-block:: sh
+
+   $ n98-magerun2.phar giftcard:info [--format[="..."]] [code]
+
+Remove a Gift Card
+"""""""""""""""""
+
+.. code-block:: sh
+
+   $ n98-magerun2.phar giftcard:remove [code]
+
+
 n98-magerun Shell
 """""""""""""""""
 

--- a/src/N98/Magento/Command/GiftCard/AbstractGiftCardCommand.php
+++ b/src/N98/Magento/Command/GiftCard/AbstractGiftCardCommand.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace N98\Magento\Command\GiftCard;
+
+use N98\Magento\Command\AbstractMagentoCommand;
+use Magento\GiftCardAccount\Model\Giftcardaccount;
+
+abstract class AbstractGiftCardCommand extends AbstractMagentoCommand
+{
+    /**
+     * @return bool
+     */
+    public function isEnabled()
+    {
+        return $this->getApplication()->isMagentoEnterprise();
+    }
+
+    /**
+     * Get the gift card model, optionally loading from an ID
+     * @param  string|null $code
+     * @return Giftcardaccount
+     */
+    public function getGiftcard($code = null)
+    {
+        $giftcard = $this->getObjectManager()->get(Giftcardaccount::class);
+        if (!is_null($code)) {
+            $giftcard->loadByCode($code);
+        }
+        return $giftcard;
+    }
+
+    /**
+     * Required to avoid "Area code not set" exceptions from Mage framework
+     */
+    public function setAdminArea()
+    {
+        $appState = $this->getObjectManager()->get('Magento\Framework\App\State');
+        $appState->setAreaCode('adminhtml');
+    }
+}

--- a/src/N98/Magento/Command/GiftCard/CreateCommand.php
+++ b/src/N98/Magento/Command/GiftCard/CreateCommand.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace N98\Magento\Command\GiftCard;
+
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Input\InputArgument;
+
+class CreateCommand extends AbstractGiftCardCommand
+{
+    /**
+     * Setup
+     * 
+     * @return void
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('giftcard:create')
+            ->addArgument('amount', InputArgument::REQUIRED, 'Amount for new gift card')
+            ->addOption('website', null, InputOption::VALUE_OPTIONAL, 'Website ID to attach gift card to')
+            ->addOption('expires', null, InputOption::VALUE_OPTIONAL, 'Expiration date in YYYY-MM-DD format')
+            ->setDescription('Create a new gift card with a specified amount');
+
+        $help = <<<HELP
+Create a new gift card with a specified amount
+HELP;
+        $this->setHelp($help);
+    }
+
+    /**
+     * @param \Symfony\Component\Console\Input\InputInterface $input
+     * @param \Symfony\Component\Console\Output\OutputInterface $output
+     * @return void
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $this->detectMagento($output, true);
+        if (!$this->initMagento()) {
+            return;
+        }
+
+        $this->setAdminArea();
+
+        $giftcard = $this->getGiftcard();
+        $giftcard->setData(
+            array(
+                'status'        => 1,
+                'is_redeemable' => 1,
+                'website_id'    => $input->getOption('website')
+                    ? : $this->getObjectManager()->get('Magento\Store\Model\StoreManager')->getWebsite(true)->getId(),
+                'balance'       => $input->getArgument('amount'),
+                'date_expires'  => $input->getOption('expires')
+            )
+        );
+        
+        $giftcard->save();
+        if (!$giftcard->getId()) {
+            $output->writeln('<error>Failed to create gift card</error>');
+            return;
+        }
+
+        $output->writeln('<info>Gift card <comment>' . $giftcard->getCode() . '</comment> was created</info>');
+    }
+}

--- a/src/N98/Magento/Command/GiftCard/InfoCommand.php
+++ b/src/N98/Magento/Command/GiftCard/InfoCommand.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace N98\Magento\Command\GiftCard;
+
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use N98\Util\Console\Helper\Table\Renderer\RendererFactory;
+use Magento\GiftCardAccount\Model\Giftcardaccount;
+
+class InfoCommand extends AbstractGiftCardCommand
+{
+    /**
+     * Setup
+     * 
+     * @return void
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('giftcard:info')
+            ->addArgument('code', \Symfony\Component\Console\Input\InputArgument::REQUIRED, 'Gift card code')
+            ->addOption(
+                'format',
+                null,
+                InputOption::VALUE_OPTIONAL,
+                'Output Format. One of [' . implode(',', RendererFactory::getFormats()) . ']'
+            )
+            ->setDescription('Get gift card account information by code');
+
+        $help = <<<HELP
+Get gift card account information by code
+HELP;
+        $this->setHelp($help);
+    }
+
+    /**
+     * @param \Symfony\Component\Console\Input\InputInterface $input
+     * @param \Symfony\Component\Console\Output\OutputInterface $output
+     * @return void
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $this->detectMagento($output, true);
+        if (!$this->initMagento()) {
+            return;
+        }
+
+        $this->setAdminArea();
+
+        $card = $this->getGiftcard($input->getArgument('code'));
+        if (!$card->getId()) {
+            $output->writeln('<error>No gift card found for that code</error>');
+            return;
+        }
+        
+        $data = array(
+            array('Gift Card Account ID', $card->getId()),
+            array('Code', $card->getCode()),
+            array('Status', Giftcardaccount::STATUS_ENABLED == $card->getStatus() ? 'Enabled' : 'Disabled'),
+            array('Date Created', $card->getDateCreated()),
+            array('Expiration Date', $card->getDateExpires()),
+            array('Website ID', $card->getWebsiteId()),
+            array('Remaining Balance', $card->getBalance()),
+            array('State', $card->getStateText()),
+            array('Is Redeemable', $card->getIsRedeemable())
+        );
+        
+        $this->getHelper('table')
+            ->setHeaders(array('Name', 'Value'))
+            ->setRows($data)
+            ->renderByFormat($output, $data, $input->getOption('format'));
+    }
+}

--- a/src/N98/Magento/Command/GiftCard/Pool/GenerateCommand.php
+++ b/src/N98/Magento/Command/GiftCard/Pool/GenerateCommand.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace N98\Magento\Command\GiftCard\Pool;
+
+use N98\Magento\Command\GiftCard\AbstractGiftCardCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Input\InputArgument;
+use Magento\GiftCardAccount\Model\Pool;
+
+class GenerateCommand extends AbstractGiftCardCommand
+{
+    /**
+     * Setup
+     * 
+     * @return void
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('giftcard:pool:generate')
+            ->setDescription('Generate a new gift card pool');
+
+        $help = <<<HELP
+Generate a new gift card pool
+HELP;
+        $this->setHelp($help);
+    }
+
+    /**
+     * @param \Symfony\Component\Console\Input\InputInterface $input
+     * @param \Symfony\Component\Console\Output\OutputInterface $output
+     * @return void
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $this->detectMagento($output, true);
+        if (!$this->initMagento()) {
+            return;
+        }
+
+        $this->setAdminArea();
+
+        try {
+            $this
+                ->getObjectManager()
+                ->create(Pool::class)
+                ->generatePool();
+
+            $output->writeln('<info>Gift card pool was generated.</info>');
+        } catch (\Exception $e) {
+            $output->writeln('<error>Failed to generate gift card pool!</error>');
+        }
+    }
+}

--- a/src/N98/Magento/Command/GiftCard/RemoveCommand.php
+++ b/src/N98/Magento/Command/GiftCard/RemoveCommand.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace N98\Magento\Command\GiftCard;
+
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Input\InputArgument;
+
+class RemoveCommand extends AbstractGiftCardCommand
+{
+    /**
+     * Setup
+     * 
+     * @return void
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('giftcard:remove')
+            ->addArgument('code', InputArgument::REQUIRED, 'Gift card code')
+            ->setDescription('Remove a gift card account by code');
+
+        $help = <<<HELP
+Remove a gift card account by code
+HELP;
+        $this->setHelp($help);
+    }
+
+    /**
+     * @param \Symfony\Component\Console\Input\InputInterface $input
+     * @param \Symfony\Component\Console\Output\OutputInterface $output
+     * @return void
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $this->detectMagento($output, true);
+        if (!$this->initMagento()) {
+            return;
+        }
+
+        $this->setAdminArea();
+
+        $code = $input->getArgument('code');
+        $card = $this->getGiftcard($code);
+
+        if (!$card->getId()) {
+            $output->writeln('<info>No gift card with matching code found</info>');
+            return;
+        }
+
+        $card->delete();
+
+        $output->writeln('<info>Deleted gift card with code <comment>' . $code . '</comment></info>');
+    }
+}


### PR DESCRIPTION
Covers #132 #133  #134:

* Ported `giftcard:create`
* Ported `giftcard:info`
* Ported `giftcard:remove`
* Ported `giftcard:pool:generate` (not "issued" yet)
* Updated readme
* Added optional expiration date to `giftcard:create`

NOTE: The `setAdminArea()` method in the AbstractGiftCardCommand is probably more general than just for gift cards. I was experiencing exceptions like "Area not set" etc being thrown from Magento framework when trying to load a giftcard model. It's reported through the Magento binary tool on their GitHub repository also, but this works for now.