### PR TITLE
If the discovered home directory does not exist - don't try and use it

### DIFF
--- a/src/N98/Magento/Application/ConfigLocator.php
+++ b/src/N98/Magento/Application/ConfigLocator.php
@@ -9,7 +9,6 @@ namespace N98\Magento\Application;
 
 use InvalidArgumentException;
 use N98\Util\OperatingSystem;
-use RuntimeException;
 
 /**
  * Class ConfigLocator

--- a/src/N98/Magento/Application/ConfigLocator.php
+++ b/src/N98/Magento/Application/ConfigLocator.php
@@ -131,7 +131,7 @@ class ConfigLocator
         }
 
         if (!is_dir($homeDirectory)) {
-            throw new RuntimeException(sprintf("Home-directory '%s' is not a directory.", $homeDirectory));
+            return $paths;
         }
 
         $basename = $this->customConfigFilename;


### PR DESCRIPTION
For discussion / inclusion.

Subject: A home directory that doesn't exist isn't a fatal error

Changes proposed in this pull request:

- Currently, if $HOME points somewhere that isn't a directory, Magerun throws a RunTime exception.
This would make sense if it relied on information coming from the home directory was required, but it's very much optional.

Rather than die, just act as if nothing was set.

Unsure as to the exact intent of the exception, so this is a request for feedback as much as a proposal for change.