### PR TITLE
Improve db:dump (documentation & table groups)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -149,16 +149,23 @@ commands:
             sales_order_status_history
             sales_order_tax
             sales_order_tax_item
+          sales_invoice sales_invoice_* sales_invoiced_*
+          sales_shipment sales_shipment_* sales_shipping_*
+          sales_creditmemo sales_creditmemo_*
           sales_recurring_* sales_refunded_* sales_payment_*
           enterprise_sales_* enterprise_customer_sales_* sales_bestsellers_*
 
+      - id: quotes
+        description: Cart (quote) data
+        tables: quote quote_*
+
       - id: customers
         description: Customer data - Should not be used without @sales
-        tables: customer_address* customer_entity*
+        tables: customer_address* customer_entity* customer_visitor
 
       - id: trade
         description: Current trade data (customers and orders). You usally do not want those in developer systems.
-        tables: @customers @sales
+        tables: @customers @sales @quotes
 
       - id: development
         description: Removes logs and trade data so developers do not have to work with real customer data

--- a/readme.rst
+++ b/readme.rst
@@ -472,17 +472,17 @@ Example: "dataflow_batch_export unimportant_module_* @log
 
 Available Table Groups:
 
-* @log Log tables
-* @dataflowtemp Temporary tables of the dataflow import/export tool
-* @importexporttemp Temporary tables of the Import/Export module
-* @stripped Standard definition for a stripped dump (logs, sessions, dataflow and importexport)
-* @sales Sales data (orders, invoices, creditmemos etc)
-* @quotes Cart (quote) data
 * @customers Customer data
-* @trade Current trade data (customers and orders). You usally do not want those in developer systems.
-* @search Search related tables (catalogsearch_)
 * @development Removes logs, sessions and trade data so developers do not have to work with real customer data
+* @ee_changelog Changelog tables of new indexer since EE 1.13
 * @idx Tables with _idx suffix and index event tables
+* @log Log tables
+* @quotes Cart (quote) data
+* @sales Sales data (orders, invoices, creditmemos etc)
+* @search Search related tables (catalogsearch_)
+* @sessions Database session tables
+* @stripped Standard definition for a stripped dump (logs and sessions)
+* @trade Current trade data (customers, orders and quotes). You usually do not want those in developer systems.
 
 Clear static view files
 """""""""""""""""""""""

--- a/readme.rst
+++ b/readme.rst
@@ -383,6 +383,107 @@ Enable Magento cache
 If no code is specified, all cache types will be enabled.
 Run `cache:list` command to see all codes.
 
+Dump database
+"""""""""""""
+
+Dumps configured Magento database with `mysqldump`.
+
+* Requires MySQL CLI tools
+
+**Arguments**
+
+    filename        Dump filename
+
+**Options**
+
+  --add-time
+        Adds time to filename (only if filename was not provided)
+
+  --compression (-c)
+        Compress the dump file using one of the supported algorithms
+
+  --only-command
+        Print only mysqldump command. Do not execute
+
+  --print-only-filename
+        Execute and prints not output except the dump filename
+
+  --dry-run
+        Do everything but the actual dump
+
+  --no-single-transaction
+        Do not use single-transaction (not recommended, this is blocking)
+
+  --human-readable
+        Use a single insert with column names per row.
+
+  --add-routines
+        Include stored routines in dump (procedures & functions).
+
+  --stdout
+        Dump to stdout
+
+  --strip
+        Tables to strip (dump only structure of those tables)
+
+  --exclude
+        Tables to exclude entirely from the dump (including structure)
+
+  --force (-f)
+        Do not prompt if all options are defined
+
+
+.. code-block:: sh
+
+   $ n98-magerun.phar db:dump
+
+Only the mysqldump command:
+
+.. code-block:: sh
+
+   $ n98-magerun.phar db:dump --only-command [filename]
+
+Or directly to stdout:
+
+.. code-block:: sh
+
+   $ n98-magerun.phar db:dump --stdout
+
+Use compression (gzip cli tool has to be installed):
+
+.. code-block:: sh
+
+   $ n98-magerun.phar db:dump --compression="gzip"
+
+Stripped Database Dump
+^^^^^^^^^^^^^^^^^^^^^^
+
+Dumps your database and excludes some tables. This is useful for development or staging environments
+where you may to provision a restricted database.
+
+Separate each table to strip by a space.
+You can use wildcards like * and ? in the table names to strip multiple tables.
+In addition you can specify pre-defined table groups, that start with an @
+Example: "dataflow_batch_export unimportant_module_* @log
+
+.. code-block:: sh
+
+   $ n98-magerun.phar db:dump --strip="@stripped"
+
+Available Table Groups:
+
+* @log Log tables
+* @dataflowtemp Temporary tables of the dataflow import/export tool
+* @importexporttemp Temporary tables of the Import/Export module
+* @stripped Standard definition for a stripped dump (logs, sessions, dataflow and importexport)
+* @sales Sales data (orders, invoices, creditmemos etc)
+* @quotes Cart (quote) data
+* @customers Customer data
+* @trade Current trade data (customers and orders). You usally do not want those in developer systems.
+* @search Search related tables (catalogsearch_)
+* @development Removes logs, sessions and trade data so developers do not have to work with real customer data
+* @idx Tables with _idx suffix and index event tables
+
 Clear static view files
 """""""""""""""""""""""
 

--- a/src/N98/Magento/Command/Database/DumpCommand.php
+++ b/src/N98/Magento/Command/Database/DumpCommand.php
@@ -61,7 +61,7 @@ class DumpCommand extends AbstractDatabaseCommand
                 'dry-run',
                 null,
                 InputOption::VALUE_NONE,
-                'do everything but the dump'
+                'Do everything but the actual dump'
             )
             ->addOption(
                 'no-single-transaction',
@@ -82,7 +82,11 @@ class DumpCommand extends AbstractDatabaseCommand
                 InputOption::VALUE_NONE,
                 'Include stored routines in dump (procedures & functions)'
             )
-            ->addOption('stdout', null, InputOption::VALUE_NONE, 'Dump to stdout')
+            ->addOption('stdout',
+                null,
+                InputOption::VALUE_NONE,
+                'Dump to stdout'
+            )
             ->addOption(
                 'strip',
                 's',
@@ -93,7 +97,7 @@ class DumpCommand extends AbstractDatabaseCommand
                 'exclude',
                 'e',
                 InputOption::VALUE_OPTIONAL,
-                'Tables to exclude from the dump'
+                'Tables to exclude entirely from the dump (including structure)'
             )
             ->addOption(
                 'force',


### PR DESCRIPTION
Subject: Improve db:dump (documentation & table groups)

Fixes #248.

Changes proposed in this pull request:

- Add documentation for `db:dump` (largely copied from M1 version) and tweak `--help` wording
- Add new `@quotes` table group and then include this group in `@trade`
- Add missing tables to `@sales` table group (invoices, shipments & credit memos)
- Add `customer_visitor` table to `@customers`