### PR TITLE
Add Magento-Root to sys:info command

### DIFF
--- a/src/N98/Magento/Command/System/InfoCommand.php
+++ b/src/N98/Magento/Command/System/InfoCommand.php
@@ -150,7 +150,7 @@ class InfoCommand extends AbstractMagentoCommand
             $settingArgument = strtolower($settingArgument);
             $this->infos = array_change_key_case($this->infos, CASE_LOWER);
             if (!isset($this->infos[$settingArgument])) {
-                throw new InvalidArgumentException('Unknown key: ' . $settingArgument);
+                throw new \InvalidArgumentException('Unknown key: ' . $settingArgument);
             }
             $output->writeln((string) $this->infos[$settingArgument]);
         } else {
@@ -225,6 +225,7 @@ class InfoCommand extends AbstractMagentoCommand
         $this->infos['Name'] = $this->productMetadata->getName();
         $this->infos['Version'] = $this->productMetadata->getVersion();
         $this->infos['Edition'] = $this->productMetadata->getEdition();
+        $this->infos['Root'] = $this->_magentoRootFolder;
     }
 
     protected function addVendors()


### PR DESCRIPTION
Magerun pull-request check-list:

- [X] Pull request against develop branch (if not, just close and create a new one against it)

Changes proposed in this pull request:

Add "root" directory to sys:info command. This is useful to use the auto-root detection of n98-magerun in bash scripts.