### PR TITLE
Homebrew php tap is deprecated

### DIFF
--- a/readme.rst
+++ b/readme.rst
@@ -106,25 +106,6 @@ execute it from the vendor’s bin folder:
     ./vendor/bin/n98-magerun2 --version
     n98-magerun2 version 1.3.2 by netz98 GmbH
 
-Install with Homebrew
-"""""""""""""""""""""
-
-First you need to have homebrew installed: http://brew.sh/
-
-Install homebrew-php tap: https://github.com/Homebrew/homebrew-php#installation
-
-Once homebrew and the tap are installed, you can install the tools with it:
-
-.. code-block:: sh
-
-    brew install n98-magerun2
-
-You can now use the tools:
-
-.. code-block:: sh
-
-    $ n98-magerun2 {command}
-
 Update
 ------
 


### PR DESCRIPTION
Magerun pull-request check-list:

- [x] Pull request against develop branch (if not, just close and create a new one against it)
- [x] README.md reflects changes (if any)

Subject: Remove homebrew installation from readme

I think currently it's not possible to install n98-magerun2 with homebrew.
The Homebrew/php tap was archived on 31st March 2018.

```
$ brew search magerun
No formula or cask found for "magerun".
```

Changes proposed in this pull request:

- Remove homebrew installation from readme