### PR TITLE
Strip Admin Users In Development DB Dump

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -124,6 +124,10 @@ commands:
 
   N98\Magento\Command\Database\DumpCommand:
     table-groups:
+      - id: admin
+        description: Admin tables
+        tables: admin* authorization*
+
       - id: log
         description: Log tables
         tables: log_url log_url_info log_visitor log_visitor_info log_visitor_online report_event report_compared_product_index report_viewed_*
@@ -186,7 +190,7 @@ commands:
 
       - id: development
         description: Removes logs and trade data so developers do not have to work with real customer data
-        tables: @trade @stripped @search
+        tables: @admin @trade @stripped @search
 
       - id: ee_changelog
         description: Changelog tables of new indexer since EE 1.13

--- a/readme.rst
+++ b/readme.rst
@@ -473,7 +473,7 @@ Example: "dataflow_batch_export unimportant_module_* @log
 Available Table Groups:
 
 * @customers Customer data
-* @development Removes logs, sessions and trade data so developers do not have to work with real customer data
+* @development Removes logs, sessions, trade data and admin users so developers do not have to work with real customer data or admin user accounts
 * @ee_changelog Changelog tables of new indexer since EE 1.13
 * @idx Tables with _idx suffix and index event tables
 * @log Log tables


### PR DESCRIPTION
Magerun pull-request check-list:

- [X] Pull request against develop branch (if not, just close and create a new one against it)
- [X] README.md reflects changes (if any)

Subject: Strip Admin Users In Development DB Dump

For security purposes, it's better to strip `admin*` and `authorization*` when dumping a production database for non-production use. For example, the production database could be restored to staging with production admin user data. The staging environment may not have the same level of security as production (e.g. default admin route, not rate limiting brute force password guessing). An attacker could leverage the staging environment to identify production user credentials and then use them to obtain access to the production system.

Changes proposed in this pull request:

- `admin*` and `authorization*` are stripped when running a development db dump

If the maintainers agree with this change, I can additionally issue a pull request to n98-magerun.