### PR TITLE
Fix issue with empty cron expressions

### DIFF
--- a/src/N98/Magento/Command/System/Cron/AbstractCronCommand.php
+++ b/src/N98/Magento/Command/System/Cron/AbstractCronCommand.php
@@ -143,7 +143,11 @@ abstract class AbstractCronCommand extends AbstractMagentoCommand
         if (isset($jobConfig['schedule'])) {
             $expr = $this->getCronExpression($jobConfig);
 
-            if ($expr == 'always') {
+            if (empty($expr)) {
+                return ['m' => '-', 'h' => '-', 'D' => '-', 'M' => '-', 'WD' => '-'];
+            }
+
+            if ($expr === 'always') {
                 return ['m' => '*', 'h' => '*', 'D' => '*', 'M' => '*', 'WD' => '*'];
             }
 


### PR DESCRIPTION
If a cron expression has an empty/null value in the store_config_data table then we get an error if we run `sys:cron:run` command.

Fixes: #781 
