### PR TITLE
Prevent exceptions in dev:console from being suppressed and hidden

### DIFF
--- a/src/N98/Magento/Command/Developer/Console/Shell.php
+++ b/src/N98/Magento/Command/Developer/Console/Shell.php
@@ -76,7 +76,7 @@ class Shell extends PsyShell
 
         if ($e instanceof NoModuleDefinedException) {
             $this->getConsoleOutput()->writeln('<warning>' . $e->getMessage() . '</warning>');
-            
+
             return;
         } elseif ($e instanceof ErrorException) {
             if (BinaryString::startsWith($e->getMessage(), 'PHP error:  Use of undefined constant')) {
@@ -93,7 +93,7 @@ class Shell extends PsyShell
         } elseif ($e instanceof ParseErrorException) {
             $message = substr($e->getMessage(), 0, strpos($e->getMessage(), ' on line'));
             $this->getConsoleOutput()->writeln('<error>' . $message . '</error>');
-            
+
             return;
         }
 

--- a/src/N98/Magento/Command/Developer/Console/Shell.php
+++ b/src/N98/Magento/Command/Developer/Console/Shell.php
@@ -76,24 +76,24 @@ class Shell extends PsyShell
 
         if ($e instanceof NoModuleDefinedException) {
             $this->getConsoleOutput()->writeln('<warning>' . $e->getMessage() . '</warning>');
-
+            
             return;
         } elseif ($e instanceof ErrorException) {
             if (BinaryString::startsWith($e->getMessage(), 'PHP error:  Use of undefined constant')) {
                 $this->getConsoleOutput()->writeln('<warning>Unknown command</warning>');
+                
+                return;
             }
-
-            return;
         } elseif ($e instanceof FatalErrorException) {
             if (BinaryString::startsWith($e->getMessage(), 'PHP Fatal error:  Call to undefined function')) {
                 $this->getConsoleOutput()->writeln('<warning>Unknown function</warning>');
+                
+                return;
             }
-
-            return;
         } elseif ($e instanceof ParseErrorException) {
             $message = substr($e->getMessage(), 0, strpos($e->getMessage(), ' on line'));
             $this->getConsoleOutput()->writeln('<error>' . $message . '</error>');
-
+            
             return;
         }
 


### PR DESCRIPTION
Hello!

This issue is fairly easy to reproduce. Just enter dev:console and try some of the following:

`a::b()`
Expects: PHP Fatal error: Class 'a' not found in eval()'d code on line 1
Actual: Nothing

`json_decode(array(), true)`
Expects: PHP warning:  json_decode() expects parameter 1 to be string, array given on line 1
Actual: Nothing

It makes for quite strenuous debugging! After some time I tracked it down to the N98 Shell writeException not printing the exception. This Pull Request makes sure that if writeException isn't handling the exception in some way, it prints it out.

Thanks!