### PR TITLE
Add check to determine whether column statistics flag is needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -584,6 +584,7 @@ Dumps configured Magento database with `mysqldump`.
 | `--strip`                 | Tables to strip (dump only structure of those tables)                                 |
 | `--exclude`               | Tables to exclude entirely from the dump (including structure)                        |
 | `--force` `-f`            | Do not prompt if all options are defined                                              |
+| `--keep-column-statistics`| Retains `column statistics` table in `mysqldump`                                      |
 
 ```sh
 $ n98-magerun2.phar db:dump


### PR DESCRIPTION
Magerun pull-request check-list:

- [x] Pull request against develop branch (if not, just close and create a new one against it)
- [x] README.md reflects changes (if any)

Subject: Checks if current MySQL installation has 'column statistics' present and adds a flag to prevent error.

Fixes #571

Changes proposed in this pull request:

- Perform a grep for the term 'column-statistics' on the `mysqldump --help` command output to determine if flag is needed

- Allows user to add an option to `db:dump` command to retain column statistics in the dump if desired

- If no such option is provided, column statistics is disabled to prevent error
