### PR TITLE
Added sys:cron:schedule command

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -90,6 +90,7 @@ commands:
     - N98\Magento\Command\System\Cron\HistoryCommand
     - N98\Magento\Command\System\Cron\ListCommand
     - N98\Magento\Command\System\Cron\RunCommand
+    - N98\Magento\Command\System\Cron\ScheduleCommand
     - N98\Magento\Command\System\InfoCommand
     - N98\Magento\Command\System\MaintenanceCommand
     - N98\Magento\Command\System\Setup\ChangeVersionCommand

--- a/src/N98/Magento/Command/System/Cron/AbstractCronCommand.php
+++ b/src/N98/Magento/Command/System/Cron/AbstractCronCommand.php
@@ -3,6 +3,7 @@
 namespace N98\Magento\Command\System\Cron;
 
 use N98\Magento\Command\AbstractMagentoCommand;
+use Symfony\Component\Console\Helper\DialogHelper;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 

--- a/src/N98/Magento/Command/System/Cron/AbstractCronCommand.php
+++ b/src/N98/Magento/Command/System/Cron/AbstractCronCommand.php
@@ -11,32 +11,27 @@ abstract class AbstractCronCommand extends AbstractMagentoCommand
     /**
      * @var \Magento\Framework\App\State
      */
-    protected $_state;
-
-    /**
-     * @var \Magento\Framework\Event\ManagerInterface
-     */
-    protected $_eventManager;
+    protected $state;
 
     /**
      * @var \Magento\Cron\Model\ConfigInterface
      */
-    protected $_cronConfig;
+    protected $cronConfig;
 
     /**
      * @var \Magento\Framework\App\Config\ScopeConfigInterface
      */
-    protected $_scopeConfig;
+    protected $scopeConfig;
 
     /**
      * @var \Magento\Cron\Model\ResourceModel\Schedule\Collection
      */
-    protected $_cronScheduleCollection;
+    protected $cronScheduleCollection;
 
     /**
      * @var \Magento\Framework\Stdlib\DateTime\TimezoneInterface
      */
