### PR TITLE
Enable tests with PHP 7.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,12 @@ matrix:
   fast_finish: true
   include:
     # Lint PHP code with future PHP versions (forward compatibility)
+    - name: PHP 7.3 Lint
+      php: 7.3
+      env: SCRIPT_JOB=LINTSH
+      script: find {src,tests} -name "*.php" ! -path '*/String.php' -print0 | xargs
+        -0 -n1 -P8 php -l | grep -v '^No syntax errors detected'; test $? -eq 1
+
     - name: PHP 7.2 Lint
       php: 7.2
       env: SCRIPT_JOB=LINTSH
@@ -36,17 +42,14 @@ matrix:
       script: find {src,tests} -name "*.php" ! -path '*/String.php' -print0 | xargs
         -0 -n1 -P8 php -l | grep -v '^No syntax errors detected'; test $? -eq 1
 
-    - name: SH Lint
-      php: 7.2
-      env: SCRIPT_JOB=LINTSH
-      script: find {src,tests} -name "*.php" ! -path '*/String.php' -print0 | xargs
-        -0 -n1 -P8 php -l | grep -v '^No syntax errors detected'; test $? -eq 1
-
     # Magento Versions
+    - name: Magento 2.3.3 PHP 7.3
+      php: 7.3
+      env: MAGENTO_VERSION="magento-ce-2.3.3" INSTALL_SAMPLE_DATA=0 PHPUNIT_EXCLUDE_GROUPS=exclude-2.2
 
-    - name: Magento 2.3.2 PHP 7.2
+    - name: Magento 2.3.3 PHP 7.2
       php: 7.2
-      env: MAGENTO_VERSION="magento-ce-2.3.2" INSTALL_SAMPLE_DATA=0 PHPUNIT_EXCLUDE_GROUPS=exclude-2.2
+      env: MAGENTO_VERSION="magento-ce-2.3.3" INSTALL_SAMPLE_DATA=0 PHPUNIT_EXCLUDE_GROUPS=exclude-2.2
 
     - name: Magento 2.2.8 PHP 7.1
       php: 7.1


### PR DESCRIPTION
Magerun pull-request check-list:

- [X] Pull request against develop branch (if not, just close and create a new one against it)

Changes proposed in this pull request:

- Enable PHP 7.3 for latest Magento 2.3.3 version. Run tests against Magento 2.3.3
