### PR TITLE
[BUGFIX] db:dump fixed table-group @customer

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -178,14 +178,17 @@ commands:
         description: Customer data - Should not be used without @sales
         tables: >
           customer_address*
-          customer_entity*
+          customer_entity
+            customer_entity_*
           customer_grid_flat
           customer_log
           customer_visitor
           newsletter_subscriber
           product_alert*
-          vault_payment_token*
-          wishlist*
+          vault_payment_token
+            vault_payment_token_*
+          wishlist
+            wishlist_*
 
       - id: trade
         description: Current trade data (customers and orders). You usally do not want those in developer systems.


### PR DESCRIPTION
Fixed table-group @customer for command db:dump with option --strip

Affected Tables which are now also only being exported as structure without data:

* 'customer_entity' and all child eav tables
* 'vault_payment_token' and 'vault_payment_token_order_payment_link'
* 'wishlist' and all child item tables

The problem was that the wildcard p.e. 'customer_entity*' doesn't match 'customer_entity' itself.
Wildcard substitutions were being added to cover that.

Magerun pull-request check-list:

- [ ] Pull request against develop branch (if not, just close and create a new one against it)
- [ ] README.md reflects changes (if any)

Subject: (50 characters or less)

Fixes # .

Changes proposed in this pull request:

- ...

- ...

- ...
