### PR TITLE
Add option to force Composer to use same PHP binary as n98-magerun2 was invoked with

### DIFF
--- a/src/N98/Magento/Command/Installer/InstallCommand.php
+++ b/src/N98/Magento/Command/Installer/InstallCommand.php
@@ -83,6 +83,12 @@ class InstallCommand extends AbstractMagentoCommand
                 InputOption::VALUE_NONE,
                 'If --noDownload passed, force to use given database if it already exists.'
             )
+            ->addOption(
+                'composer-use-same-php-binary',
+                null,
+                InputOption::VALUE_NONE,
+                'If --composer-use-same-php-binary passed, will invoke composer with the same PHP binary'
+            )
             ->setDescription('Install magento');
 
         $help = <<<HELP

--- a/src/N98/Magento/Command/Installer/SubCommand/DownloadMagento.php
+++ b/src/N98/Magento/Command/Installer/SubCommand/DownloadMagento.php
@@ -40,7 +40,7 @@ class DownloadMagento extends AbstractSubCommand
             throw new RuntimeException('A magento installation already exists in this folder');
         }
 
-        $args = new ProcessArguments(array($this->config['composer_bin'], 'create-project'));
+        $args = new ProcessArguments(array_merge($this->config['composer_bin'], array('create-project')));
         $args
             // Add composer options
             ->addArgs($package['options'])

--- a/src/N98/Magento/Command/Installer/SubCommand/InstallComposer.php
+++ b/src/N98/Magento/Command/Installer/SubCommand/InstallComposer.php
@@ -36,7 +36,15 @@ class InstallComposer extends AbstractSubCommand
         }
 
         $this->output->writeln('<info>Found executable <comment>' . $composerBin . '</comment></info>');
-        $this->config['composer_bin'] = $composerBin;
+        $this->config['composer_bin'] = array($composerBin);
+
+        $composerUseSamePhpBinary = $this->hasFlagOrOptionalBoolOption('composer-use-same-php-binary', false);
+        if ($composerUseSamePhpBinary) {
+            $this->config['composer_bin'] = array(
+                OperatingSystem::getCurrentPhpBinary(),
+                $composerBin = OperatingSystem::locateProgram($composerBin),
+            );
+        }
     }
 
     /**

--- a/src/N98/Magento/Command/Installer/SubCommand/InstallComposerPackages.php
+++ b/src/N98/Magento/Command/Installer/SubCommand/InstallComposerPackages.php
@@ -17,12 +17,8 @@ class InstallComposerPackages extends AbstractSubCommand
     public function execute()
     {
         $this->output->writeln('<comment>Install composer packages</comment>');
-        $processBuilder = new ProcessBuilder(
-            array(
-                $this->config['composer_bin'],
-                'install',
-            )
-        );
+
+        $processBuilder = new ProcessArguments(array_merge($this->config['composer_bin'], array('install')));
         $process = $processBuilder->getProcess();
         $process->setTimeout(86400);
 

--- a/src/N98/Magento/Command/Installer/SubCommand/InstallComposerPackages.php
+++ b/src/N98/Magento/Command/Installer/SubCommand/InstallComposerPackages.php
@@ -17,8 +17,7 @@ class InstallComposerPackages extends AbstractSubCommand
     public function execute()
     {
         $this->output->writeln('<comment>Install composer packages</comment>');
-
-        $processBuilder = new ProcessArguments(array_merge($this->config['composer_bin'], array('install')));
+        $processBuilder = new ProcessBuilder(array_merge($this->config['composer_bin'], array('install')));
         $process = $processBuilder->getProcess();
         $process->setTimeout(86400);
 

--- a/src/N98/Util/OperatingSystem.php
+++ b/src/N98/Util/OperatingSystem.php
@@ -73,11 +73,26 @@ class OperatingSystem
             return WindowsSystem::isProgramInstalled($program);
         }
 
+        return '' !== self::locateProgram($program);
+    }
+
+    /**
+     * Returns the absolute path to the program that should be located or an empty string if the programm
+     * could not be found.
+     *
+     * @param string $program
+     * @return string
+     */
+    public static function locateProgram($program)
+    {
+        if (self::isWindows()) {
+            return WindowsSystem::locateProgram($program);
+        }
+
         $out = null;
         $return = null;
         @exec('which ' . $program, $out, $return);
-
-        return $return === 0;
+        return ($return === 0 && isset($out[0])) ? $out[0] : '';
     }
 
     /**
@@ -133,5 +148,19 @@ class OperatingSystem
         }
 
         return '/usr/bin/env php';
+    }
+
+    /**
+     * Retrieve path to current php binary.
+     *
+     * @return string
+     */
+    public static function getCurrentPhpBinary()
+    {
+        if (isset($_SERVER['_'])) {
+            return $_SERVER['_'];
+        }
+
+        return self::getPhpBinary();
     }
 }

--- a/src/N98/Util/WindowsSystem.php
+++ b/src/N98/Util/WindowsSystem.php
@@ -91,9 +91,21 @@ class WindowsSystem
      */
     public static function isProgramInstalled($program)
     {
+        return '' !== self::locateProgram($program);
+    }
+
+    /**
+     * Returns the absolute path to the program that should be located or an empty string if the programm
+     * could not be found.
+     *
+     * @param string $program
+     * @return string
+     */
+    public static function locateProgram($program)
+    {
         // programs with an invalid name do not exist
         if (false !== strpbrk($program, self::FORBIDDEN_CHARS)) {
-            return false;
+            return '';
         }
 
         $isExecutable = self::isExecutableName($program);
@@ -109,17 +121,17 @@ class WindowsSystem
             $file = $path . '/' . $program;
 
             if ($isExecutable && is_readable($file)) {
-                return true;
+                return $file;
             }
 
             foreach ($exts as $ext => $index) {
                 $fileEx = $file . $ext;
                 if (is_readable($fileEx)) {
-                    return true;
+                    return $fileEx;
                 }
             }
         }
 
-        return false;
+        return '';
     }
 }


### PR DESCRIPTION
By supplying the --composer-use-same-php-binary option to the install command n98-magerun2 will invoke Composer with the same PHP binary n98-magerun2 was invoked. Fixes #295.
