### PR TITLE
Track changed admin passwords

### DIFF
--- a/src/N98/Magento/Command/Admin/User/AbstractAdminUserCommand.php
+++ b/src/N98/Magento/Command/Admin/User/AbstractAdminUserCommand.php
@@ -12,11 +12,19 @@ abstract class AbstractAdminUserCommand extends AbstractMagentoCommand
     protected $userModel;
 
     /**
-     * @param \Magento\User\Model\User $userModel
+     * @var \Magento\User\Model\ResourceModel\User
+     */
+    protected $userResource;
+
+    /**
+     * @param \Magento\User\Model\User               $userModel
+     * @param \Magento\User\Model\ResourceModel\User $userResource
      */
     public function inject(
-        \Magento\User\Model\User $userModel
+        \Magento\User\Model\User $userModel,
+        \Magento\User\Model\ResourceModel\User $userResource
     ) {
         $this->userModel = $userModel;
+        $this->userResource = $userResource;
     }
 }

--- a/src/N98/Magento/Command/Admin/User/ChangePasswordCommand.php
+++ b/src/N98/Magento/Command/Admin/User/ChangePasswordCommand.php
@@ -62,7 +62,8 @@ class ChangePasswordCommand extends AbstractAdminUserCommand
             }
             $user->setPassword($password);
             $user->setForceNewPassword(true);
-            $user->save();
+            $this->userResource->save($user);
+            $this->userResource->trackPassword($user, $user->getPassword());
             $output->writeln('<info>Password successfully changed</info>');
         } catch (Exception $e) {
             $output->writeln('<error>' . $e->getMessage() . '</error>');


### PR DESCRIPTION
Fix for issue #293

Call the track method after a password change. Normally a changed password will automatically tracked by an observer in adminhtml area.

This will not clear the session for a already authenticated user. A user need to logout and login again after a successful password change.
