### PR TITLE
Fix db:dump while using option "-t" instead of "--add-time"

### DIFF
--- a/src/N98/Magento/Command/Database/DumpCommand.php
+++ b/src/N98/Magento/Command/Database/DumpCommand.php
@@ -459,7 +459,7 @@ HELP;
         $nameExtension = '.sql';
 
         $optionAddTime = 'no';
-        if ($input->hasOption('add-time')) {
+        if ($input->getOption('add-time')) {
             $optionAddTime = $input->getOption('add-time');
             if (empty($optionAddTime)) {
                 $optionAddTime = 'suffix';

--- a/src/N98/Magento/Command/Database/DumpCommand.php
+++ b/src/N98/Magento/Command/Database/DumpCommand.php
@@ -459,7 +459,7 @@ HELP;
         $nameExtension = '.sql';
 
         $optionAddTime = 'no';
-        if ($input->hasParameterOption('--add-time')) {
+        if ($input->hasOption('add-time')) {
             $optionAddTime = $input->getOption('add-time');
             if (empty($optionAddTime)) {
                 $optionAddTime = 'suffix';


### PR DESCRIPTION
Magerun pull-request check-list:

- [x] Pull request against develop branch (if not, just close and create a new one against it)
- [x] README.md reflects changes (if any)

Subject: Fix db:dump while using option "-t" instead of "--add-time"

Changes proposed in this pull request:

- Use `getOption` instead of `hasParameterOption ` so you can use the shortcut for 'add-time'

