### PR TITLE
Reverted composer/composer constraint to v1.0 so we can install n98/m…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "magerun2"
     ],
     "require": {
-        "composer/composer": "^1.6.0",
+        "composer/composer": "^1.0",
         "fzaninotto/faker": "~1.4",
         "n98/junit-xml": "~1.0",
         "php": ">=5.6.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "d79aef8b4bf4d369a352226f9132049b",
+    "content-hash": "f29a44eadef2916c466eb6a6b39a4522",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -64,16 +64,16 @@
         },
         {
             "name": "composer/composer",
-            "version": "1.6.2",
+            "version": "1.6.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/composer.git",
-                "reference": "db191abd24b0be110c98ba2271ca992e1c70962f"
+                "reference": "88a69fda0f2187ad8714cedffd7a8872dceaa4c2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/composer/zipball/db191abd24b0be110c98ba2271ca992e1c70962f",
-                "reference": "db191abd24b0be110c98ba2271ca992e1c70962f",
+                "url": "https://api.github.com/repos/composer/composer/zipball/88a69fda0f2187ad8714cedffd7a8872dceaa4c2",
+                "reference": "88a69fda0f2187ad8714cedffd7a8872dceaa4c2",
                 "shasum": ""
             },
             "require": {
@@ -137,7 +137,7 @@
                 "dependency",
                 "package"
             ],
-            "time": "2018-01-05T14:28:42+00:00"
+            "time": "2018-01-31T15:28:18+00:00"
         },
         {
             "name": "composer/semver",


### PR DESCRIPTION
…agerun2 using composer in Magento 2.2

Magerun pull-request check-list:

- [x] Pull request against develop branch (if not, just close and create a new one against it)
- [ ] README.md reflects changes (if any)

Subject: Reverted composer/composer constraint to v1.0 so we can install n98/magerun2 using composer in Magento 2.2

Fixes https://github.com/netz98/n98-magerun2/issues/349
