### PR TITLE
Correct list of 'dotmailer' tables

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -250,10 +250,9 @@ commands:
           email_coupon_attribute
           email_failed_auth
           email_importer
-          email_rules
           email_order
           email_review
-          email_template
+          email_rules
           email_wishlist
 
       - id: 2fa


### PR DESCRIPTION
A full list of dotmailer tables is available here: https://github.com/dotmailer/dotmailer-magento2-extension/blob/HEAD/Setup/SchemaInterface.php

`email_template` is core Magento and should not be stripped. Ref: https://github.com/magento/magento2/blob/HEAD/app/code/Magento/Email/etc/db_schema.xml#L10

Fixes a bug introduced in #568 (released as version 4.2.0).

Changes proposed in this pull request:
- Remove `email_template` from list of tables to be stripped as part of `@dotmailer`