### PR TITLE
Display exception if cron job fails in sys:cron:run

### DIFF
--- a/src/N98/Magento/Command/System/Cron/RunCommand.php
+++ b/src/N98/Magento/Command/System/Cron/RunCommand.php
@@ -3,9 +3,9 @@
 namespace N98\Magento\Command\System\Cron;
 
 use Exception;
-use RuntimeException;
 use Magento\Cron\Model\Schedule;
 use Magento\Framework\App\Area;
+use RuntimeException;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;

--- a/src/N98/Magento/Command/System/Cron/RunCommand.php
+++ b/src/N98/Magento/Command/System/Cron/RunCommand.php
@@ -3,6 +3,7 @@
 namespace N98\Magento\Command\System\Cron;
 
 use Exception;
+use RuntimeException;
 use Magento\Cron\Model\Schedule;
 use Magento\Framework\App\Area;
 use Symfony\Component\Console\Input\InputArgument;
@@ -66,6 +67,14 @@ HELP;
                 ->setMessages($e->getMessage())
                 ->setFinishedAt(strftime('%Y-%m-%d %H:%M:%S', $this->timezone->scopeTimeStamp()))
                 ->save();
+        }
+        
+        if (isset($e)) {
+            throw new RuntimeException(
+                sprintf('Cron-job "%s" threw exception %s', $jobCode, get_class($e)),
+                0,
+                $e
+            );
         }
 
         $output->writeln('<info>done</info>');


### PR DESCRIPTION
When running sys:cron:run, if the job fails, there is no exception displayed and you simply get "done".
This is in contrast to n98-magerun for Magento 1 which displays an exception.

I've ported over the same exception reporting code from n98-magerun to n98-magerun2, but I'm happy to take feedback on different/better way to handle the exception reporting.

To reproduce:
- Modify `app/code/Magento/Sales/Cron/CleanExpiredQuotes.php` and add `throw new Exception('TEST');` to the first line of `execute()`
- Run `sys:cron:run sales_clean_quotes`

What happens:
You see `Run Magento\Sales\Cron\CleanExpiredQuotes::execute done`

Expected:
An exception reported to console, which displays a stack trace when the command line was `sys:cron:run sales_clean_quotes -v`