### PR TITLE
Add support for Magento 2.2 for generation:flush command

### DIFF
--- a/src/N98/Magento/Command/Generation/FlushCommand.php
+++ b/src/N98/Magento/Command/Generation/FlushCommand.php
@@ -28,10 +28,20 @@ class FlushCommand extends AbstractMagentoCommand
     {
         $this->detectMagento($output);
 
+        $generationFlushDirectories = [
+            $this->getApplication()->getMagentoRootFolder() . '/var/generation',
+            $this->getApplication()->getMagentoRootFolder() . '/generated/code',
+        ];
+
         $finder = Finder::create()
             ->directories()
-            ->depth(0)
-            ->in($this->getApplication()->getMagentoRootFolder() . '/var/generation');
+            ->depth(0);
+
+        foreach ($generationFlushDirectories as $directoryToFlush) {
+            if (is_dir($directoryToFlush)) {
+                $finder->in($directoryToFlush);
+            }
+        }
 
         $vendorNameToFilter = $input->getArgument('vendorName');
 


### PR DESCRIPTION
Magerun pull-request check-list:

- [X] Pull request against develop branch (if not, just close and create a new one against it)
- [X] README.md reflects changes (if any)

Fixes broken generation:flush command in Magento 2.2