### PR TITLE
make build.sh OSX compatible

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -79,7 +79,9 @@ echo "building in $(pwd -P)"
 echo "build version: $(git --no-pager log --oneline -1)"
 
 echo "provision: ulimits (soft) set from $(ulimit -Sn) to $(ulimit -Hn) (hard) for faster phar builds..."
-ulimit -Sn $(ulimit -Hn)
+if [ "$(uname -s)" != "Darwin" ]; then
+  ulimit -Sn $(ulimit -Hn)
+fi
 timestamp="$(git log --format=format:%ct HEAD -1)" # reproduceable build
 echo "build timestamp: ${timestamp}"
 

--- a/build.sh
+++ b/build.sh
@@ -31,7 +31,7 @@ establish_build_dir() {
   fi
 }
 
-name="$(awk '/<project name="([^"]*)"/ && !done {print gensub(/<project name="([^"]*)".*/, "\\1", "g"); done=1}' build.xml)"
+name="$(perl -ne '/<project name="([^"]*)"/ and print $1 and last' build.xml)"
 nice_name="$(php -r "echo str_replace(' ', '', ucwords(strtr('${name}', '-', ' ')));")"
 phar="${name}.phar"
 echo "Building ${phar}..."


### PR DESCRIPTION
Magerun pull-request check-list:

- [x] Pull request against develop branch (if not, just close and create a new one against it)
- [x] README.md reflects changes (if any)

Subject: make build.sh OSX compatible

Changes proposed in this pull request:

- use perl instead of awk b/c awk w/ OSX does not support gensub (requires gawk)
also more readable in perl (IMO)

- test for OSX before attempting to set ulimit
