### PR TITLE
Fix #516 4.0.0: Fatal error when /etc/n98-magerun2.yaml exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ RECENT CHANGES
 -----
 
 - Fix: Wrong integration:command description
+- Fix: #517: Fatal error when /etc/n98-magerun2.yaml exists
 
 4.0.0
 -----

--- a/src/N98/Magento/Application/ConfigurationLoader.php
+++ b/src/N98/Magento/Application/ConfigurationLoader.php
@@ -184,7 +184,7 @@ class ConfigurationLoader
 
             if ($systemWideConfigFile && file_exists($systemWideConfigFile)) {
                 $this->logDebug('Load system config <comment>' . $systemWideConfigFile . '</comment>');
-                $this->systemConfig = Yaml::parse($systemWideConfigFile);
+                $this->systemConfig = (array) Yaml::parse(\file_get_contents($systemWideConfigFile));
             } else {
                 $this->systemConfig = [];
             }


### PR DESCRIPTION
Magerun pull-request check-list:

- [X] Pull request against develop branch
- [X] README.md reflects changes

Fixes #516

Changes proposed in this pull request:

- Load config file instead of passing file name to Yaml::parse method. This was possible in old Symfony library version.