### PR TITLE
Correct --forceUseDb help description

### DIFF
--- a/src/N98/Magento/Command/Installer/InstallCommand.php
+++ b/src/N98/Magento/Command/Installer/InstallCommand.php
@@ -81,7 +81,7 @@ class InstallCommand extends AbstractMagentoCommand
                 'forceUseDb',
                 null,
                 InputOption::VALUE_NONE,
-                'If --noDownload passed, force to use given database if it already exists.'
+                'If --forceUseDb passed, force to use given database if it already exists.'
             )
             ->setDescription('Install magento');
 


### PR DESCRIPTION
Changes proposed in this pull request:
- the `--forceUseDb` help description contained a reference to the `--noDownload` option which gets corrected with this PR.