### PR TITLE
When mysqldump fails, make db:dump fail as well

### DIFF
--- a/src/N98/Magento/Command/Database/DumpCommand.php
+++ b/src/N98/Magento/Command/Database/DumpCommand.php
@@ -250,7 +250,9 @@ HELP;
 
         $execs = $this->createExecs($input, $output);
 
-        $this->runExecs($execs, $input, $output);
+        $success = $this->runExecs($execs, $input, $output);
+
+        return $success ? 0 : 1;
     }
 
     /**
@@ -312,6 +314,7 @@ HELP;
      * @param Execs $execs
      * @param InputInterface $input
      * @param OutputInterface $output
+     * @return bool
      */
     private function runExecs(Execs $execs, InputInterface $input, OutputInterface $output)
     {
@@ -331,7 +334,7 @@ HELP;
 
             foreach ($commands as $command) {
                 if (!$this->runExec($command, $input, $output)) {
-                    return;
+                    return false;
                 }
             }
 
@@ -343,6 +346,8 @@ HELP;
         if ($input->getOption('print-only-filename')) {
             $output->writeln($execs->getFileName());
         }
+
+        return true;
     }
 
     /**


### PR DESCRIPTION
Magerun pull-request check-list:

- [x] Pull request against develop branch (if not, just close and create a new one against it)
- [ ] README.md reflects changes (if any)

Subject: When mysqldump fails, make db:dump fail as well

Changes proposed in this pull request:

As of late, we've been seeing occasional errors like this in the mysqldump command on some specific environments:
```
mysqldump: Error 1412: Table definition has changed, please retry transaction when dumping table `catalogrule_group_website` at row: 0
```

When we perform a `db:dump` command using n98/magerun2 however, it doesn't detect this error and just returns status code 0 which makes it hard for our scripts to detect a failure happened or not.

It looks like support for return codes was already partly added in https://github.com/netz98/n98-magerun2/pull/467 which seems to be the same changes as done in magerun 1: https://github.com/netz98/n98-magerun/pull/1030 but not all code from the PR was taken over for some reason.

We still need to return 0 or 1 in the `execute` method to make the `db:dump` command return the correct status code, and that's what this PR is adding.
