### PR TITLE
Fix PSR-12-violation in the registration.php file generated by dev:module:create

### DIFF
--- a/res/twig/dev/module/create/app/code/module/registration.php.twig
+++ b/res/twig/dev/module/create/app/code/module/registration.php.twig
@@ -1,6 +1,6 @@
 <?php
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(
     ComponentRegistrar::MODULE,


### PR DESCRIPTION
Magerun pull-request check-list:

- [x] Pull request against develop branch (if not, just close and create a new one against it)
- [x] README.md reflects changes (if any)

Subject: fix PSR-12 violation in the `registration.php`generated by `dev:module:create`

phpcs reports the following PSR-12 violation as follows:

```
$ phpcs --standard=PSR12 app/code/Foo/Bar                                                                                                                       

FILE: /path/to/magento/app/code/Foo/Bar/registration.php
---------------------------------------------------------------------------------------------------
FOUND 1 ERROR AFFECTING 1 LINE
---------------------------------------------------------------------------------------------------
 3 | ERROR | [x] Import statements must not begin with a leading backslash
---------------------------------------------------------------------------------------------------
PHPCBF CAN FIX THE 1 MARKED SNIFF VIOLATIONS AUTOMATICALLY
---------------------------------------------------------------------------------------------------
```
