### PR TITLE
[#120] Ported sys:setup:change-version command

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -88,6 +88,7 @@ commands:
     - N98\Magento\Command\System\Cron\RunCommand
     - N98\Magento\Command\System\InfoCommand
     - N98\Magento\Command\System\MaintenanceCommand
+    - N98\Magento\Command\System\Setup\ChangeVersionCommand
     - N98\Magento\Command\System\Setup\CompareVersionsCommand
     - N98\Magento\Command\System\Store\ListCommand
     - N98\Magento\Command\System\Url\ListCommand

--- a/readme.rst
+++ b/readme.rst
@@ -313,6 +313,27 @@ Remove a Gift Card
    $ n98-magerun2.phar giftcard:remove [code]
 
 
+Compare Setup Versions
+""""""""""""""""""""""
+
+Compares module version with saved setup version in `setup_module` table and displays version mismatchs if found.
+
+.. code-block:: sh
+
+   $ n98-magerun2.phar sys:setup:compare-versions [--ignore-data] [--log-junit="..."] [--format[="..."]]
+
+* If a filename with `--log-junit` option is set the tool generates an XML file and no output to *stdout*.
+
+Change Setup Version
+""""""""""""""""""""
+
+Changes the version of a module. This command is useful if you want to re-run an upgrade script again possibly for 
+debugging. Alternatively you would have to alter the row in the database manually.
+
+.. code-block:: sh
+
+   $ n98-magerun2.phar sys:setup:change-version module version
+
 n98-magerun Shell
 """""""""""""""""
 

--- a/src/N98/Magento/Command/System/Setup/AbstractSetupCommand.php
+++ b/src/N98/Magento/Command/System/Setup/AbstractSetupCommand.php
@@ -3,54 +3,69 @@
 namespace N98\Magento\Command\System\Setup;
 
 use N98\Magento\Command\AbstractMagentoCommand;
-use Symfony\Component\Console\Input\InputArgument;
-use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console\Output\OutputInterface;
-use N98\Util\Console\Helper\Table\Renderer\RendererFactory;
+use Magento\Framework\Module\ModuleListInterface;
+use Magento\Framework\Module\ResourceInterface;
 
 /**
  * Class AbstractSetupCommand
  * @package N98\Magento\Command\System\Setup
  */
-class AbstractSetupCommand extends AbstractMagentoCommand
+abstract class AbstractSetupCommand extends AbstractMagentoCommand
 {
+    /**
+     * @var ModuleListInterface
+     */
+    protected $moduleList;
 
     /**
-     * @param string $moduleName
-     * @return array
+     * @var ResourceInterface
      */
-    public function getModuleSetupResources($moduleName)
-    {
-        $moduleSetups   = array();
-        $resources      = \Mage::getConfig()->getNode('global/resources')->children();
+    protected $resource;
 
-        foreach ($resources as $resName => $resource) {
-            $modName = (string) $resource->setup->module;
-
-            if ($modName == $moduleName) {
-                $moduleSetups[$resName] = $resource;
-            }
-        }
-
-        return $moduleSetups;
+    /**
+     * Gather dependencies
+     * @param ModuleListInterface $moduleList
+     * @param ResourceInterface   $resource
+     */
+    public function inject(
+        ModuleListInterface $moduleList,
+        ResourceInterface $resource
+    ) {
+        $this->moduleList = $moduleList;
+        $this->resource = $resource;
     }
 
     /**
-     * @param InputInterface $input
+     * Determine if a module exists. If it does, return the actual module name (not lowercased).
+     * @param  string $requestedModuleName
      * @return string
-     * @throws \InvalidArgumentException
+     * @throws \InvalidArgumentException When the module doesn't exist
      */
-    public function getModule(InputInterface $input)
+    public function getMagentoModuleName($requestedModuleName)
     {
-        $modules = \Mage::app()->getConfig()->getNode('modules')->asArray();
-
-        foreach ($modules as $moduleName => $data) {
-            if (strtolower($moduleName) === strtolower($input->getArgument('module'))) {
+        $lowercaseModuleName = strtolower($requestedModuleName);
+        foreach ($this->getMagentoModuleList() as $moduleName => $moduleInfo) {
+            if ($lowercaseModuleName === strtolower($moduleName)) {
                 return $moduleName;
             }
         }
+        
+        throw new \InvalidArgumentException(sprintf('Module does not exist: "%s"', $requestedModuleName));
+    }
 
-        throw new \InvalidArgumentException(sprintf('No module found with name: "%s"', $input->getArgument('module')));
+    /**
+     * @return array
+     */
+    protected function getMagentoModuleList()
+    {
+        return $this->moduleList->getAll();
+    }
+
+    /**
+     * @return ResourceInterface
+     */
+    protected function getMagentoModuleResource()
+    {
+        return $this->resource;
     }
 }

--- a/src/N98/Magento/Command/System/Setup/ChangeVersionCommand.php
+++ b/src/N98/Magento/Command/System/Setup/ChangeVersionCommand.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace N98\Magento\Command\System\Setup;
+
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class ChangeVersionCommand extends AbstractSetupCommand
+{
+    /**
+     * Setup
+     * @return void
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('sys:setup:change-version')
+            ->addArgument('module', InputArgument::REQUIRED, 'Module name')
+            ->addArgument('version', InputArgument::REQUIRED, 'New version value')
+            ->setDescription('Change module resource version');
+        $help = <<<HELP
+Change a module's resource version
+HELP;
+        $this->setHelp($help);
+    }
+
+    /**
+     * @param  InputInterface  $input
+     * @param  OutputInterface $output
+     * @return void
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $this->detectMagento($output, true);
+
+        if (!$this->initMagento()) {
+            return;
+        }
+
+        $moduleVersion = $input->getArgument('version');
+        $moduleName    = $this->getMagentoModuleName($input->getArgument('module'));
+
+        /** @var \Magento\Framework\Module\ResourceInterface $resource */
+        $resource = $this->getMagentoModuleResource();
+
+        $originalVersion = $resource->getDbVersion($moduleName);
+
+        $resource->setDbVersion($moduleName, $moduleVersion);
+        $resource->setDataVersion($moduleName, $moduleVersion);
+
+        $output->writeln(
+            sprintf(
+                '<info>Successfully updated: "%s" from version "%s" to version: "%s"</info>',
+                $moduleName,
+                $originalVersion,
+                $moduleVersion
+            )
+        );
+    }
+}

--- a/tests/N98/Magento/Command/System/Setup/AbstractSetupCommandTest.php
+++ b/tests/N98/Magento/Command/System/Setup/AbstractSetupCommandTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace N98\Magento\Command\System\Setup;
+
+use N98\Magento\Command\PHPUnit\TestCase;
+
+class AbstractSetupCommandTest extends TestCase
+{
+    /**
+     * Mocked command
+     * @var Mock_AbstractSetupCommand
+     */
+    protected $command;
+
+    /**
+     * Set up the mocked command for testing
+     */
+    public function setUp()
+    {
+        $this->command = $this->getMockBuilder('N98\Magento\Command\System\Setup\AbstractSetupCommand')
+            ->disableOriginalConstructor()
+            ->setMethods(array('getMagentoModuleList'))
+            ->getMockForAbstractClass();
+
+        $this->command
+            ->expects($this->once())
+            ->method('getMagentoModuleList')
+            ->will($this->returnValue(array('Magento_Catalog' => 'info', 'Magento_Customer' => 'info')));
+    }
+
+    /**
+     * Test the getMagentoModuleName() method returns the actual module name when it exists
+     * @param string $moduleName
+     *
+     * @dataProvider validModuleNameProvider
+     */
+    public function testShouldReturnModuleNameForExistingModule($moduleName)
+    {
+        $result = $this->command->getMagentoModuleName($moduleName);
+        $this->assertStringStartsWith('Magento', $result);
+    }
+
+    /**
+     * Provide some inconsistently cased module names
+     * @return array
+     */
+    public function validModuleNameProvider()
+    {
+        return array(
+            array('magento_catalog'),
+            array('magento_customer'),
+            array('Magento_Catalog'),
+            array('MaGeNtO_cUstOmeR')
+        );
+    }
+
+    /**
+     * Ensure that an exception is thrown when a module doesn't exist
+     * @expectedException InvalidArgumentException
+     */
+    public function testShouldThrowExceptionWhenModuleDoesntExist()
+    {
+        $this->command->getMagentoModuleName('Some_Module_That_Will_Never_Exist');
+    }
+}

--- a/tests/N98/Magento/Command/System/Setup/ChangeVersionCommandTest.php
+++ b/tests/N98/Magento/Command/System/Setup/ChangeVersionCommandTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace N98\Magento\Command\System\Setup;
+
+use Symfony\Component\Console\Tester\CommandTester;
+use N98\Magento\Command\PHPUnit\TestCase;
+
+class ChangeVersionCommandTest extends TestCase
+{
+    /**
+     * @var ChangeVersionCommand;
+     */
+    protected $command;
+
+    /**
+     * @var CommandTester
+     */
+    protected $commandTester;
+
+    /**
+     * Set up the test dependencies
+     */
+    public function setUp()
+    {
+        $application = $this->getApplication();
+        $application->add(new ChangeVersionCommand());
+
+        $this->command = $this->getApplication()->find('sys:setup:change-version');
+
+        $this->commandTester = new CommandTester($this->command);
+    }
+
+    /**
+     * Ensure that the version for a random Magento module can be changed
+     */
+    public function testShouldExecuteCorrectlyAndDisplaySuccessMessage()
+    {
+        $this->commandTester->execute(
+            array(
+                'command' => $this->command->getName(),
+                'module'  => 'magento_customer',
+                'version' => '2.0.0'
+            )
+        );
+
+        $this->assertContains(
+            'Successfully updated: "Magento_Customer"',
+            $this->commandTester->getDisplay()
+        );
+    }
+
+    /**
+     * Ensure an exception is thrown when the module doesn't exist
+     * @expectedException InvalidArgumentException
+     */
+    public function testExecuteShouldThrowExceptionWhenModuleDoesntExist()
+    {
+        $this->commandTester->execute(
+            array(
+                'command' => $this->command->getName(),
+                'module'  => 'non_existent_module',
+                'version' => '2.0.0'
+            )
+        );
+    }
+}

--- a/tests/N98/Magento/Command/System/Setup/CompareVersionsCommandTest.php
+++ b/tests/N98/Magento/Command/System/Setup/CompareVersionsCommandTest.php
@@ -20,12 +20,14 @@ class CompareVersionsCommandTest extends TestCase
                 'command' => $command->getName()
             )
         );
-    
-        $this->assertRegExp('/Setup/', $commandTester->getDisplay());
-        $this->assertRegExp('/Module/', $commandTester->getDisplay());
-        $this->assertRegExp('/DB/', $commandTester->getDisplay());
-        $this->assertRegExp('/Data/', $commandTester->getDisplay());
-        $this->assertRegExp('/Status/', $commandTester->getDisplay());
+
+        $result = $commandTester->getDisplay();
+
+        $this->assertRegExp('/Setup/', $result);
+        $this->assertRegExp('/Module/', $result);
+        $this->assertRegExp('/DB/', $result);
+        $this->assertRegExp('/Data/', $result);
+        $this->assertRegExp('/Status/', $result);
     }
 
     public function testJunit()


### PR DESCRIPTION
Resolved #120.

Changes:

* Ported sys:setup:change-version command
* Updated references to M1 framework for M2 in abstract command
* Added unit tests

Notes:

* I've removed the setup argument as it appears that Magento 2 has removed the granularity of different setup resources.
* ~~I've removed the inject() method use in favour of mockable getters (although it pained me to do it)~~ Update: left in place, using getters as well for mocking
* ~~The tests that mock the command classes need to be run in isolation, otherwise the following error is thrown: `PHP Fatal error:  Call to undefined method Magento\Framework\Module\ModuleList::getNames() in [.../]src/vendor/magento/framework/Module/DependencyChecker.php on line 50`~~ Not required any longer.