### PR TITLE
Added additional tables to "search" table-group, fixes #354.

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -201,7 +201,10 @@ commands:
 
       - id: search
         description: Search related tables
-        tables: "catalogsearch_*"
+        tables: >
+          catalogsearch_*
+          search_query
+          search_synonyms
 
       - id: idx
         description: Tables with _idx suffix


### PR DESCRIPTION
Improve db:dump command.

`db:dump --strip="@search"` should drop `search_query` and `search_synonym` tables as well.

Fixes #354 