### PR TITLE
Provides more config values for install command

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -417,6 +417,17 @@ commands:
             - mbstring
             - zip
 
+      db:
+        host: localhost
+        user: root
+        pass:
+        port: 3306
+        name: magento
+
+      base-url: http://magento2.localdomain/
+
+      sample-data: true
+
       defaults:
         currency: EUR
         locale: de_DE

--- a/src/N98/Magento/Command/Installer/SubCommand/CreateDatabase.php
+++ b/src/N98/Magento/Command/Installer/SubCommand/CreateDatabase.php
@@ -60,7 +60,9 @@ class CreateDatabase extends AbstractSubCommand
             do {
 
                 // Host
-                $dbHostDefault = $this->input->getOption('dbHost') ? $this->input->getOption('dbHost') : 'localhost';
+                $dbHostDefault = $this->input->getOption('dbHost') ?
+                    $this->input->getOption('dbHost') :
+                    $this->commandConfig['installation']['db']['host'];
                 $this->config->setString(
                     'db_host',
                     $dialog->askAndValidate(
@@ -74,7 +76,9 @@ class CreateDatabase extends AbstractSubCommand
                 );
 
                 // Port
-                $dbPortDefault = $this->input->getOption('dbPort') ? $this->input->getOption('dbPort') : 3306;
+                $dbPortDefault = $this->input->getOption('dbPort') ?
+                    $this->input->getOption('dbPort') :
+                    $this->commandConfig['installation']['db']['port'];
                 $this->config->setInt(
                     'db_port',
                     intval($dialog->askAndValidate(
@@ -88,7 +92,9 @@ class CreateDatabase extends AbstractSubCommand
                 );
 
                 // User
-                $dbUserDefault = $this->input->getOption('dbUser') ? $this->input->getOption('dbUser') : 'root';
+                $dbUserDefault = $this->input->getOption('dbUser') ?
+                    $this->input->getOption('dbUser') :
+                    $this->commandConfig['installation']['db']['user'];
                 $this->config->setString(
                     'db_user',
                     $dialog->askAndValidate(
@@ -102,7 +108,9 @@ class CreateDatabase extends AbstractSubCommand
                 );
 
                 // Password
-                $dbPassDefault = $this->input->getOption('dbPass') ? $this->input->getOption('dbPass') : '';
+                $dbPassDefault = $this->input->getOption('dbPass') ?
+                    $this->input->getOption('dbPass') :
+                    $this->commandConfig['installation']['db']['pass'];
                 $this->config->setString(
                     'db_pass',
                     $dialog->ask(
@@ -114,7 +122,9 @@ class CreateDatabase extends AbstractSubCommand
                 );
 
                 // DB-Name
-                $dbNameDefault = $this->input->getOption('dbName') ? $this->input->getOption('dbName') : 'magento';
+                $dbNameDefault = $this->input->getOption('dbName') ?
+                    $this->input->getOption('dbName') :
+                    $this->commandConfig['installation']['db']['name'];
                 $this->config->setString(
                     'db_name',
                     $dialog->askAndValidate(

--- a/src/N98/Magento/Command/Installer/SubCommand/InstallMagento.php
+++ b/src/N98/Magento/Command/Installer/SubCommand/InstallMagento.php
@@ -7,6 +7,7 @@ use N98\Magento\Command\SubCommand\AbstractSubCommand;
 use N98\Util\Exec;
 use N98\Util\OperatingSystem;
 use RuntimeException;
+use Symfony\Component\Console\Helper\DialogHelper;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class InstallMagento extends AbstractSubCommand
@@ -39,6 +40,7 @@ class InstallMagento extends AbstractSubCommand
 
         $this->getCommand()->getApplication()->setAutoExit(false);
 
+        /** @var DialogHelper $dialog */
         $dialog = $this->getCommand()->getHelper('dialog');
 
         $defaults = $this->commandConfig['installation']['defaults'];
@@ -148,9 +150,11 @@ class InstallMagento extends AbstractSubCommand
             ? $this->input->getOption('baseUrl')
             : $dialog->askAndValidate(
                 $this->output,
-                '<question>Please enter the base url:</question> ',
+                '<question>Please enter the base url:</question> <comment>[' .
+                $defaultBaseUrl . ']</comment>:',
                 $validateBaseUrl,
-                false
+                false,
+                $this->commandConfig['installation']['base-url']
             );
         $baseUrl = rtrim($baseUrl, '/') . '/'; // normalize baseUrl
 

--- a/src/N98/Magento/Command/Installer/SubCommand/InstallSampleData.php
+++ b/src/N98/Magento/Command/Installer/SubCommand/InstallSampleData.php
@@ -20,7 +20,11 @@ class InstallSampleData extends AbstractSubCommand
         $installationFolder = $this->config->getString('installationFolder');
         chdir($installationFolder);
 
-        $flag = $this->getOptionalBooleanOption('installSampleData', 'Install sample data?');
+        $flag = $this->getOptionalBooleanOption(
+            'installSampleData',
+            'Install sample data?',
+            $this->commandConfig['installation']['sample-data']
+        );
 
         if ($flag) {
             $this->runSampleDataInstaller();


### PR DESCRIPTION
Changes proposed in this pull request:

* Adds DB default settings in the installation config (host, port, user and db name). It's possible to use the `%s` placeholder in DB name config setting that will be replaced with the installation folder base name.
* Adds default base URL setting in the installation config and like the DB name it's possible to use the `%s` placeholder that will be replaced with the installation folder base name.
* Adds the boolean sample data setting in the installation config to specify whether to install sample data or not by default.

With these changes it's possible to run an unattended installation with:

    n98-magerun2.phar install -n --magentoVersionByName="magento-ce-2.2.0" --installationFolder="myproject"

Or with:

    n98-magerun2.phar install -n --noDownload --installationFolder="myproject"

if the `myproject` contains a Magento version already downloaded.

In such examples the `http://myproject.dev/` base URL and `myproject` database name will be used along other default settings.