### PR TITLE
Fix order of import statements in the Setup classes generated by dev:module:create

### DIFF
--- a/res/twig/dev/module/create/app/code/module/Setup/UpgradeData.php.twig
+++ b/res/twig/dev/module/create/app/code/module/Setup/UpgradeData.php.twig
@@ -2,9 +2,9 @@
 
 namespace {{ vendorNamespace }}\{{ moduleName }}\Setup;
 
-use Magento\Framework\Setup\UpgradeDataInterface;
 use Magento\Framework\Setup\ModuleContextInterface;
 use Magento\Framework\Setup\ModuleDataSetupInterface;
+use Magento\Framework\Setup\UpgradeDataInterface;
 
 /**
  * {@inheritdoc}

--- a/res/twig/dev/module/create/app/code/module/Setup/UpgradeSchema.php.twig
+++ b/res/twig/dev/module/create/app/code/module/Setup/UpgradeSchema.php.twig
@@ -2,9 +2,9 @@
 
 namespace {{ vendorNamespace }}\{{ moduleName }}\Setup;
 
-use Magento\Framework\Setup\UpgradeSchemaInterface;
 use Magento\Framework\Setup\ModuleContextInterface;
 use Magento\Framework\Setup\SchemaSetupInterface;
+use Magento\Framework\Setup\UpgradeSchemaInterface;
 
 /**
  * {@inheritdoc}


### PR DESCRIPTION
Magerun pull-request check-list:

- [x] Pull request against develop branch (if not, just close and create a new one against it)
- [x] README.md reflects changes (if any)

Subject: fix order of import statements in the `Setup` classes generated by `dev:module:create`.

This resolves the following issues:
* Running [Optimize Imports in PhpStorm](https://www.jetbrains.com/help/phpstorm/creating-and-optimizing-imports.html#optimize-imports) resulted in changes to the file (because the imports were ordered alfabetically).
* Running Php_CodeSniffer with the [`SlevomatCodingStandard.Namespaces.AlphabeticallySortedUses` sniff](https://github.com/slevomat/coding-standard#slevomatcodingstandardnamespacesalphabeticallysorteduses-) gave an error on the files in this PR.