### PR TITLE
Add table authorization_role to table group @admin

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -144,7 +144,7 @@ commands:
     table-groups:
       - id: admin
         description: Admin tables
-        tables: admin* magento_logging_event magento_logging_event_changes ui_bookmark
+        tables: admin* authorization_role magento_logging_event magento_logging_event_changes ui_bookmark
 
       - id: oauth
         description: OAuth tables


### PR DESCRIPTION
Magerun pull-request check-list:

- [x] Pull request against develop branch (if not, just close and create a new one against it)
- [x] README.md reflects changes (if any)

Subject: Add table authorization_role to table group @admin

Fixes # .

Changes proposed in this pull request:

- Add table authorization_role to table group @admin. This is needed since that table is directly depending on table admin_user. The README.md states already that the admin roles are included in this group but without the table authorization_role it wouldn't be true. The table authorization_role contains references to admin_user. E.g. by excluding one admin_user when making an database dump we also need to exclude the other table - otherwise there will be broken references
