### PR TITLE
Fix composer package naming

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,10 +38,10 @@
         "ext-xdebug": "*",
         "bamarni/symfony-console-autocomplete": "^1.2.0",
         "friendsofphp/php-cs-fixer": "~1.12.0",
-        "mikey179/vfsStream": "~1.4",
         "phing/phing": "~2.10.0",
         "phpunit/phpunit": "~6.2.0",
-        "seld/phar-utils": "~1.0.1"
+        "seld/phar-utils": "~1.0.1",
+        "mikey179/vfsstream": "^1.6"
     },
     "suggest": {
          "n98/magerun2-dist": "Deploys only the phar file. Use this to prevent dependency conflicts."

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3921f43e94c19f9d69688cb73d825768",
+    "content-hash": "1a1b88402ce439763321b59aec97d6c8",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -1865,24 +1865,24 @@
             "time": "2016-11-15T09:10:47+00:00"
         },
         {
-            "name": "mikey179/vfsStream",
-            "version": "v1.6.5",
+            "name": "mikey179/vfsstream",
+            "version": "v1.6.8",
             "source": {
                 "type": "git",
-                "url": "https://github.com/mikey179/vfsStream.git",
-                "reference": "d5fec95f541d4d71c4823bb5e30cf9b9e5b96145"
+                "url": "https://github.com/bovigo/vfsStream.git",
+                "reference": "231c73783ebb7dd9ec77916c10037eff5a2b6efe"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mikey179/vfsStream/zipball/d5fec95f541d4d71c4823bb5e30cf9b9e5b96145",
-                "reference": "d5fec95f541d4d71c4823bb5e30cf9b9e5b96145",
+                "url": "https://api.github.com/repos/bovigo/vfsStream/zipball/231c73783ebb7dd9ec77916c10037eff5a2b6efe",
+                "reference": "231c73783ebb7dd9ec77916c10037eff5a2b6efe",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.5"
+                "phpunit/phpunit": "^4.5|^5.0"
             },
             "type": "library",
             "extra": {
@@ -1908,7 +1908,7 @@
             ],
             "description": "Virtual file system to mock the real file system in unit tests.",
             "homepage": "http://vfs.bovigo.org/",
-            "time": "2017-08-01T08:02:14+00:00"
+            "time": "2019-10-30T15:31:00+00:00"
         },
         {
             "name": "myclabs/deep-copy",


### PR DESCRIPTION
Packages with uppercase characters are invalid for Composer 2.0

Magerun pull-request check-list:

- [X] Pull request against develop branch (if not, just close and create a new one against it)

Fixes: Invalid composer.json