### PR TITLE
Fix count on non-countable variable for php 7.2 compatibility

### DIFF
--- a/src/N98/Util/Console/Helper/ParameterHelper.php
+++ b/src/N98/Util/Console/Helper/ParameterHelper.php
@@ -234,7 +234,7 @@ class ParameterHelper extends AbstractHelper
     protected function _validateArgument(OutputInterface $output, $name, $value, $constraints)
     {
         $validator = $this->initValidator();
-        $errors = null;
+        $errors = array();
 
         if (!empty($value)) {
             $errors = $validator->validateValue(array($name => $value), $constraints);


### PR DESCRIPTION
Magerun pull-request check-list:

- [x] Pull request against develop branch (if not, just close and create a new one against it)
- [x] README.md reflects changes (if any)

Subject: Fix count on non-countable variable for php 7.2 compatibility

Changes proposed in this pull request:

- Calling `count` on a variable with a `null` value produces a warning in PHP 7.2
