### PR TITLE
ScriptCommand legacy code refactored

### DIFF
--- a/src/N98/Magento/Command/ScriptCommand.php
+++ b/src/N98/Magento/Command/ScriptCommand.php
@@ -331,28 +331,10 @@ HELP;
     }
 
     /**
-     * Checks if legacy code prior Magento 2.1 should be used
-     *
-     * @return mixed Returns `true` for Magento 2.0, return `false` for Magento 2.1+
-     */
-    protected function useLegacy()
-    {
-        if (is_null($this->legacy)) {
-            $this->legacy = defined('\Magento\Framework\AppInterface::VERSION');
-        }
-
-        return $this->legacy;
-    }
-
-    /**
      * @return string
      */
     protected function getMagentoVersion()
     {
-        if ($this->useLegacy()) {
-            return \Magento\Framework\AppInterface::VERSION;
-        }
-
         return $this->getProductMetadata()->getVersion();
     }
 
@@ -362,10 +344,6 @@ HELP;
      */
     protected function getMagentoEdition()
     {
-        if ($this->useLegacy()) {
-            return 'Community'; // @TODO Replace this if EE is available
-        }
-
         return $this->getProductMetadata()->getEdition();
     }
 

--- a/src/N98/Magento/Command/ScriptCommand.php
+++ b/src/N98/Magento/Command/ScriptCommand.php
@@ -29,11 +29,6 @@ class ScriptCommand extends AbstractMagentoCommand
     protected $_stopOnError = false;
 
     /**
-     * @var null|bool
-     */
-    protected $legacy = null;
-
-    /**
      * @var null|\Magento\Framework\App\ProductMetadata
      */
     protected $productMetadata = null;

