### PR TITLE
[BUGFIX] Bugfx in reinit to prevent config already initialized

### DIFF
--- a/src/N98/Magento/Application.php
+++ b/src/N98/Magento/Application.php
@@ -612,6 +612,7 @@ class Application extends BaseApplication
     public function reinit($initConfig = array(), InputInterface $input = null, OutputInterface $output = null)
     {
         $this->_isInitialized = false;
+        $this->config = null;
         $this->init($initConfig, $input, $output);
     }
 


### PR DESCRIPTION
If the Application's reinit method is called the $this->init($initConfig, $input, $output); throws an UnexpectedValueException (Config already initialized)
because the $this->config variable is still set

this fix just resets $this->config

Found the issue while trying to install magento2.0.2 from command line via: docker exec -it magento2demo_app_1 bin/n98-magerun2 install \
--useDefaultConfigParams=yes --installationFolder="." \
--dbHost=mysql --dbUser=magento --dbPass=magento --dbName=magento \
--baseUrl=http://magento2.local/ --noDownload --forceUseDb=true