### PR TITLE
Fix issue #333 - dev:template-hints not working with Magento 2.2.0

### DIFF
--- a/src/N98/Magento/Command/AbstractMagentoStoreConfigCommand.php
+++ b/src/N98/Magento/Command/AbstractMagentoStoreConfigCommand.php
@@ -144,7 +144,7 @@ abstract class AbstractMagentoStoreConfigCommand extends AbstractMagentoCommand
         }
 
         $configSetCommands = [
-            'command'    => 'config:set',
+            'command'    => 'config:store:set',
             'path'       => $this->configPath,
             'value'      => $isFalse ? 1 : 0,
             '--scope'    => $scope,


### PR DESCRIPTION
Magerun pull-request check-list:

- [X] Pull request against develop branch (if not, just close and create a new one against it)

Fixes #333

Changes proposed in this pull request:

Use the new "config:store:set" command instead of the "config:set" command.