### PR TITLE
Strip all dotmailer tables

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -241,15 +241,19 @@ commands:
       - id: dotmailer
         description: Dotmailer tables
         tables: >
-          email_abandoned_cart
+          email_abandoned_cart        
           email_automation
           email_campaign
           email_catalog
           email_contact
-          email_import
+          email_contact_consent
+          email_coupon_attribute
+          email_failed_auth
+          email_importer
           email_rules
           email_order
           email_review
+          email_template
           email_wishlist
 
       - id: 2fa

--- a/config.yaml
+++ b/config.yaml
@@ -240,7 +240,17 @@ commands:
 
       - id: dotmailer
         description: Dotmailer tables
-        tables: email_abandoned_cart email_automation email_campaign email_contact
+        tables: >
+          email_abandoned_cart
+          email_automation
+          email_campaign
+          email_catalog
+          email_contact
+          email_import
+          email_rules
+          email_order
+          email_review
+          email_wishlist
 
       - id: 2fa
         description: Two Factor Auth tables


### PR DESCRIPTION
Mainly the email_importer was a concern, which can be massive (and contains customer data). 
But also the other tables you do not want to have filled with data when getting a `@development` dump

Magerun pull-request check-list:

- [x] Pull request against develop branch (if not, just close and create a new one against it)
- [x] README.md reflects changes (if any)

Subject: (50 characters or less)

Fixes # .

Changes proposed in this pull request:

- add all dotmailer tables to the dotmailer group

