### PR TITLE
Add ui_bookmark to admin group

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -144,7 +144,7 @@ commands:
     table-groups:
       - id: admin
         description: Admin tables
-        tables: admin* magento_logging_event magento_logging_event_changes
+        tables: admin* magento_logging_event magento_logging_event_changes ui_bookmark
 
       - id: oauth
         description: OAuth tables


### PR DESCRIPTION
Magerun pull-request check-list:

- [x] Pull request against develop branch (if not, just close and create a new one against it)
- [ ] README.md reflects changes (if any)

Subject: Add ui_bookmark to admin table group

`ui_bookmark` keeps track of admin sorting and  states of grids - an easy inclusion into `@admin`. See: https://www.pixiemedia.co.uk/blog/magento2-ui-component-bookmarks.html