### PR TITLE
Fix #401 - warning in db:dump command with --stdout

### DIFF
--- a/src/N98/Magento/Command/Database/DumpCommand.php
+++ b/src/N98/Magento/Command/Database/DumpCommand.php
@@ -488,7 +488,7 @@ HELP;
                 $fileName = $defaultName;
             }
         } else {
-            if ($optionAddTime) {
+            if ($optionAddTime && $fileName !== null) {
                 $pathParts = pathinfo($fileName);
                 $fileName = ($pathParts['dirname'] == '.' ? '' : $pathParts['dirname'] . '/') .
                     $namePrefix . $pathParts['filename'] . $nameSuffix . '.' . $pathParts['extension'];


### PR DESCRIPTION
Check if filename is passed. If not, do not try to use it.

Fixes #401 
