### PR TITLE
Strip inventory_reservation in @sales group

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -185,6 +185,7 @@ commands:
             sales_creditmemo_*
           sales_recurring_* sales_refunded_* sales_payment_*
           enterprise_sales_* enterprise_customer_sales_* sales_bestsellers_* magento_customercustomattributes_sales_flat_*
+          inventory_reservation
           paypal_billing_agreement*
           paypal_payment_transaction
           paypal_settlement_report*


### PR DESCRIPTION
Magerun pull-request check-list:
- [x] Pull request against develop branch (if not, just close and create a new one against it)
- [x] README.md reflects changes (if any)

Subject: Add `inventory_reservation` table to `@sales` group

Changes proposed in this pull request:
The `inventory_reservation` table (from [`magento/module-inventory-reservations`](https://github.com/magento/inventory/blob/1.2.2/InventoryReservations/etc/db_schema.xml#L10)) contains entries that relate to orders (`order_placed`, `shipment_created`, `creditmemo_created`, `order_canceled`, etc). When the order tables are stripped, it makes sense to strip these inventory reservation entries also. If these are not stripped, stock information isn't reliable.