### PR TITLE
Fixes sys:cron:schedule 'area code is not set' exception.

### DIFF
--- a/src/N98/Magento/Command/System/Cron/ScheduleCommand.php
+++ b/src/N98/Magento/Command/System/Cron/ScheduleCommand.php
@@ -3,6 +3,7 @@
 namespace N98\Magento\Command\System\Cron;
 
 use Magento\Cron\Model\Schedule;
+use Magento\Framework\App\Area;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;

--- a/src/N98/Magento/Command/System/Cron/ScheduleCommand.php
+++ b/src/N98/Magento/Command/System/Cron/ScheduleCommand.php
@@ -29,6 +29,11 @@ HELP;
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        $this->state->setAreaCode(Area::AREA_CRONTAB);
+        $objectManager = $this->getObjectManager();
+        $configLoader = $objectManager->get('Magento\Framework\ObjectManager\ConfigLoaderInterface');
+        $objectManager->configure($configLoader->load(Area::AREA_CRONTAB));
+
         list($jobCode, $jobConfig) = $this->getJobForExecuteMethod($input, $output);
 
         $output->write(


### PR DESCRIPTION
Magerun pull-request check-list:

- [x] Pull request against develop branch (if not, just close and create a new one against it)
- [ ] README.md reflects changes (if any)

----

After upgrading magerun2 from version 1.3.2 to 1.3.3, and running the command:
`sys:cron:schedule some-cronjob`, we get the error:

```
  [Magento\Framework\Exception\SessionException]
  Area code not set: Area code must be set before starting a session.

  [Magento\Framework\Exception\LocalizedException]
  Area code is not set
```

This problem was recently introduced by https://github.com/netz98/n98-magerun2/commit/64063ae6f91ee764993e7c6b2e953c66a51fcdd0 & https://github.com/netz98/n98-magerun2/commit/a50f3b75ae13eda8488a82cd308f9062fd483892

Fixing it by using the same workaround as in https://github.com/netz98/n98-magerun2/commit/64063ae6f91ee764993e7c6b2e953c66a51fcdd0

Not sure if all the code is needed though, only the first line already solves the problem, not sure if the other 3 lines are actually necessary?

Thanks!