### PR TITLE
Strip B2B quotes as part of @quotes alias

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -177,7 +177,7 @@ commands:
 
       - id: quotes
         description: Cart (quote) data
-        tables: quote quote_*
+        tables: negotiable_quote negotiable_quote_* quote quote_*
 
       - id: customers
         description: Customer data - Should not be used without @sales
@@ -248,7 +248,7 @@ commands:
           *_aggregated_monthly
           *_aggregated_yearly
           *_aggregated_order
-      
+
       - id: replica
         description: Replica tables
         tables: "*_replica"

--- a/readme.rst
+++ b/readme.rst
@@ -575,7 +575,7 @@ Available Table Groups:
 * @ee_changelog Changelog tables of new indexer since EE 1.13
 * @idx Tables with _idx suffix and index event tables
 * @log Log tables
-* @quotes Cart (quote) data
+* @quotes Cart (quote) data and B2B quotes
 * @sales Sales data (orders, invoices, creditmemos etc)
 * @search Search related tables (catalogsearch_)
 * @sessions Database session tables


### PR DESCRIPTION
Changes proposed in this pull request:
- Also strip `negotiable_quote` and associated tables as part of `@quotes` alias. These come from the B2B module and should not be included in development databases.