### PR TITLE
Add --force to db:import

### DIFF
--- a/src/N98/Magento/Command/Database/ImportCommand.php
+++ b/src/N98/Magento/Command/Database/ImportCommand.php
@@ -32,6 +32,7 @@ class ImportCommand extends AbstractDatabaseCommand
             )
             ->addOption('drop', null, InputOption::VALUE_NONE, 'Drop and recreate database before import')
             ->addOption('drop-tables', null, InputOption::VALUE_NONE, 'Drop tables before import')
+            ->addOption('force', null, InputOption::VALUE_NONE, 'Continue even if an SQL error occurs')
             ->setDescription('Imports database with mysql cli client according to database defined in env.php');
 
         $help = <<<HELP
@@ -121,9 +122,14 @@ HELP;
 
         $compressor = AbstractCompressor::create($input->getOption('compression'));
 
+        $exec = 'mysql ';
+        if ($input->getOption('force')) {
+            $exec = 'mysql --force ';
+        }
+
         // create import command
         $exec = $compressor->getDecompressingCommand(
-            'mysql ' . $dbHelper->getMysqlClientToolConnectionString(),
+            $exec . $dbHelper->getMysqlClientToolConnectionString(),
             $fileName
         );
         if ($input->getOption('only-command')) {


### PR DESCRIPTION
Add `--force` option to `db:import`

>Continue even if an SQL error occurs
>- https://dev.mysql.com/doc/refman/8.0/en/mysql-command-options.html#option_mysql_force

**Before**
```
$ n98-magerun2 db:import -cgzip ./prod.sql.gz

  Import MySQL Database

Importing SQL dump ./prod.sql.gz to database database_name
ERROR 1359 (HY000) at line 7146: Trigger already exists
gzip: error writing to output: Broken pipe

Finished
```

**After**
```
$ n98-magerun2 db:import --force -cgzip ./prod.sql.gz

  Import MySQL Database

Importing SQL dump ./baseprod.sql.gz to database database_name
ERROR 1359 (HY000) at line 7146: Trigger already exists
ERROR 1359 (HY000) at line 7164: Trigger already exists
Finished
```