### PR TITLE
Adds a config:env:delete command

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,6 +354,24 @@ n98-magerun2.phar config:env:set --input-format=json directories.document_root_i
 n98-magerun2.phar config:env:set --input-format=json cron_consumers_runner.consumers '["some.consumer", "some.other.consumer"]'
 ```
 
+### Delete key from env.php file
+
+Remove a configuration from the env.php file by providing a key.
+
+Sub-arrays in config.php can be specified by adding a "." character to every array.
+
+```sh
+n98-magerun2.phar config:env:delete <key>
+```
+
+Examples:
+
+```sh
+n98-magerun2.phar config:env:delete system
+n98-magerun2.phar config:env:delete cache.frontend.default.backend
+n98-magerun2.phar config:env:delete cache.frontend.default.backend_options
+```
+
 ### Show env.php settings
 
 ```sh

--- a/config.yaml
+++ b/config.yaml
@@ -86,6 +86,7 @@ commands:
     - N98\Magento\Command\Config\Env\CreateCommand
     - N98\Magento\Command\Config\Env\ShowCommand
     - N98\Magento\Command\Config\Env\SetCommand
+    - N98\Magento\Command\Config\Env\DeleteCommand
     - N98\Magento\Command\Config\Store\DeleteCommand
     - N98\Magento\Command\Config\Store\GetCommand
     - N98\Magento\Command\Config\Store\SetCommand

--- a/src/N98/Magento/Command/Config/Env/DeleteCommand.php
+++ b/src/N98/Magento/Command/Config/Env/DeleteCommand.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace N98\Magento\Command\Config\Env;
+
+use Adbar\Dot;
+use N98\Magento\Command\AbstractMagentoCommand;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Class DeleteCommand
+ * @package N98\Magento\Command\Config\Env
+ */
+class DeleteCommand extends AbstractMagentoCommand
+{
+    protected function configure()
+    {
+        $this
+            ->setName('config:env:delete')
+            ->setDescription('Delete entry from env.php')
+            ->addArgument('key', InputArgument::REQUIRED, 'config key')
+            ->setHelp('Removes a specific config from the env.php file. Use config:env:show command to see the existing values.');
+    }
+
+    /**
+     * @param \Symfony\Component\Console\Input\InputInterface $input
+     * @param \Symfony\Component\Console\Output\OutputInterface $output
+     * @return int|void
+     * @throws \Exception
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $this->detectMagento($output);
+
+        $envFilePath = $this->getApplication()->getMagentoRootFolder() . '/app/etc/env.php';
+
+        if (!file_exists($envFilePath)) {
+            throw new \RuntimeException('env.php file does not exist.');
+        }
+
+        $envConfig = include $envFilePath;
+        $env = new Dot($envConfig);
+
+        $key = $input->getArgument('key');
+
+        $checksumBefore = sha1($env->toJson());
+        $env->delete($key);
+        $checksumAfter = sha1($env->toJson());
+
+        if ($checksumBefore !== $checksumAfter) {
+            if (@file_put_contents(
+                $envFilePath,
+                "<?php\n\nreturn " . EnvHelper::exportVariable($env->all()) . ";\n"
+            )
+            ) {
+                $output->writeln(sprintf('<info>Config <comment>%s</comment> successfully removed</info>', $key));
+            } else {
+                $output->writeln('<error>Config value could not be removed</error>');
+            }
+        } else {
+            $output->writeln('<info>Config doesn\'t exists</info>');
+        }
+    }
+}

--- a/tests/N98/Magento/Command/Config/Env/DeleteCommandTest.php
+++ b/tests/N98/Magento/Command/Config/Env/DeleteCommandTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace N98\Magento\Command\Config\Env;
+
+use N98\Magento\Command\TestCase;
+
+/**
+ * Class DeleteCommandTest
+ * @package N98\Magento\Command\Config\Env
+ */
+class DeleteCommandTest extends TestCase
+{
+    public function testExecute()
+    {
+        // first add a dummy key
+        $this->assertExecute(
+            [
+                'command' => 'config:env:set',
+                'key' => 'magerun.test',
+                'value' => 'test'
+            ]
+        );
+
+        // Check if config gets removed
+        $this->assertDisplayContains(
+            [
+                'command' => 'config:env:delete',
+                'key' => 'magerun.test'
+            ],
+            'Config magerun.test successfully removed '
+        );
+
+        // Check for idempotency
+        $this->assertDisplayContains(
+            [
+                'command' => 'config:env:delete',
+                'key' => 'magerun.test',
+                '--verbose' => true // Add dummy option to force different input hash
+            ],
+            'Config doesn\'t exists'
+        );
+    }
+}


### PR DESCRIPTION
Magerun pull-request check-list:

- [x] Pull request against develop branch (if not, just close and create a new one against it)
- [x] README.md reflects changes (if any)

Subject: adds a config:env:delete command

Changes proposed in this pull request:

I was searching for a command line command to remove Redis cache configurations from the `env.php` file but didn't find any. This has been requested a [couple](https://community.magento.com/t5/Magento-2-x-Admin-Configuration/Disabling-Redis-cache-from-command-line/m-p/89599) of [times](https://community.magento.com/t5/Magento-2-x-Feature-Requests-and/Add-support-for-disabling-Redis-cache-from-command-line/idi-p/89789) on the Magento forums, so it looks like this might be helpful to more people 🙂 

This PR adds a way to do this.