### PR TITLE
Feature/git friendly dumps

### DIFF
--- a/readme.rst
+++ b/readme.rst
@@ -482,6 +482,9 @@ Dumps configured Magento database with `mysqldump`.
   --human-readable
         Use a single insert with column names per row.
 
+  --git-friendly
+        Use one insert statement, but with line breaks instead of separate insert statements.
+
   --add-routines
         Include stored routines in dump (procedures & functions).
 

--- a/src/N98/Magento/Command/Database/DumpCommand.php
+++ b/src/N98/Magento/Command/Database/DumpCommand.php
@@ -80,7 +80,7 @@ class DumpCommand extends AbstractDatabaseCommand
                 'git-friendly',
                 null,
                 InputOption::VALUE_NONE,
-                'Use one insert statement, but with line breaks. Similar to --human-readable, but you wont need to use --optimize to speed up the import.'
+                'Use one insert statement, but with line breaks instead of separate insert statements. Similar to --human-readable, but you wont need to use --optimize to speed up the import.'
             )
             ->addOption(
                 'add-routines',


### PR DESCRIPTION
This PR implements Git Friendly Dumps as proposed in  #386.

It adds the option `--git-friendly` to the `db:dump` command. With that option, the dump will have only one insert statement per table, but with line-breaks (unlike `--human-readable` which will create an insert statement for each record in the table.

Dumps which are created with this option won't need `--optimize` on import.

Fixes  #386