--- a/src/N98/Magento/Command/ScriptCommand.php
+++ b/src/N98/Magento/Command/ScriptCommand.php
@@ -287,6 +287,8 @@ HELP;
 
     protected function initScriptVars()
     {
+        $this->initMagento();
+        
         $rootFolder = $this->getApplication()->getMagentoRootFolder();
         if (!empty($rootFolder)) {
             $this->scriptVars['${magento.root}']    = $rootFolder;
@@ -348,8 +350,7 @@ HELP;
     protected function getProductMetadata()
     {
         if(is_null($this->productMetadata)) {
-            $objectManager         = $this->getApplication()->getObjectManager();
-            $this->productMetadata = $objectManager->get('\Magento\Framework\App\ProductMetadata');
+            $this->productMetadata = $this->getObjectManager()->get('\Magento\Framework\App\ProductMetadata');
         }
 
         return $this->productMetadata;

--- a/tests/N98/Magento/Command/ScriptCommandTest.php
+++ b/tests/N98/Magento/Command/ScriptCommandTest.php
@@ -7,6 +7,12 @@ use N98\Magento\Command\PHPUnit\TestCase;
 
 class ScriptCommandTest extends TestCase
 {
+    /** @var null|bool  */
+    protected $legacy = null;
+    
+    /** @var null|\Magento\Framework\App\ProductMetadata  */
+    protected $productMetadata = null;
+    
     public function testExecute()
     {
         $application = $this->getApplication();
@@ -22,24 +28,10 @@ class ScriptCommandTest extends TestCase
             )
         );
         
-        if (defined('\Magento\Framework\AppInterface::VERSION')) {
-            // Magento 2.0 compatibility
-            $magentoVersion = \Magento\Framework\AppInterface::VERSION;
-            $magentoEdition = 'Community'; // @TODO Replace this if EE is available
-        }
-        else {
-            // Magento 2.1+ compatibility
-            /** @var \Magento\Framework\App\ProductMetadata $productMetadata */
-            $productMetadata = $this->getApplication()->getObjectManager()->get('\Magento\Framework\App\ProductMetadata');
-            
-            $magentoVersion = $productMetadata->getVersion();
-            $magentoEdition = $productMetadata->getEdition();           
-        }        
-
         // Check pre defined vars
         $this->assertContains('magento.root: ' . $this->getApplication()->getMagentoRootFolder(), $commandTester->getDisplay());
-        $this->assertContains('magento.version: ' . $magentoVersion, $commandTester->getDisplay());
-        $this->assertContains('magento.edition: ' . $magentoEdition, $commandTester->getDisplay());
+        $this->assertContains('magento.version: ' . $this->getMagentoVersion(), $commandTester->getDisplay());
+        $this->assertContains('magento.edition: ' . $this->getMagentoEdition(), $commandTester->getDisplay());
         
         $this->assertContains('magerun.version: ' . $this->getApplication()->getVersion(), $commandTester->getDisplay());
 
@@ -49,5 +41,57 @@ class ScriptCommandTest extends TestCase
         $this->assertContains('Magento Websites', $commandTester->getDisplay());
         $this->assertContains('web/secure/base_url', $commandTester->getDisplay());
         $this->assertContains('web/seo/use_rewrites => 1', $commandTester->getDisplay());
+    }
+
+    /**
+     * Checks if legacy code prior Magento 2.1 should be used
+     * 
+     * @return mixed Returns `true` for Magento 2.0, return `false` for Magento 2.1+
+     */
+    protected function useLegacy()
+    {
+        if (is_null($this->legacy)) {
+            $this->legacy = defined('\Magento\Framework\AppInterface::VERSION');
+        }
+        
+        return $this->legacy;
+    }
+
+    /**
+     * @return string
+     */
+    protected function getMagentoVersion()
+    {
+        if ($this->useLegacy()) {
+            return \Magento\Framework\AppInterface::VERSION;
+        }
+
+        return $this->getProductMetadata()->getVersion();
+    }
+
+    /**
+     *
+     * @return mixed
+     */
+    protected function getMagentoEdition()
+    {
+        if ($this->useLegacy()) {
+            return 'Community'; // @TODO Replace this if EE is available
+        }
+
+        return $this->getProductMetadata()->getEdition();
+    }
+
+    /**
+     * @return \Magento\Framework\App\ProductMetadata
+     */
+    protected function getProductMetadata()
+    {
+        if(is_null($this->productMetadata)) {
+            $objectManager         = $this->getApplication()->getObjectManager();
+            $this->productMetadata = $objectManager->get('\Magento\Framework\App\ProductMetadata');
+        }
+        
+        return $this->productMetadata;
     }
 }

--- a/tests/N98/Magento/Command/ScriptCommandTest.php
+++ b/tests/N98/Magento/Command/ScriptCommandTest.php
@@ -6,10 +6,7 @@ use Symfony\Component\Console\Tester\CommandTester;
 use N98\Magento\Command\PHPUnit\TestCase;
 
 class ScriptCommandTest extends TestCase
-{
-    /** @var null|bool  */
-    protected $legacy = null;
-    
+{    
     /** @var null|\Magento\Framework\App\ProductMetadata  */
     protected $productMetadata = null;
     
@@ -44,28 +41,10 @@ class ScriptCommandTest extends TestCase
     }
 
     /**
-     * Checks if legacy code prior Magento 2.1 should be used
-     * 
-     * @return mixed Returns `true` for Magento 2.0, return `false` for Magento 2.1+
-     */
-    protected function useLegacy()
-    {
-        if (is_null($this->legacy)) {
-            $this->legacy = defined('\Magento\Framework\AppInterface::VERSION');
-        }
-        
-        return $this->legacy;
-    }
-
-    /**
      * @return string
      */
     protected function getMagentoVersion()
     {
-        if ($this->useLegacy()) {
-            return \Magento\Framework\AppInterface::VERSION;
-        }
-
         return $this->getProductMetadata()->getVersion();
     }
 
@@ -75,10 +54,6 @@ class ScriptCommandTest extends TestCase
      */
     protected function getMagentoEdition()
     {
-        if ($this->useLegacy()) {
-            return 'Community'; // @TODO Replace this if EE is available
-        }
-
         return $this->getProductMetadata()->getEdition();
     }
 


### PR DESCRIPTION
Refactored code from PR https://github.com/netz98/n98-magerun2/pull/214 (already merged).
Relates to Fix #212 .
Fixes issue https://github.com/netz98/n98-magerun2/issues/218 .

Changes proposed in this pull request:
Usage of public methods ´\Magento\Framework\App\ProductMetadata::getVersion()´ ´\Magento\Framework\App\ProductMetadata::getEdition()´ is compatible with all tagged version of Magento 2 (see https://github.com/magento/magento2/blob/0.42.0-beta9/lib/internal/Magento/Framework/App/ProductMetadata.php)
There is no need to rely on ´\Magento\Framework\AppInterface::VERSION´ constant any more, which was removed in Magento 2.1.
