### PR TITLE
Implement input format json for config env set command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 
 
 phpunit.xml
+.phpunit.result.cache
 .php_cs.cache
 
 # Gitub

--- a/README.md
+++ b/README.md
@@ -344,7 +344,7 @@ n98-magerun2.phar config:env:set --input-format=json cron_consumers_runner.consu
 ### Show env.php settings
 
 ```sh
-n98-magerun2.phar config:env:show config:env:show [options] [<key>]
+n98-magerun2.phar config:env:show [options] [<key>]
 ```
 
 If no key is passed, the whole content of the file is displayed as table.

--- a/README.md
+++ b/README.md
@@ -325,6 +325,9 @@ Sub-arrays in config.php can be specified by adding a "." character to every arr
 n98-magerun2.phar config:env:set <key> [<value>]
 ```
 
+You can also choose to provide a json text argument as value, by using the optional `--input-format=json` flag.
+This will allow you to add values that aren't a string but also other scalar types.
+
 Examples:
 
 ```sh
@@ -332,6 +335,10 @@ n98-magerun2.phar config:env:set backend.frontName mybackend
 n98-magerun2.phar config:env:set crypt.key bb5b0075303a9bb8e3d210a971674367
 n98-magerun2.phar config:env:set session.redis.host 192.168.1.1
 n98-magerun2.phar config:env:set 'x-frame-options' '*'
+
+n98-magerun2.phar config:env:set --input-format=json queue.consumers_wait_for_messages 0
+n98-magerun2.phar config:env:set --input-format=json directories.document_root_is_pub true
+n98-magerun2.phar config:env:set --input-format=json cron_consumers_runner.consumers '["some.consumer", "some.other.consumer"]'
 ```
 
 ### Show env.php settings

--- a/src/N98/Magento/Command/Config/Env/ShowCommand.php
+++ b/src/N98/Magento/Command/Config/Env/ShowCommand.php
@@ -73,6 +73,11 @@ class ShowCommand extends AbstractMagentoCommand
             $table =[];
 
             foreach ($flattenArray as $configKey => $configValue) {
+                // prevents a crash when a key contains an empty array as value
+                if ($configValue === []) {
+                    $configValue = '';
+                }
+
                 $table[] = [
                     'key' => $configKey,
                     'value' => $configValue,

--- a/tests/N98/Magento/Command/Config/Env/SetCommandTest.php
+++ b/tests/N98/Magento/Command/Config/Env/SetCommandTest.php
@@ -47,4 +47,45 @@ class SetCommandTest extends TestCase
             ['0A1B'],
         ];
     }
+
+    /**
+     * @dataProvider jsonDataProvider
+     */
+    public function testWithInputFormatJson($value)
+    {
+        $this->assertDisplayContains(
+            [
+                'command' => 'config:env:set',
+                '--input-format' => 'json',
+                'key' => 'magerun.test',
+                'value' => $value
+            ],
+            'Config magerun.test successfully set to ' . $value
+        );
+
+        // Check for idempotency
+        $this->assertDisplayContains(
+            [
+                'command' => 'config:env:set',
+                '--input-format' => 'json',
+                'key' => 'magerun.test',
+                'value' => $value,
+                '--verbose' => true // Add dummy option to force different input hash
+            ],
+            'Config was already set'
+        );
+    }
+
+    public function jsonDataProvider(): array
+    {
+        return [
+            [json_encode(20)],
+            [json_encode('20')],
+            [json_encode(1.0)],
+            [json_encode('1.0')],
+            [json_encode(true)],
+            [json_encode('true')],
+            [json_encode(['key' => 'value'])],
+        ];
+    }
 }

--- a/tests/N98/Magento/Command/Config/Env/ShowCommandTest.php
+++ b/tests/N98/Magento/Command/Config/Env/ShowCommandTest.php
@@ -22,4 +22,22 @@ class ShowCommandTest extends TestCase
             'install.date'
         );
     }
+
+    public function testExecuteWithEmptyArrayValue()
+    {
+        $this->assertExecute(
+            [
+                'command' => 'config:env:set',
+                '--input-format' => 'json',
+                'key' => 'magerun.test',
+                'value' => '[]'
+            ]
+        );
+
+        $this->assertExecute(
+            [
+                'command' => 'config:env:show',
+            ]
+        );
+    }
 }


### PR DESCRIPTION
Magerun pull-request check-list:

- [x] Pull request against develop branch (if not, just close and create a new one against it)
- [x] README.md reflects changes (if any)

Subject: Various changes to the `config:env:*` commands

Fixes https://github.com/netz98/n98-magerun2/issues/766

Changes proposed in this pull request:

- Ignores `.phpunit.result.cache` files, this file kept popping up when running unit tests on my local machine

- Fixes a small bug in the `config:env:show` command when you execute it without a key and have something like this in your `env.php` file:
```php
    "downloadable_domains" => [

    ],
```

- Fixes a small bug in the README file where it incorrectly mentioned `config:env:show` [twice](https://github.com/netz98/n98-magerun2/blob/99522042b25d344ff46644e6497d0c06b84d19e7/README.md#show-envphp-settings)

- The big change of this PR: introduces a `--input-format` option for the `config:env:set` command which allows you to specify values in json text format to allow you to set values that aren't strings.

As for what @ktomk mentioned in the issue linked above:
> The concept should have an eye on config:env:show as well (if there is such a thing) so symmetry is established and round-trips may become possible. similar if there are delete operations.

I have a change ready for that, but I'm not sure if this is the right way to implement it: https://github.com/hostep/n98-magerun2/commit/7835aa35a296272cbc2d8a9aaa9971a9b33a748f
Right now you need to provide the flattened key in the `config:env:show` command, so `config:env:show cron_consumers_runner.max_messages` works, but `config:env:show cron_consumers_runner` does not work. This extra `--no-flatten-key` flag works around this, but since we can't assume all values are strings, this automatically outputs it encoded as json.
What do you guys think about this? Is this a good implementation or do you think this needs to be implemented differently? If I need to open a new PR for that one to discuss it separately, please let me know.

> If it would additionally support concatenated json objects and reading from file and standard input would be golden.

I didn't look into this, not sure if other commands in magerun2 already do something like this?

---

I'm really bad at choosing names, so if you have remarks about anything, please don't hesitate to ask for changes 🙂 