### PR TITLE
Fix #329 - Add session hack to prevent "area code not set"

### DIFF
--- a/src/N98/Magento/Command/Admin/User/ChangePasswordCommand.php
+++ b/src/N98/Magento/Command/Admin/User/ChangePasswordCommand.php
@@ -53,6 +53,9 @@ class ChangePasswordCommand extends AbstractAdminUserCommand
         }
 
         try {
+            // @see \Magento\Framework\Session\SessionManager::isSessionExists Hack to prevent session problems
+            @session_start();
+
             $result = $user->validate();
             if (is_array($result)) {
                 throw new Exception(implode(PHP_EOL, $result));


### PR DESCRIPTION
Magerun pull-request check-list:

- [X] Pull request against develop branch (if not, just close and create a new one against it)

Fixes #329 

Changes proposed in this pull request:

- Add session start "hack" which prevents SidResolver to open a new session which removes areaCode from AppState.