### PR TITLE
Add magento2 as detectable root directory

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -35,6 +35,7 @@ detect:
     - webroot
     - web-root
     - wwwroot
+    - magento2
 
 event:
   subscriber:


### PR DESCRIPTION
Magerun pull-request check-list:

- [x] Pull request against develop branch (if not, just close and create a new one against it)
- [x] README.md reflects changes (if any)

This is nice for setups where the webroot is a different directory than the pub directory.

For example:
```
$ ls -l public
cron.php->../magento2/pub/cron.php
errors->../magento2/pub/errors
get.php->../magento2/pub/get.php
humans.txt->../magento2/humans.txt
index.php->../magento2/pub/index.php
media->../magento2/pub/media
opt->../magento2/pub/opt
robots.txt->../magento2/robots.txt
static->../magento2/pub/static
static.php->../magento2/pub/static.php
```

If you're in the parent directory of magento2 and public, it won't detect the magento2 installation.