### PR TITLE
Fix error status for executed commmands in a pipe

### DIFF
--- a/src/N98/Magento/Command/Database/DumpCommand.php
+++ b/src/N98/Magento/Command/Database/DumpCommand.php
@@ -350,14 +350,14 @@ HELP;
         $commandOutput = '';
 
         if ($input->getOption('stdout')) {
-            passthru($command, $returnValue);
+            passthru($command, $returnCode);
         } else {
-            Exec::run($command, $commandOutput, $returnValue);
+            Exec::run($command, $commandOutput, $returnCode);
         }
 
-        if ($returnValue > 0) {
+        if ($returnCode > 0) {
             $output->writeln('<error>' . $commandOutput . '</error>');
-            $output->writeln('<error>Return Code: ' . $returnValue . '. ABORTED.</error>');
+            $output->writeln('<error>Return Code: ' . $returnCode . '. ABORTED.</error>');
 
             return false;
         }

--- a/src/N98/Util/Exec.php
+++ b/src/N98/Util/Exec.php
@@ -22,6 +22,11 @@ class Exec
     const CODE_CLEAN_EXIT = 0;
 
     /**
+     * Every error in a pipe will be exited with an error code
+     */
+    const SET_O_PIPEFAIL = 'set -o pipefail; ';
+
+    /**
      * @param string $command
      * @param string|null $output
      * @param int $returnCode
@@ -33,14 +38,14 @@ class Exec
             throw new RuntimeException($message);
         }
 
-        $command .= self::REDIRECT_STDERR_TO_STDOUT;
+        $command = self::SET_O_PIPEFAIL . $command . self::REDIRECT_STDERR_TO_STDOUT;
 
         exec($command, $outputArray, $returnCode);
         $output = self::parseCommandOutput((array) $outputArray);
 
         if ($returnCode !== self::CODE_CLEAN_EXIT) {
             throw new RuntimeException(
-                sprintf('Exit status %d for command %s. Output was: %s', $returnCode, $command, $output)
+                sprintf("Exit status %d for command %s. Output was: %s", $returnCode, $command, $output)
             );
         }
     }


### PR DESCRIPTION
Pipe commands are not handled correct.
The db:dump command will always return "0" which means "correct" even if an error occurs.