### PR TITLE
Fix failing VariablesCommandTest for MariaDB 10.1.19

### DIFF
--- a/tests/N98/Magento/Command/Database/VariablesCommandTest.php
+++ b/tests/N98/Magento/Command/Database/VariablesCommandTest.php
@@ -65,6 +65,6 @@ class VariablesCommandTest extends TestCase
         ));
 
         $this->assertRegExp('~max_binlog_stmt_cache_size," [0-9\.]+[A-Z]"~', $commandTester->getDisplay());
-        $this->assertRegExp('~myisam_max_sort_file_size,"  [0-9\.]+[A-Z]"~', $commandTester->getDisplay());
+        $this->assertRegExp('~myisam_max_sort_file_size," +[0-9\.]+[A-Z]"~', $commandTester->getDisplay());
     }
 }


### PR DESCRIPTION
Magerun pull-request check-list:

- [x] Pull request against develop branch (if not, just close and create a new one against it)
- [ ] README.md reflects changes (if any)

Subject: Fix failing VariablesCommandTest for MariaDB 10.1.19

Changes proposed in this pull request:

- Fixes failing VariablesCommandTest for MariaDB 10.1.19

<pre>
1) N98\Magento\Command\Database\VariablesCommandTest::testRounding
Failed asserting that '"Variable Name",Value
aria_block_size,"  8.00K"
[---snip---]
myisam_max_sort_file_size," 10.00G"
[---snip---]
wsrep_max_ws_size,"  2.00G"
' matches PCRE pattern "~myisam_max_sort_file_size,"  [0-9\.]+[A-Z]"~".
</pre>