### PR TITLE
db:dump strip=@stripped does not strip sensitive data

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -140,8 +140,8 @@ commands:
         tables: session persistent_session
 
       - id: stripped
-        description: Standard definition for a stripped dump (logs, sessions)
-        tables: @log @sessions
+        description: Standard definition for a stripped dump (logs, sessions, dotmailer)
+        tables: @log @sessions @dotmailer
 
       - id: sales
         description: Sales data (orders, invoices, creditmemos etc)
@@ -214,6 +214,10 @@ commands:
       - id: idx
         description: Tables with _idx suffix
         tables: "*_idx"
+
+      - id: dotmailer
+        description: Dotmailer tables
+        tables: email_abandoned_cart email_automation email_campaign email_contact
 
   N98\Magento\Command\Installer\InstallCommand:
     magento-packages:

--- a/readme.rst
+++ b/readme.rst
@@ -537,6 +537,7 @@ Example: "dataflow_batch_export unimportant_module_* @log
 
 Available Table Groups:
 
+* @dotmailer Dotmailer data(email_abandoned_cart email_automation email_campaign email_contact)
 * @customers Customer data (and company data from the B2B extension)
 * @development Removes logs, sessions, trade data and admin users so developers do not have to work with real customer data or admin user accounts
 * @ee_changelog Changelog tables of new indexer since EE 1.13


### PR DESCRIPTION
Strip dotmailer tables which comes bundled with Magento because it might contain customer-sensitive data (the email address) for tables email_abandoned_cart email_automation email_campaign email_contact.

Fixes #380 .

Changes proposed in this pull request:

- add dotmailer group

- dotmailer group will include (email_abandoned_cart email_automation email_campaign email_contact) tables

Please let me know if there is more to check/change for this PR.
