### PR TITLE
Add option --skip-magento-compatibility-check

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,11 +168,13 @@ $ php n98-magerun2.phar list
 
 Global config parameters:
 
-| Parameter           | Description                                |
-| --------------------| -------------------------------------------|
-| `--root-dir`        | Force Magento root dir. No auto detection. |
-| `--skip-config`     | Do not load any custom config.             |
-| `--skip-root-check` | Do not check if n98-magerun2 runs as root. |
+| Parameter                      | Description                                 |
+| -------------------------------| --------------------------------------------|
+| `--root-dir`                   | Force Magento root dir. No auto detection.  |
+| `--skip-config`                | Do not load any custom config.              |
+| `--skip-root-check`            | Do not check if n98-magerun2 runs as root.  |
+| `--skip-core-commands`         | Do not include Magento commands.            |
+| `--skip-magento-compatibility` | Do not check Magento version compatibility. |
 
 ### Open Shop in Browser
 

--- a/src/N98/Magento/Application.php
+++ b/src/N98/Magento/Application.php
@@ -687,6 +687,17 @@ class Application extends BaseApplication
         );
         $inputDefinition->addOption($skipMagento2CoreCommands);
 
+        /**
+         * Skip Magento compatibility check
+         */
+        $skipMagentoCompatibilityCheck = new InputOption(
+            '--skip-magento-compatibility-check',
+            '',
+            InputOption::VALUE_NONE,
+            'Do not check for Magento version compatibility'
+        );
+        $inputDefinition->addOption($skipMagentoCompatibilityCheck);
+
         return $inputDefinition;
     }
 

--- a/src/N98/Magento/Application/Console/EventSubscriber/CheckCompatibility.php
+++ b/src/N98/Magento/Application/Console/EventSubscriber/CheckCompatibility.php
@@ -42,6 +42,10 @@ class CheckCompatibility implements EventSubscriberInterface, ApplicationAwareIn
      */
     public function checkCompatibility(ConsoleEvent $event)
     {
+        if ($event->getInput()->hasParameterOption('--skip-magento-compatibility-check')) {
+            return;
+        }
+
         try {
             $this->application->initMagento(true);
             $objectManager = $this->application->getObjectManager();


### PR DESCRIPTION
Magerun pull-request check-list:

- [x] Pull request against develop branch (if not, just close and create a new one against it)
- [x] README.md reflects changes (if any)

Subject: Add possibility to skip checking compatibility with the Magento version

Changes proposed in this pull request:

- Add option `skip-magento-compatibility` to default input definition
- Check for that option in the CheckCompatibility EventSubscriber (I had to use raw method `hasParameterOption` instead of `hasOption`, because the input has not been parsed at that point.)
