### PR TITLE
Simple Version update for Magento 2.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "symfony/finder": "~2.3||~3.0",
         "symfony/process": "~2.3",
         "symfony/validator": "~2.3",
-        "symfony/yaml": "~2.3",
+        "symfony/yaml": "^3.0",
         "twig/twig": "~1.0",
         "pbergman/tree-helper": "^1.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "symfony/finder": "~2.3||~3.0",
         "symfony/process": "~2.3",
         "symfony/validator": "~2.3",
-        "symfony/yaml": "^3.0",
+        "symfony/yaml": "~2.3||^3.0",
         "twig/twig": "~1.0",
         "pbergman/tree-helper": "^1.0"
     },

--- a/config.yaml
+++ b/config.yaml
@@ -127,15 +127,15 @@ commands:
     table-groups:
       - id: admin
         description: Admin tables
-        tables: admin* authorization*
+        tables: 'admin* authorization*'
 
       - id: log
         description: Log tables
-        tables: log_url log_url_info log_visitor log_visitor_info log_visitor_online report_event report_compared_product_index report_viewed_*
+        tables: 'log_url log_url_info log_visitor log_visitor_info log_visitor_online report_event report_compared_product_index report_viewed_*'
 
       - id: sessions
         description: Database session tables
-        tables: core_session
+        tables: 'core_session'
 
       - id: stripped
         description: Standard definition for a stripped dump (logs, sessions)
@@ -170,7 +170,7 @@ commands:
 
       - id: quotes
         description: Cart (quote) data
-        tables: quote quote_*
+        tables: 'quote quote_*'
 
       - id: customers
         description: Customer data - Should not be used without @sales

--- a/config.yaml
+++ b/config.yaml
@@ -139,7 +139,7 @@ commands:
 
       - id: stripped
         description: Standard definition for a stripped dump (logs, sessions)
-        tables: @log @sessions
+        tables: '@log @sessions'
 
       - id: sales
         description: Sales data (orders, invoices, creditmemos etc)
@@ -187,11 +187,11 @@ commands:
 
       - id: trade
         description: Current trade data (customers and orders). You usally do not want those in developer systems.
-        tables: @customers @sales @quotes
+        tables: '@customers @sales @quotes'
 
       - id: development
         description: Removes logs and trade data so developers do not have to work with real customer data
-        tables: @admin @trade @stripped @search
+        tables: '@admin @trade @stripped @search'
 
       - id: ee_changelog
         description: Changelog tables of new indexer since EE 1.13


### PR DESCRIPTION
Do not degrade Symfony YAML component when installing Magerun 2 w/ latest Magento 2.2 via Composer.

There is an incompatibility with the YAML format when Symfony YAML 3.x is used ("@" use in non-quoted scalars - e.g. for table-groups in Magerun config files, since ca. 2005 per YAML specs). As the Magerun project didn't communicate this non-standard use of the reserved notation earlier, Magerun users who write their own table-groups need to be made aware of this.

- [ ] Blog-post on magerun.net about the issue
- [ ] Add composer installations of the source version of Magerun  (1+2) into the Travis build
- [ ] Update version constraints w/ a Magerun version that shows a backwards incompatible change.
