### PR TITLE
Add scripts location

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -19,6 +19,7 @@ helpers:
 
 script:
   folders:
+    - /usr/share/n98-magerun2/scripts
     - /usr/local/share/n98-magerun2/scripts
 
 init:


### PR DESCRIPTION
Added `/usr/share/n98-magerun2/scripts` location.

This helps to facilitate packaged (e.g. RPM) scripts installed to `/usr/share/n98-magerun2/scripts`. 