### PR TITLE
Allow crons to run from __call

### DIFF
--- a/src/N98/Magento/Command/System/Cron/RunCommand.php
+++ b/src/N98/Magento/Command/System/Cron/RunCommand.php
@@ -54,7 +54,7 @@ HELP;
 
         $model = $this->getObjectManager()->get($jobConfig['instance']);
 
-        if (!$model || !method_exists($model, $jobConfig['method'])) {
+        if (!$model || !is_callable(array($model, $jobConfig['method']))) {
             throw new \RuntimeException(
                 sprintf(
                     'Invalid callback: %s::%s does not exist',


### PR DESCRIPTION
While this may seem nonstandard, there is actually some Enterprise code that encourages this pattern. The execution of ``call_usr_func_array`` is wrapped in a try/catch, so I don't think this should pose any issues.