### PR TITLE
Allow -1 as value for infinite max nesting level for xdebug

### DIFF
--- a/readme.rst
+++ b/readme.rst
@@ -2,7 +2,10 @@
 netz98 magerun CLI tools for Magento 2
 ======================================
 
-The n98 magerun cli tools provides some handy tools to work with Magento from command line.
+.. image:: https://img.shields.io/website-up-down-green-red/http/shields.io.svg?style=plastic   :target: http://magerun.net/
+
+The n98 magerun cli tools provides some handy tools to work with Magento from command line. Please also check out the `n98-magerun Website
+<http://magerun.net/>`_ for further information, releases or tutorials.
 
 Build Status
 ------------

--- a/src/N98/Magento/Command/Installer/SubCommand/PreCheckPhp.php
+++ b/src/N98/Magento/Command/Installer/SubCommand/PreCheckPhp.php
@@ -42,7 +42,7 @@ class PreCheckPhp extends AbstractSubCommand
      */
     protected function checkXDebug()
     {
-        if (extension_loaded('xdebug') && xdebug_is_enabled() && ini_get('xdebug.max_nesting_level') < 200) {
+        if (extension_loaded('xdebug') && xdebug_is_enabled() && ini_get('xdebug.max_nesting_level') != -1 && ini_get('xdebug.max_nesting_level') < 200) {
             $errorMessage = 'Please change PHP ini setting "xdebug.max_nesting_level". '
                             . 'Please change it to a value >= 200. '
                             . 'Your current value is ' . ini_get('xdebug.max_nesting_level');


### PR DESCRIPTION
Magerun pull-request check-list:

- [x] Pull request against develop branch (if not, just close and create a new one against it)
- [ ] README.md reflects changes (if any)

Subject: (50 characters or less)

Magerun now gives an error when xdebug.max_nesting_level is set to `-1`, which is a valid value meaning "no maximum".

```
$ n98-magerun2.phar install

  Magento 2 Installation

  [RuntimeException]
  Please change PHP ini setting "xdebug.max_nesting_level". Please change it to a value >= 200. Your current value is -1

```