### PR TITLE
Extra directory for plugins

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -6,6 +6,7 @@ twig:
 
 plugin:
   folders:
+    - /usr/share/n98-magerun2/modules
     - /usr/local/share/n98-magerun2/modules
 
 helpers:


### PR DESCRIPTION
Similiar to [n98-magerun issue](https://github.com/netz98/n98-magerun/issues/1016): it would be great if n98-magerun2 checks with /usr/share/n98-magerun2/modules directory for packaged plugins first.