### PR TITLE
Remove "exclude-2.2" group annotation to re-enable skipped tests

### DIFF
--- a/tests/N98/Magento/Command/Script/Repository/ListCommandTest.php
+++ b/tests/N98/Magento/Command/Script/Repository/ListCommandTest.php
@@ -7,7 +7,6 @@ use N98\Magento\Command\TestCase;
 /**
  * Class ListCommandTest
  * @package N98\Magento\Command\Script\Repository
- * @group exclude-2.2
  */
 class ListCommandTest extends TestCase
 {

--- a/tests/N98/Magento/Command/Script/Repository/RunCommandTest.php
+++ b/tests/N98/Magento/Command/Script/Repository/RunCommandTest.php
@@ -7,7 +7,6 @@ use N98\Magento\Command\TestCase;
 /**
  * Class RunCommandTest
  * @package N98\Magento\Command\Script\Repository
- * @group exclude-2.2
  */
 class RunCommandTest extends TestCase
 {

--- a/tests/N98/Magento/Command/ScriptCommandTest.php
+++ b/tests/N98/Magento/Command/ScriptCommandTest.php
@@ -5,7 +5,6 @@ namespace N98\Magento\Command;
 /**
  * Class ScriptCommandTest
  * @package N98\Magento\Command
- * @group exclude-2.2
  */
 class ScriptCommandTest extends TestCase
 {

--- a/tests/N98/Util/ExecTest.php
+++ b/tests/N98/Util/ExecTest.php
@@ -9,7 +9,6 @@ use RuntimeException;
  * Class ExecTest
  *
  * @package N98\Util
- * @group exclude-2.2
  */
 class ExecTest extends \PHPUnit_Framework_TestCase
 {


### PR DESCRIPTION
Magerun pull-request check-list:

- [X] Pull request against develop branch (if not, just close and create a new one against it)
- [X] README.md reflects changes (if any)

Re-Enable skipped tests. The tests are skipped because of some memory issues in travis build jobs. The tests are now running in separated processes. So the issue should be fixed for the travis build.