### PR TITLE
Fix create customer store id

### DIFF
--- a/src/N98/Magento/Command/Customer/CreateCommand.php
+++ b/src/N98/Magento/Command/Customer/CreateCommand.php
@@ -101,7 +101,7 @@ class CreateCommand extends AbstractCustomerCommand
             $customer->setEmail($email);
             $customer->setFirstname($firstname);
             $customer->setLastname($lastname);
-            $customer->setStoreId($website->getDefaultGroup()->getId());
+            $customer->setStoreId($website->getDefaultGroup()->getDefaultStore()->getId());
 
             try {
                 $this->appState->setAreaCode('frontend');


### PR DESCRIPTION
Magerun pull-request check-list:

- [x] Pull request against develop branch (if not, just close and create a new one against it)
- [x] README.md reflects changes (if any)

Subject: (50 characters or less)

Fixes # store_id and created_in value in customer_entity when create customer by n98 command

Changes proposed in this pull request:

- Change default store group id by default store id
