### PR TITLE
Add set-gtid-purged-off to db:dump

### DIFF
--- a/src/N98/Magento/Command/Database/DumpCommand.php
+++ b/src/N98/Magento/Command/Database/DumpCommand.php
@@ -70,6 +70,12 @@ class DumpCommand extends AbstractDatabaseCommand
                 'Do everything but the actual dump'
             )
             ->addOption(
+                'set-gtid-purged-off',
+                null,
+                InputOption::VALUE_NONE,
+                'add --set-gtid-purged=OFF'
+            )
+            ->addOption(
                 'no-single-transaction',
                 null,
                 InputOption::VALUE_NONE,
@@ -285,6 +291,10 @@ HELP;
 
         if ($input->getOption('human-readable')) {
             $execs->addOptions('--complete-insert --skip-extended-insert ');
+        }
+
+        if ($input->getOption('set-gtid-purged-off')) {
+            $execs->addOptions('--set-gtid-purged=OFF ');
         }
 
         if ($input->getOption('add-routines')) {


### PR DESCRIPTION
Magerun pull-request check-list:
- [ ] Pull request against develop branch (if not, just close and create a new one against it)
- [ ] README.md reflects changes (if any)

I am not sure how relevant this is here or whether it would be preferable to manage it in the `my.cnf` (or equivalent) like so

```
[mysqld]
set-gtid-purged=OFF
```

Either way, we had our database dumps from prod break all of a sudden when something in the cloud side updated and started adding `SET @@GLOBAL.GTID_PURGED='';` to our dumps which broke importing them locally and on other test systems.

Even if this PR is rejected maybe it will help anyone else using magerun who searches for this issue find a solution.
