### PR TITLE
Add --add-strict-types option to dev:module:create command

### DIFF
--- a/res/autocompletion/bash/n98-magerun2.phar.bash
+++ b/res/autocompletion/bash/n98-magerun2.phar.bash
@@ -177,7 +177,7 @@ _n98-magerun2()
             opts="${opts} "
             ;;
             dev:module:create)
-            opts="${opts} --minimal --add-blocks --add-helpers --add-models --add-setup --add-all --enable --modman --add-readme --add-composer --author-name --author-email --description"
+            opts="${opts} --minimal --add-blocks --add-helpers --add-models --add-setup --add-all --enable --modman --add-readme --add-composer --add-strict-types --author-name --author-email --description"
             ;;
             dev:module:list)
             opts="${opts} --vendor --format"

--- a/res/twig/dev/module/create/app/code/module/Setup/InstallData.php.twig
+++ b/res/twig/dev/module/create/app/code/module/Setup/InstallData.php.twig
@@ -1,5 +1,9 @@
 <?php
 
+{%  if addStrictTypes %}
+declare(strict_types=1);
+
+{%  endif %}
 namespace {{ vendorNamespace }}\{{ moduleName }}\Setup;
 
 use Magento\Framework\Setup\InstallDataInterface;

--- a/res/twig/dev/module/create/app/code/module/Setup/InstallSchema.php.twig
+++ b/res/twig/dev/module/create/app/code/module/Setup/InstallSchema.php.twig
@@ -1,5 +1,9 @@
 <?php
 
+{%  if addStrictTypes %}
+declare(strict_types=1);
+
+{%  endif %}
 namespace {{ vendorNamespace }}\{{ moduleName }}\Setup;
 
 use Magento\Framework\Setup\InstallSchemaInterface;

--- a/res/twig/dev/module/create/app/code/module/Setup/UpgradeData.php.twig
+++ b/res/twig/dev/module/create/app/code/module/Setup/UpgradeData.php.twig
@@ -1,5 +1,9 @@
 <?php
 
+{%  if addStrictTypes %}
+declare(strict_types=1);
+
+{%  endif %}
 namespace {{ vendorNamespace }}\{{ moduleName }}\Setup;
 
 use Magento\Framework\Setup\ModuleContextInterface;

--- a/res/twig/dev/module/create/app/code/module/Setup/UpgradeSchema.php.twig
+++ b/res/twig/dev/module/create/app/code/module/Setup/UpgradeSchema.php.twig
@@ -1,5 +1,9 @@
 <?php
 
+{%  if addStrictTypes %}
+declare(strict_types=1);
+
+{%  endif %}
 namespace {{ vendorNamespace }}\{{ moduleName }}\Setup;
 
 use Magento\Framework\Setup\ModuleContextInterface;

--- a/res/twig/dev/module/create/app/code/module/registration.php.twig
+++ b/res/twig/dev/module/create/app/code/module/registration.php.twig
@@ -1,5 +1,9 @@
 <?php
 
+{%  if addStrictTypes %}
+declare(strict_types=1);
+
+{%  endif %}
 use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(

--- a/src/N98/Magento/Command/Developer/Module/CreateCommand.php
+++ b/src/N98/Magento/Command/Developer/Module/CreateCommand.php
@@ -32,6 +32,7 @@ class CreateCommand extends AbstractMagentoCommand
             ->addOption('modman', null, InputOption::VALUE_NONE, 'Create all files in folder with a modman file.')
             ->addOption('add-readme', null, InputOption::VALUE_NONE, 'Adds a readme.md file to generated module')
             ->addOption('add-composer', null, InputOption::VALUE_NONE, 'Adds a composer.json file to generated module')
+            ->addOption('add-strict-types', null, InputOption::VALUE_NONE, 'Add strict_types declaration to generated PHP files')
             ->addOption('author-name', null, InputOption::VALUE_OPTIONAL, 'Author for readme.md or composer.json')
             ->addOption('author-email', null, InputOption::VALUE_OPTIONAL, 'Author for readme.md or composer.json')
             ->addOption('description', null, InputOption::VALUE_OPTIONAL, 'Description for readme.md or composer.json')
@@ -142,6 +143,7 @@ class CreateCommand extends AbstractMagentoCommand
             'authorName'      => $input->getOption('author-name'),
             'authorEmail'     => $input->getOption('author-email'),
             'description'     => $input->getOption('description'),
+            'addStrictTypes'  => $input->getOption('add-strict-types'),
         ]);
     }
 


### PR DESCRIPTION
Magerun pull-request check-list:

- [x] Pull request against develop branch (if not, just close and create a new one against it)
- [x] README.md reflects changes (if any)

Subject: Add `--add-strict-types` option to `dev:module:create` command

This adds the following line to all PHP files that are generated by the command:

```php
declare(strict_types=1);
```

This also makes sure the [SlevomatCodingStandard.TypeHints.DeclareStrictTypes sniff](https://github.com/slevomat/coding-standard#slevomatcodingstandardtypehintsdeclarestricttypes-) passes the test.