### PR TITLE
Add "suggest" to use the phar distribution

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,6 +43,9 @@
         "phpunit/phpunit": "~6.2.0",
         "seld/phar-utils": "~1.0.1"
     },
+    "suggest": {
+         "n98/magerun2-dist": "Deploys only the phar file. Use this to prevent dependency conflicts."
+    }, 
     "autoload": {
         "psr-0": {
             "N98": "src"


### PR DESCRIPTION
Adds a suggest entry in composer.json which provides a hint to use the phar dist package.