### PR TITLE
Update template hints config value

### DIFF
--- a/src/N98/Magento/Command/Developer/TemplateHintsCommand.php
+++ b/src/N98/Magento/Command/Developer/TemplateHintsCommand.php
@@ -24,7 +24,7 @@ class TemplateHintsCommand extends AbstractMagentoStoreConfigCommand
     /**
      * @var string
      */
-    protected $configPath = 'dev/debug/template_hints';
+    protected $configPath = 'dev/debug/template_hints_storefront';
 
     /**
      * @var string


### PR DESCRIPTION
Magerun pull-request check-list:

- [x] Pull request against develop branch (if not, just close and create a new one against it)
- [x] README.md reflects changes (if any)

Subject: Update template-hints config value

Fixes #230 

Changes proposed in this pull request:

- Propose changing config path for toggling template hints to `template_hints_storefront` ~~because it has changed to this in version 2.1, and thus breaks at that version. I am currently basing this on 2.1.0-rc3, so I guess this change might best wait until formal release.~~

Also, I think that a new command may need to be added for toggling admin panel hints as that's now a separate config and can no longer be specified as a store via `dev:template-hints`.