### PR TITLE
add option to dump db with —no-tablespaces option

### DIFF
--- a/README.md
+++ b/README.md
@@ -586,6 +586,7 @@ Dumps configured Magento database with `mysqldump`.
 | `--human-readable`        | Use a single insert with column names per row.                                        |
 | `--git-friendly`          | Use one insert statement, but with line breaks instead of separate insert statements. |
 | `--add-routines`          | Include stored routines in dump (procedures & functions).                             |
+| `--no-tablespaces`        | Use this option if you want to create a dump without having the PROCESS privilege.    |
 | `--stdout`                | Dump to stdout                                                                        |
 | `--strip`                 | Tables to strip (dump only structure of those tables)                                 |
 | `--exclude`               | Tables to exclude entirely from the dump (including structure)                        |

--- a/src/N98/Magento/Command/Database/DumpCommand.php
+++ b/src/N98/Magento/Command/Database/DumpCommand.php
@@ -95,6 +95,12 @@ class DumpCommand extends AbstractDatabaseCommand
                 'Include stored routines in dump (procedures & functions)'
             )
             ->addOption(
+                'no-tablespaces',
+                null,
+                InputOption::VALUE_NONE,
+                'Use this option if you want to create a dump without having the PROCESS privilege'
+            )
+            ->addOption(
                 'stdout',
                 null,
                 InputOption::VALUE_NONE,
@@ -283,6 +289,10 @@ HELP;
 
         if ($input->getOption('add-routines')) {
             $execs->addOptions('--routines ');
+        }
+
+        if ($input->getOption('no-tablespaces')) {
+            $execs->addOptions('--no-tablespaces ');
         }
 
         if ($this->checkColumnStatistics()) {


### PR DESCRIPTION
Magerun pull-request check-list:

- [x] Pull request against develop branch (if not, just close and create a new one against it)
- [x] README.md reflects changes (if any)

Changes proposed in this pull request:

- With the release of MySQL 5.7.31 it is necessary to add the --no-tablespace option to the mysqldump command if you want to create a dump without the PROCESS privilege (https://dev.mysql.com/doc/relnotes/mysql/5.7/en/news-5-7-31.html#mysqld-5-7-31-security)
