### PR TITLE
Do not use n98-magerun2 Composer classes in original Magento autoloader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ RECENT CHANGES
 - Imp: Add handling for missing authorization rule/role in db:import (by Christian Münch, Alexander Menk)
 - Add: Add table authorization_role to table group @admin (by hannes011)
 - Fix: #781 - empty cron expression (by Christian Münch)
+- Fix: #789 - sampledata:deploy returns composer error, bin/magento works
 
 4.6.1
 -----

--- a/src/N98/Magento/Application/AutoloaderDecorator.php
+++ b/src/N98/Magento/Application/AutoloaderDecorator.php
@@ -23,7 +23,9 @@ class AutoloaderDecorator implements AutoloaderInterface
     private $magentoAutoloader;
 
     /**
-     * TestAutoloader constructor.
+     * AutoloaderDecorator constructor.
+     *
+     * @param \Magento\Framework\Autoload\AutoloaderInterface $magentoAutoloader
      * @param \Composer\Autoload\ClassLoader $n98MagerunAutoloader
      */
     public function __construct(AutoloaderInterface $magentoAutoloader, ClassLoader $n98MagerunAutoloader)
@@ -135,6 +137,17 @@ class AutoloaderDecorator implements AutoloaderInterface
     private function mirrorPsr4Pathes(ClassLoader $n98MagerunAutoloader)
     {
         foreach ($n98MagerunAutoloader->getPrefixesPsr4() as $prefixPsr4 => $pathes) {
+
+            /**
+             * Do not use n98-magerun2 bundled composer for Magento autoloader.
+             * Magento could have a different Composer version bundled.
+             *
+             * @see https://github.com/netz98/n98-magerun2/issues/789
+             */
+            if ($prefixPsr4 === 'Composer\\') {
+                continue;
+            }
+
             $this->magentoAutoloader->addPsr4($prefixPsr4, $pathes, true);
         }
     }


### PR DESCRIPTION
Magerun pull-request check-list:

- [X] Pull request against develop branch (if not, just close and create a new one against it)

Fixes #789

Changes proposed in this pull request:

- Do not mirror PSR-4 prefix of n98-magerun2 autoloader to original Magento autoloader