### PR TITLE
Check if pipefail option exists

### DIFF
--- a/src/N98/Util/Exec.php
+++ b/src/N98/Util/Exec.php
@@ -38,7 +38,11 @@ class Exec
             throw new RuntimeException($message);
         }
 
-        $command = self::SET_O_PIPEFAIL . $command . self::REDIRECT_STDERR_TO_STDOUT;
+        if (OperatingSystem::isBashCompatibleShell()) {
+            $command = self::SET_O_PIPEFAIL . $command;
+        }
+
+        $command .= self::REDIRECT_STDERR_TO_STDOUT;
 
         exec($command, $outputArray, $returnCode);
         $output = self::parseCommandOutput((array) $outputArray);
@@ -70,4 +74,6 @@ class Exec
     {
         return implode(PHP_EOL, $commandOutput) . PHP_EOL;
     }
+
+
 }

--- a/src/N98/Util/Exec.php
+++ b/src/N98/Util/Exec.php
@@ -38,7 +38,7 @@ class Exec
             throw new RuntimeException($message);
         }
 
-        if (OperatingSystem::isBashCompatibleShell()) {
+        if (OperatingSystem::isBashCompatibleShell() && self::isPipefailOptionAvailable()) {
             $command = self::SET_O_PIPEFAIL . $command;
         }
 
@@ -75,5 +75,13 @@ class Exec
         return implode(PHP_EOL, $commandOutput) . PHP_EOL;
     }
 
+    /**
+     * @return bool
+     */
+    private static function isPipefailOptionAvailable()
+    {
+        exec('set -o | grep pipefail 2>&1', $output, $returnCode);
 
+        return $returnCode == self::CODE_CLEAN_EXIT;
+    }
 }

--- a/src/N98/Util/OperatingSystem.php
+++ b/src/N98/Util/OperatingSystem.php
@@ -163,4 +163,15 @@ class OperatingSystem
 
         return self::getPhpBinary();
     }
+
+    /**
+     * @return bool
+     */
+    public static function isBashCompatibleShell()
+    {
+        return in_array(
+            basename(getenv('SHELL')),
+            ['bash', 'zsh']
+        );
+    }
 }


### PR DESCRIPTION
If current shell does not support pipefail option, all exec calls are broken.