### PR TITLE
[#120] Ported sys:setup:change-version command

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -88,6 +88,7 @@ commands:
     - N98\Magento\Command\System\Cron\RunCommand
     - N98\Magento\Command\System\InfoCommand
     - N98\Magento\Command\System\MaintenanceCommand
+    - N98\Magento\Command\System\Setup\ChangeVersionCommand
     - N98\Magento\Command\System\Setup\CompareVersionsCommand
     - N98\Magento\Command\System\Store\ListCommand
     - N98\Magento\Command\System\Url\ListCommand

--- a/readme.rst
+++ b/readme.rst
@@ -313,6 +313,27 @@ Remove a Gift Card
    $ n98-magerun2.phar giftcard:remove [code]
 
 
+Compare Setup Versions
+""""""""""""""""""""""
+
+Compares module version with saved setup version in `setup_module` table and displays version mismatchs if found.
+
+.. code-block:: sh
+
+   $ n98-magerun2.phar sys:setup:compare-versions [--ignore-data] [--log-junit="..."] [--format[="..."]]
+
+* If a filename with `--log-junit` option is set the tool generates an XML file and no output to *stdout*.
+
+Change Setup Version
+""""""""""""""""""""
+
+Changes the version of a module. This command is useful if you want to re-run an upgrade script again possibly for 
+debugging. Alternatively you would have to alter the row in the database manually.
+
+.. code-block:: sh
+
+   $ n98-magerun2.phar sys:setup:change-version module version
+
 n98-magerun Shell
 """""""""""""""""
 

--- a/src/N98/Magento/Command/System/Setup/ChangeVersionCommand.php
+++ b/src/N98/Magento/Command/System/Setup/ChangeVersionCommand.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace N98\Magento\Command\System\Setup;
+
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class ChangeVersionCommand extends AbstractSetupCommand
+{
+    protected $moduleList;
+    /**
+     * Setup
+     * @return void
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('sys:setup:change-version')
+            ->addArgument('module', InputArgument::REQUIRED, 'Module name')
+            ->addArgument('version', InputArgument::REQUIRED, 'New version value')
+            ->setDescription('Change module resource version');
+        $help = <<<HELP
+Change a module's resource version
+HELP;
+        $this->setHelp($help);
+    }
+
+    /**
+     * @param  InputInterface  $input
+     * @param  OutputInterface $output
+     * @return void
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $this->detectMagento($output, true);
+
+        if (!$this->initMagento()) {
+            return;
+        }
+
+        $moduleVersion = $input->getArgument('version');
+        $moduleName    = $this->getModuleName($input->getArgument('module'));
+
+        /** @var \Magento\Framework\Module\ResourceInterface */
+        $this->getResource()->setDbVersion($moduleName, $moduleVersion);
+        $this->getResource()->setDataVersion($moduleName, $moduleVersion);
+
+        $output->writeln(
+            sprintf(
+                '<info>Successfully updated: "%s" to version: "%s"</info>',
+                $moduleName,
+                $moduleVersion
+            )
+        );
+    }
+}

--- a/src/N98/Magento/Command/System/Setup/CompareVersionsCommand.php
+++ b/src/N98/Magento/Command/System/Setup/CompareVersionsCommand.php
@@ -2,25 +2,14 @@
 
 namespace N98\Magento\Command\System\Setup;
 
-use N98\Magento\Command\AbstractMagentoCommand;
 use N98\JUnitXml\Document as JUnitXmlDocument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use N98\Util\Console\Helper\Table\Renderer\RendererFactory;
 
