### PR TITLE
Remove Composer download methods in abstract command

### DIFF
--- a/src/N98/Magento/Command/AbstractMagentoCommand.php
+++ b/src/N98/Magento/Command/AbstractMagentoCommand.php
@@ -167,60 +167,6 @@ abstract class AbstractMagentoCommand extends Command
     }
 
     /**
-     * @param InputInterface $input
-     * @param OutputInterface $output
-     * @return \Composer\Downloader\DownloadManager
-     */
-    public function getComposerDownloadManager($input, $output)
-    {
-        return $this->getComposer($input, $output)->getDownloadManager();
-    }
-
-    /**
-     * @param array $config
-     * @return PackageInterface
-     */
-    public function createComposerPackageByConfig(array $config)
-    {
-        $packageLoader = new PackageLoader();
-
-        return $packageLoader->load($config);
-    }
-
-    /**
-     * brings locally cached repository up to date if it is missing the requested tag
-     *
-     * @param PackageInterface $package
-     * @param string $targetFolder
-     */
-    protected function checkRepository(PackageInterface $package, $targetFolder)
-    {
-        if ($package->getSourceType() == 'git') {
-            $command = sprintf(
-                'cd %s && git rev-parse refs/tags/%s',
-                escapeshellarg($targetFolder),
-                escapeshellarg($package->getSourceReference())
-            );
-            $existingTags = shell_exec($command);
-            if (!$existingTags) {
-                $command = sprintf('cd %s && git fetch', escapeshellarg($targetFolder));
-                shell_exec($command);
-            }
-        } elseif ($package->getSourceType() == 'hg') {
-            $command = sprintf(
-                'cd %s && hg log --template "{tags}" -r %s',
-                escapeshellarg($targetFolder),
-                escapeshellarg($package->getSourceReference())
-            );
-            $existingTag = shell_exec($command);
-            if ($existingTag === $package->getSourceReference()) {
-                $command = sprintf('cd %s && hg pull', escapeshellarg($targetFolder));
-                shell_exec($command);
-            }
-        }
-    }
-
-    /**
      * @param string $type
      *
      * @return bool


### PR DESCRIPTION
Use Composer helper or guzzle for downloads!

Magerun pull-request check-list:

- [X] Pull request against develop branch (if not, just close and create a new one against it)

Subject: Remove public methods to removed composer download manager

Changes proposed in this pull request:

- Remove methods -> use guzzle for general purpose downloads or `$this->getHelper('composer')` to work with external composer binary.