### PR TITLE
Change Magento Version for Circle-CI Build to 2.2

### DIFF
--- a/build/circleci/source.sh
+++ b/build/circleci/source.sh
@@ -11,7 +11,7 @@ buildecho()
 export CLOVER_XML="${CIRCLE_ARTIFACTS:-.}/clover.xml"
 buildecho "clover.xml: '${CLOVER_XML}', exported as \$CLOVER_XML."
 
-export MAGENTO_VERSION="magento-ce-2.0.0"
+export MAGENTO_VERSION="magento-ce-2.2.0"
 export DB=mysql
 export INSTALL_SAMPLE_DATA=0
 export COVERAGE=10


### PR DESCRIPTION
Magerun pull-request check-list:

- [X] Pull request against develop branch (if not, just close and create a new one against it)
- [X] README.md reflects changes (if any)

Fixes broken Circle-CI build.

Increased the Magento Version from 2.0.0 to 2.2.0.