### PR TITLE
When the mysql import fails, make db:import fail as well

### DIFF
--- a/src/N98/Magento/Command/Database/ImportCommand.php
+++ b/src/N98/Magento/Command/Database/ImportCommand.php
@@ -160,11 +160,13 @@ HELP;
             $dbHelper->dropTables($output);
         }
 
-        $this->doImport($output, $fileName, $exec);
+        $success = $this->doImport($output, $fileName, $exec);
 
         if ($input->getOption('optimize')) {
             unlink($fileName);
         }
+
+        return $success ? 0 : 1;
     }
 
     public function asText()
@@ -194,10 +196,12 @@ HELP;
      * @param string $fileName
      * @param string $exec
      *
-     * @return void
+     * @return bool
      */
-    protected function doImport(OutputInterface $output, $fileName, $exec)
+    protected function doImport(OutputInterface $output, $fileName, $exec): bool
     {
+        $success = true;
+
         $returnValue = null;
         $commandOutput = null;
         $output->writeln(
@@ -207,7 +211,10 @@ HELP;
         exec($exec, $commandOutput, $returnValue);
         if ($returnValue != 0) {
             $output->writeln('<error>' . implode(PHP_EOL, $commandOutput) . '</error>');
+            $success = false;
         }
         $output->writeln('<info>Finished</info>');
+
+        return $success;
     }
 }


### PR DESCRIPTION
Magerun pull-request check-list:

- [x] Pull request against develop branch (if not, just close and create a new one against it)
- [ ] README.md reflects changes (if any)

Subject: When the mysql import fails, make db:import fail as well

Changes proposed in this pull request:

When you try to import an sql file through `db:import` and the sql file has a syntax error or some other error, then the status code from `db:import` was `0` which indicates no errors were seen even though the error is being outputted. This is not correct and scripts using `db:import` won't see the failure and keep running as if everything went fine.
This PR changes this so it has status code `1` when an error occurs during `db:import`.

This is very similar to https://github.com/netz98/n98-magerun2/pull/551 but now for `db:import`

When the `--force` flag is used (introduced in https://github.com/netz98/n98-magerun2/pull/666) the status code remains `0` even when an error occurred. This is expected I believe.