### PR TITLE
Add company table to @customer table group

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -189,6 +189,8 @@ commands:
             vault_payment_token_*
           wishlist
             wishlist_*
+          company
+            company_*
 
       - id: trade
         description: Current trade data (customers and orders). You usally do not want those in developer systems.

--- a/readme.rst
+++ b/readme.rst
@@ -537,7 +537,7 @@ Example: "dataflow_batch_export unimportant_module_* @log
 
 Available Table Groups:
 
-* @customers Customer data
+* @customers Customer data (and company data from the B2B extension)
 * @development Removes logs, sessions, trade data and admin users so developers do not have to work with real customer data or admin user accounts
 * @ee_changelog Changelog tables of new indexer since EE 1.13
 * @idx Tables with _idx suffix and index event tables


### PR DESCRIPTION
Hi,

This PR adds the company tables (from the B2B Commerce extension) to the `@customers` table groups. 

I've added this to `@customers` because the company_* tables are related with the customers.
This should prevent the  `No such entity with customerId = X` error when opening a company in the backend when using a DB dump with the customer data stripped.

Please let me know if something has to be done before this can be merged. 

Thanks!