-    protected $_timezone;
+    protected $timezone;
 
     /**
      * @param \Magento\Framework\App\State $state
@@ -54,12 +49,11 @@ abstract class AbstractCronCommand extends AbstractMagentoCommand
         \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig,
         \Magento\Cron\Model\ResourceModel\Schedule\Collection $cronScheduleCollection
     ) {
-        $this->_state = $state;
-        $this->_eventManager = $eventManager;
-        $this->_cronConfig = $cronConfig;
-        $this->_scopeConfig = $scopeConfig;
-        $this->_cronScheduleCollection = $cronScheduleCollection;
-        $this->_timezone = $timezone;
+        $this->state = $state;
+        $this->cronConfig = $cronConfig;
+        $this->scopeConfig = $scopeConfig;
+        $this->cronScheduleCollection = $cronScheduleCollection;
+        $this->timezone = $timezone;
     }
 
     /**
@@ -69,7 +63,7 @@ abstract class AbstractCronCommand extends AbstractMagentoCommand
     {
         $table = array();
 
-        $jobs = $this->_cronConfig->getJobs();
+        $jobs = $this->cronConfig->getJobs();
 
         foreach ($jobs as $jobGroupCode => $jobGroup) {
             foreach ($jobGroup as $job) {
@@ -97,7 +91,7 @@ abstract class AbstractCronCommand extends AbstractMagentoCommand
      */
     protected function getJobConfig($jobCode)
     {
-        foreach ($this->_cronConfig->getJobs() as $jobGroup) {
+        foreach ($this->cronConfig->getJobs() as $jobGroup) {
             foreach ($jobGroup as $job) {
                 if ($job['name'] == $jobCode) {
                     return $job;

--- a/src/N98/Magento/Command/System/Cron/AbstractCronCommand.php
+++ b/src/N98/Magento/Command/System/Cron/AbstractCronCommand.php
@@ -32,9 +32,15 @@ abstract class AbstractCronCommand extends AbstractMagentoCommand
     protected $_cronScheduleCollection;
 
     /**
+     * @var \Magento\Framework\Stdlib\DateTime\TimezoneInterface
+     */
+    protected $_timezone;
+
+    /**
      * @param \Magento\Framework\App\State $state
      * @param \Magento\Framework\Event\ManagerInterface $eventManager
      * @param \Magento\Cron\Model\ConfigInterface $cronConfig
+     * @param \Magento\Framework\Stdlib\DateTime\TimezoneInterface $timezone
      * @param \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig
      * @param \Magento\Cron\Model\ResourceModel\Schedule\Collection $cronScheduleCollection
      */
@@ -42,6 +48,7 @@ abstract class AbstractCronCommand extends AbstractMagentoCommand
         \Magento\Framework\App\State $state,
         \Magento\Framework\Event\ManagerInterface $eventManager,
         \Magento\Cron\Model\ConfigInterface $cronConfig,
+        \Magento\Framework\Stdlib\DateTime\TimezoneInterface $timezone,
         \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig,
         \Magento\Cron\Model\ResourceModel\Schedule\Collection $cronScheduleCollection
     ) {
@@ -50,6 +57,7 @@ abstract class AbstractCronCommand extends AbstractMagentoCommand
         $this->_cronConfig = $cronConfig;
         $this->_scopeConfig = $scopeConfig;
         $this->_cronScheduleCollection = $cronScheduleCollection;
+        $this->_timezone = $timezone;
     }
 
     /**

--- a/src/N98/Magento/Command/System/Cron/AbstractCronCommand.php
+++ b/src/N98/Magento/Command/System/Cron/AbstractCronCommand.php
@@ -3,6 +3,8 @@
 namespace N98\Magento\Command\System\Cron;
 
 use N98\Magento\Command\AbstractMagentoCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
 
 abstract class AbstractCronCommand extends AbstractMagentoCommand
 {
@@ -132,5 +134,36 @@ abstract class AbstractCronCommand extends AbstractMagentoCommand
         }
 
         return ['m' => '-', 'h' => '-', 'D' => '-', 'M' => '-', 'WD' => '-'];
+    }
+
+    /**
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     * @param array $jobs
+     * @return string
+     * @throws \InvalidArgumentException
+     * @throws \Exception
+     */
+    protected function askJobCode(InputInterface $input, OutputInterface $output, $jobs)
+    {
+        foreach ($jobs as $key => $job) {
+            $question[] = '<comment>[' . ($key + 1) . ']</comment> ' . $job['Job'] . PHP_EOL;
+        }
+        $question[] = '<question>Please select job: </question>' . PHP_EOL;
+
+        /** @var $dialog DialogHelper */
+        $dialog = $this->getHelper('dialog');
+        $jobCode = $dialog->askAndValidate(
+            $output,
+            $question,
+            function ($typeInput) use ($jobs) {
+                if (!isset($jobs[$typeInput - 1])) {
+                    throw new \InvalidArgumentException('Invalid job');
+                }
+                return $jobs[$typeInput - 1]['Job'];
+            }
+        );
+
+        return $jobCode;
     }
 }

--- a/src/N98/Magento/Command/System/Cron/HistoryCommand.php
+++ b/src/N98/Magento/Command/System/Cron/HistoryCommand.php
@@ -10,11 +10,6 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class HistoryCommand extends AbstractCronCommand
 {
-    /**
-     * @var array
-     */
-    protected $infos;
-
     protected function configure()
     {
         $this

--- a/src/N98/Magento/Command/System/Cron/HistoryCommand.php
+++ b/src/N98/Magento/Command/System/Cron/HistoryCommand.php
@@ -47,7 +47,7 @@ class HistoryCommand extends AbstractCronCommand
         }
 
         $timezone = $input->getOption('timezone')
-            ? $input->getOption('timezone') : $this->_scopeConfig->getValue('general/locale/timezone');
+            ? $input->getOption('timezone') : $this->scopeConfig->getValue('general/locale/timezone');
 
         if (!$input->getOption('format')) {
             $output->writeln('<info>Times shown in <comment>' . $timezone . '</comment></info>');
@@ -55,12 +55,12 @@ class HistoryCommand extends AbstractCronCommand
 
         $date = $this->getObjectManager()->create('Magento\Framework\Stdlib\DateTime\DateTime');
         $offset = $date->calculateOffset($timezone);
-        $this->_cronScheduleCollection
+        $this->cronScheduleCollection
             ->addFieldToFilter('status', array('neq' => Schedule::STATUS_PENDING))
             ->addOrder('finished_at', \Magento\Framework\Data\Collection::SORT_ORDER_DESC);
 
         $table = array();
-        foreach ($this->_cronScheduleCollection as $job) {
+        foreach ($this->cronScheduleCollection as $job) {
             $table[] = array(
                 $job->getJobCode(),
                 $job->getStatus(),

--- a/src/N98/Magento/Command/System/Cron/ListCommand.php
+++ b/src/N98/Magento/Command/System/Cron/ListCommand.php
@@ -9,11 +9,6 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class ListCommand extends AbstractCronCommand
 {
-    /**
-     * @var array
-     */
-    protected $infos;
-
     protected function configure()
     {
         $this

--- a/src/N98/Magento/Command/System/Cron/RunCommand.php
+++ b/src/N98/Magento/Command/System/Cron/RunCommand.php
@@ -68,20 +68,20 @@ HELP;
             $schedule
                 ->setJobCode($jobCode)
                 ->setStatus(Schedule::STATUS_RUNNING)
-                ->setExecutedAt(strftime('%Y-%m-%d %H:%M:%S', time()))
+                ->setExecutedAt(strftime('%Y-%m-%d %H:%M:%S', $this->timezone->scopeTimeStamp()))
                 ->save();
 
             $this->state->emulateAreaCode('crontab', $callback, array($schedule));
 
             $schedule
                 ->setStatus(Schedule::STATUS_SUCCESS)
-                ->setFinishedAt(strftime('%Y-%m-%d %H:%M:%S', time()))
+                ->setFinishedAt(strftime('%Y-%m-%d %H:%M:%S', $this->timezone->scopeTimeStamp()))
                 ->save();
         } catch (Exception $e) {
             $schedule
                 ->setStatus(Schedule::STATUS_ERROR)
                 ->setMessages($e->getMessage())
-                ->setFinishedAt(strftime('%Y-%m-%d %H:%M:%S', time()))
+                ->setFinishedAt(strftime('%Y-%m-%d %H:%M:%S', $this->timezone->scopeTimeStamp()))
                 ->save();
         }
 

--- a/src/N98/Magento/Command/System/Cron/RunCommand.php
+++ b/src/N98/Magento/Command/System/Cron/RunCommand.php
@@ -3,7 +3,6 @@
 namespace N98\Magento\Command\System\Cron;
 
 use Magento\Cron\Model\Schedule;
-use Symfony\Component\Console\Helper\DialogHelper;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;

--- a/src/N98/Magento/Command/System/Cron/RunCommand.php
+++ b/src/N98/Magento/Command/System/Cron/RunCommand.php
@@ -10,12 +10,6 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class RunCommand extends AbstractCronCommand
 {
-    const REGEX_RUN_MODEL = '#^([a-z0-9_]+/[a-z0-9_]+)::([a-z0-9_]+)$#i';
-    /**
-     * @var array
-     */
-    protected $infos;
-
     protected function configure()
     {
         $this

--- a/src/N98/Magento/Command/System/Cron/RunCommand.php
+++ b/src/N98/Magento/Command/System/Cron/RunCommand.php
@@ -93,35 +93,4 @@ HELP;
 
         $output->writeln('<info>done</info>');
     }
-
-    /**
-     * @param InputInterface $input
-     * @param OutputInterface $output
-     * @param array $jobs
-     * @return string
-     * @throws \InvalidArgumentException
-     * @throws \Exception
-     */
-    protected function askJobCode(InputInterface $input, OutputInterface $output, $jobs)
-    {
-        foreach ($jobs as $key => $job) {
-            $question[] = '<comment>[' . ($key + 1) . ']</comment> ' . $job['Job'] . PHP_EOL;
-        }
-        $question[] = '<question>Please select job: </question>' . PHP_EOL;
-
-        /** @var $dialog DialogHelper */
-        $dialog = $this->getHelper('dialog');
-        $jobCode = $dialog->askAndValidate(
-            $output,
-            $question,
-            function ($typeInput) use ($jobs) {
-                if (!isset($jobs[$typeInput - 1])) {
-                    throw new \InvalidArgumentException('Invalid job');
-                }
-                return $jobs[$typeInput - 1]['Job'];
-            }
-        );
-
-        return $jobCode;
-    }
 }

--- a/src/N98/Magento/Command/System/Cron/RunCommand.php
+++ b/src/N98/Magento/Command/System/Cron/RunCommand.php
@@ -70,14 +70,14 @@ HELP;
         );
 
         try {
-            $schedule = $this->_cronScheduleCollection->getNewEmptyItem();
+            $schedule = $this->cronScheduleCollection->getNewEmptyItem();
             $schedule
                 ->setJobCode($jobCode)
                 ->setStatus(Schedule::STATUS_RUNNING)
                 ->setExecutedAt(strftime('%Y-%m-%d %H:%M:%S', time()))
                 ->save();
 
-            $this->_state->emulateAreaCode('crontab', $callback, array($schedule));
+            $this->state->emulateAreaCode('crontab', $callback, array($schedule));
 
             $schedule
                 ->setStatus(Schedule::STATUS_SUCCESS)

--- a/src/N98/Magento/Command/System/Cron/ScheduleCommand.php
+++ b/src/N98/Magento/Command/System/Cron/ScheduleCommand.php
@@ -73,35 +73,4 @@ HELP;
 
         $output->writeln('<info>done</info>');
     }
-
-    /**
-     * @param InputInterface $input
-     * @param OutputInterface $output
-     * @param array $jobs
-     * @return string
-     * @throws \InvalidArgumentException
-     * @throws \Exception
-     */
-    protected function askJobCode(InputInterface $input, OutputInterface $output, $jobs)
-    {
-        foreach ($jobs as $key => $job) {
-            $question[] = '<comment>[' . ($key + 1) . ']</comment> ' . $job['Job'] . PHP_EOL;
-        }
-        $question[] = '<question>Please select job: </question>' . PHP_EOL;
-
-        /** @var $dialog DialogHelper */
-        $dialog = $this->getHelper('dialog');
-        $jobCode = $dialog->askAndValidate(
-            $output,
-            $question,
-            function ($typeInput) use ($jobs) {
-                if (!isset($jobs[$typeInput - 1])) {
-                    throw new \InvalidArgumentException('Invalid job');
-                }
-                return $jobs[$typeInput - 1]['Job'];
-            }
-        );
-
-        return $jobCode;
-    }
 }

--- a/src/N98/Magento/Command/System/Cron/ScheduleCommand.php
+++ b/src/N98/Magento/Command/System/Cron/ScheduleCommand.php
@@ -60,15 +60,15 @@ HELP;
             '<info>Scheduling </info><comment>' . $jobConfig['instance'] . '::' . $jobConfig['method'] . '</comment> '
         );
 
-        // add one second from the current time, just because it feels better ...
-        $scheduledAtTime = $this->_timezone->scopeTimeStamp() + 1;
+        $createdAtTime   = $this->_timezone->scopeTimeStamp();
+        $scheduledAtTime = $createdAtTime;
 
         $schedule = $this->_cronScheduleCollection->getNewEmptyItem();
         $schedule
             ->setJobCode($jobCode)
             ->setStatus(Schedule::STATUS_PENDING)
-            ->setCreatedAt(strftime('%Y-%m-%d %H:%M:%S', $this->_timezone->scopeTimeStamp()))
-            ->setScheduledAt($scheduledAtTime)
+            ->setCreatedAt(strftime('%Y-%m-%d %H:%M:%S', $createdAtTime))
+            ->setScheduledAt(strftime('%Y-%m-%d %H:%M', $scheduledAtTime))
             ->save();
 
         $output->writeln('<info>done</info>');

--- a/src/N98/Magento/Command/System/Cron/ScheduleCommand.php
+++ b/src/N98/Magento/Command/System/Cron/ScheduleCommand.php
@@ -3,7 +3,6 @@
 namespace N98\Magento\Command\System\Cron;
 
 use Magento\Cron\Model\Schedule;
-use Symfony\Component\Console\Helper\DialogHelper;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -60,7 +59,7 @@ HELP;
             '<info>Scheduling </info><comment>' . $jobConfig['instance'] . '::' . $jobConfig['method'] . '</comment> '
         );
 
-        $createdAtTime   = $this->timezone->scopeTimeStamp();
+        $createdAtTime = $this->timezone->scopeTimeStamp();
         $scheduledAtTime = $createdAtTime;
 
         $schedule = $this->cronScheduleCollection->getNewEmptyItem();

--- a/src/N98/Magento/Command/System/Cron/ScheduleCommand.php
+++ b/src/N98/Magento/Command/System/Cron/ScheduleCommand.php
@@ -60,10 +60,10 @@ HELP;
             '<info>Scheduling </info><comment>' . $jobConfig['instance'] . '::' . $jobConfig['method'] . '</comment> '
         );
 
-        $createdAtTime   = $this->_timezone->scopeTimeStamp();
+        $createdAtTime   = $this->timezone->scopeTimeStamp();
         $scheduledAtTime = $createdAtTime;
 
-        $schedule = $this->_cronScheduleCollection->getNewEmptyItem();
+        $schedule = $this->cronScheduleCollection->getNewEmptyItem();
         $schedule
             ->setJobCode($jobCode)
             ->setStatus(Schedule::STATUS_PENDING)

--- a/src/N98/Magento/Command/System/Cron/ScheduleCommand.php
+++ b/src/N98/Magento/Command/System/Cron/ScheduleCommand.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace N98\Magento\Command\System\Cron;
+
+use Magento\Cron\Model\Schedule;
+use Symfony\Component\Console\Helper\DialogHelper;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class ScheduleCommand extends AbstractCronCommand
+{
+    protected function configure()
+    {
+        $this
+            ->setName('sys:cron:schedule')
+            ->addArgument('job', InputArgument::OPTIONAL, 'Job code')
+            ->setDescription('Schedule a cronjob for execution right now, by job code');
+        $help = <<<HELP
+If no `job` argument is passed you can select a job from a list.
+HELP;
+        $this->setHelp($help);
+    }
+
+    /**
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     * @throws \Exception
+     * @return int|void
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $jobCode = $input->getArgument('job');
+        $jobs = $this->getJobs();
+
+        if (!$jobCode) {
+            $this->writeSection($output, 'Cronjob');
+            $jobCode = $this->askJobCode($input, $output, $jobs);
+        }
+
+        $jobConfig = $this->getJobConfig($jobCode);
+
+        if (empty($jobCode) || !isset($jobConfig['instance'])) {
+            throw new \InvalidArgumentException('No job config found!');
+        }
+
+        $model = $this->getObjectManager()->get($jobConfig['instance']);
+
+        if (!$model || !is_callable(array($model, $jobConfig['method']))) {
+            throw new \RuntimeException(
+                sprintf(
+                    'Invalid callback: %s::%s does not exist',
+                    $jobConfig['instance'],
+                    $jobConfig['method']
+                )
+            );
+        }
+
+        $output->write(
+            '<info>Scheduling </info><comment>' . $jobConfig['instance'] . '::' . $jobConfig['method'] . '</comment> '
+        );
+
+        // add one second from the current time, just because it feels better ...
+        $scheduledAtTime = $this->_timezone->scopeTimeStamp() + 1;
+
+        $schedule = $this->_cronScheduleCollection->getNewEmptyItem();
+        $schedule
+            ->setJobCode($jobCode)
+            ->setStatus(Schedule::STATUS_PENDING)
+            ->setCreatedAt(strftime('%Y-%m-%d %H:%M:%S', $this->_timezone->scopeTimeStamp()))
+            ->setScheduledAt($scheduledAtTime)
+            ->save();
+
+        $output->writeln('<info>done</info>');
+    }
+
+    /**
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     * @param array $jobs
+     * @return string
+     * @throws \InvalidArgumentException
+     * @throws \Exception
+     */
+    protected function askJobCode(InputInterface $input, OutputInterface $output, $jobs)
+    {
+        foreach ($jobs as $key => $job) {
+            $question[] = '<comment>[' . ($key + 1) . ']</comment> ' . $job['Job'] . PHP_EOL;
+        }
+        $question[] = '<question>Please select job: </question>' . PHP_EOL;
+
+        /** @var $dialog DialogHelper */
+        $dialog = $this->getHelper('dialog');
+        $jobCode = $dialog->askAndValidate(
+            $output,
+            $question,
+            function ($typeInput) use ($jobs) {
+                if (!isset($jobs[$typeInput - 1])) {
+                    throw new \InvalidArgumentException('Invalid job');
+                }
+                return $jobs[$typeInput - 1]['Job'];
+            }
+        );
+
+        return $jobCode;
+    }
+}

--- a/src/N98/Magento/Command/System/Store/ListCommand.php
+++ b/src/N98/Magento/Command/System/Store/ListCommand.php
@@ -11,11 +11,6 @@ use Symfony\Component\Console\Output\OutputInterface;
 class ListCommand extends AbstractMagentoCommand
 {
     /**
-     * @var array
-     */
-    protected $infos;
-
-    /**
      * @var \Magento\Store\Model\StoreManagerInterface
      */
     protected $storeManager;

--- a/src/N98/Magento/Command/System/Website/ListCommand.php
+++ b/src/N98/Magento/Command/System/Website/ListCommand.php
@@ -11,11 +11,6 @@ use Symfony\Component\Console\Output\OutputInterface;
 class ListCommand extends AbstractMagentoCommand
 {
     /**
-     * @var array
-     */
-    protected $infos;
-
-    /**
      * @var \Magento\Store\Model\StoreManagerInterface
      */
     protected $storeManager;

--- a/tests/N98/Magento/Command/System/Cron/ScheduleCommandTest.php
+++ b/tests/N98/Magento/Command/System/Cron/ScheduleCommandTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace N98\Magento\Command\System\Cron;
+
+use N98\Magento\Command\TestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class ScheduleCommandTest extends TestCase
+{
+    public function testExecute()
+    {
+        $application = $this->getApplication();
+        $application->add(new ListCommand());
+        $command = $this->getApplication()->find('sys:cron:schedule');
+
+        $commandTester = new CommandTester($command);
+        $commandTester->execute([
+            'command' => $command->getName(),
+            'job'     => 'backend_clean_cache',
+        ]);
+
+        $this->assertContains('Scheduling Magento\Backend\Cron\CleanCache::execute done', $commandTester->getDisplay());
+    }
+}


### PR DESCRIPTION
Magerun pull-request check-list:

- [x] Pull request against develop branch (if not, just close and create a new one against it)
- [ ] README.md reflects changes (if any)

Sometimes we want to run a cronjob, but not keep our ssh session or terminal open while running `sys:cron:run`. This PR adds a `sys:cron:schedule` command which schedules a certain job in the cron schedule to be executed the next time the cron is being run.
Was inspired by the excellent [Aoe_Scheduler module](https://github.com/AOEpeople/Aoe_Scheduler) for M1.

Possible discussion points:
1) The name `schedule` might be confusing, people might expect they can provide a timestamp on which time they want to schedule a job. Is this wanted? We could also name the command `schedule-now` or something like that?

2) I copied a lot of code from the `RunCommand` class. This should definitely be refactored away. Should we put shared code in the `AbstractCronCommand` class, or someplace else?

3) There is something wrong with the timezone of the times in the `RunCommand` class. I haven't fixed this yet over there, but this new class should work correctly. I took a look at how [M2 itself does this](https://github.com/magento/magento2/blob/056ad90b7ee3177d1665d39c86191ac156bff697/app/code/Magento/Cron/Observer/ProcessCronQueueObserver.php#L443-L478) and based my code on that.

If there are any remarks, let me know!
