### PR TITLE
Add phar wrapper for Magento 2.3.1 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,8 @@
         "symfony/validator": "~2.3",
         "symfony/yaml": "~2.3",
         "twig/twig": "~1.0",
-        "pbergman/tree-helper": "^1.0"
+        "pbergman/tree-helper": "^1.0",
+        "typo3/phar-stream-wrapper": "^3.1"
     },
     "require-dev": {
         "ext-xdebug": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3921f43e94c19f9d69688cb73d825768",
+    "content-hash": "db3cf8055cd8ac68812fc559bfaf1a5c",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -1655,6 +1655,48 @@
                 "templating"
             ],
             "time": "2018-07-13T07:12:17+00:00"
+        },
+        {
+            "name": "typo3/phar-stream-wrapper",
+            "version": "v3.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/TYPO3/phar-stream-wrapper.git",
+                "reference": "19edc4e0ca5174764e3c946431b8b00326304944"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/TYPO3/phar-stream-wrapper/zipball/19edc4e0ca5174764e3c946431b8b00326304944",
+                "reference": "19edc4e0ca5174764e3c946431b8b00326304944",
+                "shasum": ""
+            },
+            "require": {
+                "ext-fileinfo": "*",
+                "ext-json": "*",
+                "php": "^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "TYPO3\\PharStreamWrapper\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Interceptors for PHP's native phar:// stream handling",
+            "homepage": "https://typo3.org/",
+            "keywords": [
+                "phar",
+                "php",
+                "security",
+                "stream-wrapper"
+            ],
+            "time": "2019-03-01T23:18:27+00:00"
         }
     ],
     "packages-dev": [

--- a/src/N98/Magento/Application/Magento2Initializer.php
+++ b/src/N98/Magento/Application/Magento2Initializer.php
@@ -30,6 +30,7 @@ class Magento2Initializer
     public function init($magentoRootFolder)
     {
         $this->requireOnce($magentoRootFolder . '/app/bootstrap.php');
+        $this->pharWrapperFix();
 
         $magentoAutoloader = AutoloaderRegistry::getAutoloader();
 
@@ -73,5 +74,15 @@ class Magento2Initializer
         }
 
         $requireOnce($path);
+    }
+
+    /**
+     * Magento 2.3.1 removes the phar wrapper
+     */
+    private function pharWrapperFix()
+    {
+        if (!in_array('phar', stream_get_wrappers())) {
+            stream_wrapper_register('phar', \TYPO3\PharStreamWrapper\PharStreamWrapper::class);
+        }
     }
 }


### PR DESCRIPTION
Magento 2.3.1 removes the phar stream wrapper in the app/bootstrap.php.
We re-enable the phar wrapper even after loading the bootstrap.

Magerun pull-request check-list:

- [X] Pull request against develop branch

Fixes problem with bootstrap.php in Magento 2.3.1 which removes the phar stream wrapper.