### PR TITLE
db:dump does not support unix socket connection specified via "host" instead of "unix_socket"

### DIFF
--- a/src/N98/Util/Console/Helper/DatabaseHelper.php
+++ b/src/N98/Util/Console/Helper/DatabaseHelper.php
@@ -86,11 +86,11 @@ class DatabaseHelper extends AbstractHelper
         if (isset($config['db']['table_prefix'])) {
             $this->dbSettings['prefix'] = (string) $config['db']['table_prefix'];
         }
-
-        if (
-            isset($this->dbSettings['host'])
-            && strpos($this->dbSettings['host'], ':') !== false
-        ) {
+       
+        if (strpos($this->dbSettings['host'], '/') !== false) {
+            $this->dbSettings['unix_socket'] = $this->dbSettings['host'];
+            unset($this->dbSettings['host']);
+        } elseif (strpos($this->dbSettings['host'], ':') !== false) {
             list($this->dbSettings['host'], $this->dbSettings['port']) = explode(':', $this->dbSettings['host']);
         }
 


### PR DESCRIPTION
Magerun pull-request check-list:

- [x] Pull request against develop branch (if not, just close and create a new one against it)
- [x] README.md reflects changes (if any) *N/A?*

Subject: db:dump does not support unix socket connection

Changes proposed in this pull request:

The db:dump command is using getMysqlClientToolConnectionString which supports unix socket connections, but unfortunately the detectDbSettings is not detecting it in the same way as getConnection. This normalises so that it works correctly in the same way Magento does too.

Code in getConnection that already performs exactly what this PR changes the getMysqlClientToolConnectionString to perform:
https://github.com/netz98/n98-magerun2/blob/23d927e4c54cee2b41a07487d0a17184696c0be6/src/N98/Util/Console/Helper/DatabaseHelper.php#L129-L134

Currently with host set to a socket path, magerun works fine, so does Magento, but magerun db:dump completely fails due to a mysqldump command line with `-h/path/to/socket` which is not correct.

The isset is removed because there are no isset anywhere else further in the code path, so it is assumed already to exist. For example in getConnection there is no isset and in fact if host is not set, the getMysqlClientToolConnectionString still tries to access it without an isset.