### PR TITLE
Optimise the runtime of script:repo commands

### DIFF
--- a/src/N98/Magento/Command/Script/Repository/ScriptLoader.php
+++ b/src/N98/Magento/Command/Script/Repository/ScriptLoader.php
@@ -159,6 +159,7 @@ final class ScriptLoader
         /* @var $finder Finder */
         $finder = Finder::create()
             ->files()
+            ->exclude('pub')
             ->followLinks(true)
             ->ignoreUnreadableDirs(true)
             ->name('*' . AbstractRepositoryCommand::MAGERUN_EXTENSION)


### PR DESCRIPTION
**Subject**: Optimise the runtime of script:repo commands

**Fixes** # Scanning for magerun scripts taking too long when scanning the media files on EFS filesystems

**Changes proposed in this pull request:**

**Problem description:**
The command `n98-magerun2 script:repo:list`
is running for 10 to 30 minutes before showing the expected result.

**To reproduce the situation:**
A large “pub/media” folder having thousands of directories containing many files.
If the filesystem is slow (eg, using NFS or a slow disk), the problem will be worse.

When debugging the command I found that the `findScriptFiles()` function will the whole magneto folder and the magerun config paths.
Accessing many files on NFS can be very slow so that it takes 10 to 30 minutes depending on the size of the media folder.
So my approach is to exclude the public folder from being scanned.
That might prevent security issues as well?