### PR TITLE
Added support for more areas in the observer list

### DIFF
--- a/src/N98/Magento/Command/Developer/Module/Observer/ListCommand.php
+++ b/src/N98/Magento/Command/Developer/Module/Observer/ListCommand.php
@@ -18,6 +18,13 @@ class ListCommand extends AbstractMagentoCommand
         'adminhtml',
         'frontend',
         'crontab',
+        'webapi_rest',
+        'webapi_soap',
+        'doc',
+
+        // 'admin' has been declared deprecated since
+        // https://github.com/magento/magento2/commit/5448233594d94688b146564d7bdb882d6e88058a#diff-5bc6336cfbfd5aeb18404416f508b6c4
+        'admin',
     ];
 
     protected function configure()


### PR DESCRIPTION
Magerun pull-request check-list:

- [x] Pull request against develop branch (if not, just close and create a new one against it)
- [ ] README.md reflects changes (if any)

Subject: Added support for more areas in the observer list

Fixes #249

These area's exist in all current versions of Magento: 2.0.0 through 2.1.2
Recently the 'admin' area has been deprecated (this hasn't been released in a tagged version though).