### PR TITLE
Uses Magento's DirectoryList to get config folder path (app/etc)

### DIFF
--- a/src/N98/Magento/Application.php
+++ b/src/N98/Magento/Application.php
@@ -5,6 +5,7 @@ namespace N98\Magento;
 use BadMethodCallException;
 use Composer\Autoload\ClassLoader;
 use Exception;
+use Magento\Framework\App\Filesystem\DirectoryList;
 use Magento\Framework\Autoload\AutoloaderRegistry;
 use Magento\Framework\ObjectManagerInterface;
 use N98\Magento\Application\AutoloaderDecorator;
@@ -337,10 +338,11 @@ class Application extends BaseApplication
         }
 
         $this->detectMagento(null, $output);
+        /** @var DirectoryList $directoryList */
+        $directoryList = $this->_objectManager->get(DirectoryList::class);
+        $configDir = rtrim($directoryList->getPath(DirectoryList::CONFIG), DIRECTORY_SEPARATOR);
         /* If magento is not installed yet, don't check */
-        if ($this->detectionResult->getRootFolder() === null
-            || !file_exists($this->getMagentoRootFolder() . '/app/etc/env.php')
-        ) {
+        if ($this->detectionResult->getRootFolder() === null || !file_exists($configDir . '/env.php')) {
             return;
         }
 
@@ -358,8 +360,7 @@ class Application extends BaseApplication
             return;
         }
 
-        $directoryList = $this->_objectManager->get('\Magento\Framework\App\Filesystem\DirectoryList');
-        $currentVarDir = $directoryList->getPath('var');
+        $currentVarDir = $directoryList->getPath(DirectoryList::VAR_DIR);
 
         if ($currentVarDir === $tempVarDir) {
             $output->writeln([

--- a/src/N98/Magento/Command/Installer/SubCommand/DownloadMagento.php
+++ b/src/N98/Magento/Command/Installer/SubCommand/DownloadMagento.php
@@ -36,7 +36,7 @@ class DownloadMagento extends AbstractSubCommand
         $package = $this->config['magentoVersionData'];
         $this->config->setArray('magentoPackage', $package);
 
-        if (file_exists($this->config->getString('installationFolder') . '/app/etc/env.php')) {
+        if (file_exists($this->config->getString('installationFolder') . '/' . $this->getConfigDir() . '/env.php')) {
             throw new RuntimeException('A magento installation already exists in this folder');
         }
 
@@ -168,5 +168,21 @@ class DownloadMagento extends AbstractSubCommand
 
             $composerHelper->setConfigValue($configKey, [$username, $password]);
         }
+    }
+
+    /**
+     * This method emulates the behavior of the `Magento\Framework\App\Filesystem\DirectoryList` component which, in
+     * the end, reads the config directory path from the `$_SERVER['MAGE_DIR']['etc']['path']` if it exists and falls
+     * back on the `app/etc` default value otherwise. Obviously is not possible to use the `DirectoryList` component
+     * here because Magento has not been downloaded yet; so we have to emulate the original behavior.
+     *
+     * @return string
+     */
+    private function getConfigDir()
+    {
+        if (isset($_SERVER['MAGE_DIRS']['etc']['path'])) {
+            return trim($_SERVER['MAGE_DIRS']['etc']['path'], DIRECTORY_SEPARATOR);
+        }
+        return 'app/etc';
     }
 }


### PR DESCRIPTION
This PR removes the hardcoded `app/etc` path in the following components/commands:
- The `checkVarDir` method of the main `Application`
- The `DownloadMagento` subcommand
- The base configuration loading inside the `MagentoHelper`
