### PR TITLE
Properly emulate cron app state

### DIFF
--- a/src/N98/Magento/Command/System/Cron/RunCommand.php
+++ b/src/N98/Magento/Command/System/Cron/RunCommand.php
@@ -44,8 +44,6 @@ HELP;
             $jobCode = $this->askJobCode($input, $output, $jobs);
         }
 
-        $this->_state->setAreaCode('crontab');
-
         $jobConfig = $this->getJobConfig($jobCode);
 
         if (empty($jobCode)|| !isset($jobConfig['instance'])) {
@@ -78,7 +76,7 @@ HELP;
                 ->setExecutedAt(strftime('%Y-%m-%d %H:%M:%S', time()))
                 ->save();
 
-            call_user_func_array($callback, array($schedule));
+            $this->_state->emulateAreaCode('crontab', $callback, array($schedule));
 
             $schedule
                 ->setStatus(Schedule::STATUS_SUCCESS)


### PR DESCRIPTION
Following up from discussion in PR #192 

This is the proper way to emulate cron state. I don't think it is doing anything different than the current implementation, just changing area code, but still -- might as well use the standardized emulation method. Found this out from magento/magento2#4393