### PR TITLE
Fixed running cronjobs configured in database, scheduled imports for …

### DIFF
--- a/src/N98/Magento/Command/System/Cron/AbstractCronCommand.php
+++ b/src/N98/Magento/Command/System/Cron/AbstractCronCommand.php
@@ -81,9 +81,9 @@ abstract class AbstractCronCommand extends AbstractMagentoCommand
         $jobs = $this->cronConfig->getJobs();
 
         foreach ($jobs as $jobGroupCode => $jobGroup) {
-            foreach ($jobGroup as $job) {
+            foreach ($jobGroup as $jobKey => $job) {
                 $row = [
-                    'Job'   => isset($job['name']) ? $job['name'] : null,
+                    'Job'   => isset($job['name']) ? $job['name'] : $jobKey,
                     'Group' => $jobGroupCode,
                 ];
 
@@ -107,8 +107,8 @@ abstract class AbstractCronCommand extends AbstractMagentoCommand
     protected function getJobConfig($jobCode)
     {
         foreach ($this->cronConfig->getJobs() as $jobGroup) {
-            foreach ($jobGroup as $job) {
-                if (isset($job['name']) && $job['name'] == $jobCode) {
+            foreach ($jobGroup as $jobKey => $job) {
+                if (isset($job['name']) && ($job['name'] == $jobCode || $jobKey == $jobCode)) {
                     return $job;
                 }
             }


### PR DESCRIPTION
Magerun pull-request check-list:

- [V] Pull request against develop branch (if not, just close and create a new one against it)
- [/] README.md reflects changes (if any)

Subject: Fix for cronjobs configured in database

Fixes # .

Changes proposed in this pull request:

- Added the array key in two foreaches over jobGroup giving the jobCode as key.
$job['name'] does not exist when the the jobCode is configured in the database, for scheduled imports for example. This fix uses the key as jobCode, making the jobs visible in the sys:cron:list command and resolves the error when you try to run the sys:cron:run command.