-class CompareVersionsCommand extends AbstractMagentoCommand
+class CompareVersionsCommand extends AbstractSetupCommand
 {
-    /**
-     * @var \Magento\Framework\Module\ModuleListInterface
-     */
-    private $moduleList;
-
-    /**
-     * @var \Magento\Framework\Module\ResourceInterface
-     */
-    private $resource;
-
     protected function configure()
     {
         $this
@@ -41,17 +30,6 @@ HELP;
     }
 
     /**
-     * @param \Magento\Framework\Module\ModuleListInterface $moduleList
-     */
-    public function inject(
-        \Magento\Framework\Module\ModuleListInterface $moduleList,
-        \Magento\Framework\Module\ResourceInterface $resource
-    ) {
-        $this->moduleList = $moduleList;
-        $this->resource = $resource;
-    }
-
-    /**
      * @param \Symfony\Component\Console\Input\InputInterface $input
      * @param \Symfony\Component\Console\Output\OutputInterface $output
      * @return int|null|void
@@ -59,7 +37,7 @@ HELP;
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $time = microtime(true);
-        $ignoreDataUpdate   = $input->getOption('ignore-data');
+        $ignoreDataUpdate = $input->getOption('ignore-data');
 
         $headers = array('Setup', 'Module', 'DB', 'Data', 'Status');
         if ($ignoreDataUpdate) {
@@ -68,12 +46,12 @@ HELP;
 
         $errorCounter = 0;
         $table = array();
-        foreach ($this->moduleList->getAll() as $moduleName => $moduleInfo) {
+        foreach ($this->getModuleList()->getAll() as $moduleName => $moduleInfo) {
 
-            $moduleVersion  = $moduleInfo['setup_version'];
-            $dbVersion      = $this->resource->getDbVersion($moduleName);
+            $moduleVersion = $moduleInfo['setup_version'];
+            $dbVersion     = $this->getResource()->getDbVersion($moduleName);
             if (!$ignoreDataUpdate) {
-                $dataVersion = $this->resource->getDataVersion($moduleName);
+                $dataVersion = $this->getResource()->getDataVersion($moduleName);
             }
 
             $ok = $dbVersion == $moduleVersion;
@@ -97,9 +75,7 @@ HELP;
             $table[] = $row;
         }
 
-        //if there is no output format
-        //highlight the status
-        //and show error'd rows at bottom
+        // If there is no output format highlight the status and show error'd rows at bottom
         if (!$input->getOption('format')) {
 
             usort($table, function($a, $b) {

--- a/tests/N98/Magento/Command/System/Setup/AbstractSetupCommandTest.php
+++ b/tests/N98/Magento/Command/System/Setup/AbstractSetupCommandTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace N98\Magento\Command\System\Setup;
+
+use N98\Magento\Command\PHPUnit\TestCase;
+
+class AbstractSetupCommandTest extends TestCase
+{
+    /**
+     * Test the getModuleName() method returns the actual module name when it exists
+     * @param  string $moduleName
+     * @dataProvider validModuleNameProvider
+     */
+    public function testShouldReturnModuleNameForExistingModule($moduleName)
+    {
+        $subjectMock = $this->getSubjectMock();
+
+        $result = $subjectMock->getModuleName($moduleName);
+        $this->assertStringStartsWith('Magento', $result);
+    }
+
+    /**
+     * Provide some inconsistently cased module names
+     * @return string
+     */
+    public function validModuleNameProvider()
+    {
+        return array(
+            array('magento_catalog'),
+            array('magento_customer'),
+            array('Magento_Catalog'),
+            array('MaGeNtO_cUstOmeR')
+        );
+    }
+
+    /**
+     * Ensure that an exception is thrown when a module doesn't exist
+     * @expectedException InvalidArgumentException
+     */
+    public function testShouldThrowExceptionWhenModuleDoesntExist()
+    {
+        $this->getSubjectMock()->getModuleName('Some_Module_That_Will_Never_Exist');
+    }
+
+    /**
+     * Return a mocked test subject
+     * @return Mock_ChangeVersionCommand
+     */
+    protected function getSubjectMock()
+    {
+        $moduleListMock = $this->getMockBuilder('\Magento\Framework\Module\ModuleList')
+            ->setMethods(array('getAll'))
+            ->getMock();
+
+        $moduleListMock
+            ->expects($this->once())
+            ->method('getAll')
+            ->will($this->returnValue(array('Magento_Catalog' => 'info', 'Magento_Customer' => 'info')));
+
+        // Test one its children since the framework expects to be testing commands
+        $subjectMock = $this->getMockBuilder('\N98\Magento\Command\System\Setup\ChangeVersionCommand')
+            ->setMethods(array('getModuleList'))
+            ->getMock();
+
+        $subjectMock
+            ->expects($this->once())
+            ->method('getModuleList')
+            ->will($this->returnValue($moduleListMock));
+
+        return $subjectMock;
+    }
+}

--- a/tests/N98/Magento/Command/System/Setup/ChangeVersionCommandTest.php
+++ b/tests/N98/Magento/Command/System/Setup/ChangeVersionCommandTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace N98\Magento\Command\System\Setup;
+
+use Symfony\Component\Console\Tester\CommandTester;
+use N98\Magento\Command\PHPUnit\TestCase;
+
+class ChangeVersionCommandTest extends TestCase
+{
+    /**
+     * Ensure that the resource setters are called
+     */
+    public function testExecute()
+    {
+        $command = $this->getMockBuilder('\N98\Magento\Command\System\Setup\ChangeVersionCommand')
+            ->setMethods(array('getModuleName', 'getResource'))
+            ->getMock();
+
+        $command
+            ->expects($this->once())
+            ->method('getModuleName')
+            ->with('magento_customer')
+            ->will($this->returnValue('Magento_Customer'));
+
+        $resourceMock = $this->getMockBuilder('\Magento\Framework\Module\ModuleResource')
+            ->setMethods(array('setDbVersion', 'setDataVersion'))
+            ->getMock();
+
+        $resourceMock
+            ->expects($this->once())
+            ->method('setDbVersion')
+            ->with('Magento_Customer');
+
+        $resourceMock
+            ->expects($this->once())
+            ->method('setDataVersion')
+            ->with('Magento_Customer');
+
+        $command
+            ->expects($this->exactly(2))
+            ->method('getResource')
+            ->will($this->returnValue($resourceMock));
+
+        $application = $this->getApplication();
+        $application->add($command);
+        $command = $this->getApplication()->find('sys:setup:change-version');
+
+        $commandTester = new CommandTester($command);
+        $commandTester->execute(
+            array(
+                'command' => $command->getName(),
+                'module'  => 'magento_customer',
+                'version' => '1.2.3'
+            )
+        );
+
+        $this->assertContains(
+            'Successfully updated: "Magento_Customer" to version: "1.2.3"',
+            $commandTester->getDisplay()
+        );
+    }
+}


### PR DESCRIPTION
Changes:

* Ported `sys:setup:change-version` command
* Updated references to M1 framework for M2 in abstract command
* Added unit tests

Notes:

* I've removed the `setup` argument as it appears that Magento 2 has removed the granularity of different setup resources.
* I've removed the `inject()` method use in favour of mockable getters (although it pained me to do it)