### PR TITLE
Emulation-Mode not needed after set current area. This resolves #245

### DIFF
--- a/src/N98/Magento/Command/System/Cron/RunCommand.php
+++ b/src/N98/Magento/Command/System/Cron/RunCommand.php
@@ -44,8 +44,6 @@ HELP;
 
         list($jobCode, $jobConfig, $model) = $this->getJobForExecuteMethod($input, $output);
 
-        $callback = array($model, $jobConfig['method']);
-
         $output->write(
             '<info>Run </info><comment>' . $jobConfig['instance'] . '::' . $jobConfig['method'] . '</comment> '
         );
@@ -59,7 +57,7 @@ HELP;
             ->save();
 
         try {
-            $this->state->emulateAreaCode(Area::AREA_CRONTAB, $callback, array($schedule));
+            call_user_func([$model, $jobConfig['method']], $schedule);
 
             $schedule
                 ->setStatus(Schedule::STATUS_SUCCESS)


### PR DESCRIPTION
Magerun pull-request check-list:

- [x] Pull request against develop branch (if not, just close and create a new one against it)

Subject: Not using Emulation-Mode in on RunCommand

Fixes #245 

Changes proposed in this pull request:

- Thanks to #377 , it is not needed to start command in emulation mode

Issue-Description:

In #277, emulation mode was introduced for command. But if you use another `startEmulationMode`/`emulateAreaCode` with empty cache, the error

> Required parameter 'theme_dir' was not passed

still exists. The Problem is, that the started emulation mode in RunCommand set `isAreaCodeEmulated` to `true` and on `startEmulationMode`, Magento tries to load a theme in crontab-scope (see `\Magento\Theme\Model\Theme::getArea`), which throws the Exception in `\Magento\Framework\View\Design\Fallback\Rule\Simple::getPatternDirs`.
If there is a cache, it works in case, you have done a request fur the requested store/scope.