### PR TITLE
Replace dependency "adbario/php-dot-notation" with "dflydev/dot-access-data"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "ext-json": "*",
         "ext-posix": "*",
         "ext-zip": "*",
-        "adbario/php-dot-notation": "^2.2",
+        "dflydev/dot-access-data": "^3.0",
         "fakerphp/faker": "~1.16",
         "guzzlehttp/guzzle": "^7.4",
         "n98/junit-xml": "~1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,37 +4,41 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4033d956f19ab255b1352ee72d8009ad",
+    "content-hash": "49414aa8d42dc82cf2240e8ef8dd7c85",
     "packages": [
         {
-            "name": "adbario/php-dot-notation",
-            "version": "2.2.0",
+            "name": "dflydev/dot-access-data",
+            "version": "v3.0.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/adbario/php-dot-notation.git",
-                "reference": "eee4fc81296531e6aafba4c2bbccfc5adab1676e"
+                "url": "https://github.com/dflydev/dflydev-dot-access-data.git",
+                "reference": "0992cc19268b259a39e86f296da5f0677841f42c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/adbario/php-dot-notation/zipball/eee4fc81296531e6aafba4c2bbccfc5adab1676e",
-                "reference": "eee4fc81296531e6aafba4c2bbccfc5adab1676e",
+                "url": "https://api.github.com/repos/dflydev/dflydev-dot-access-data/zipball/0992cc19268b259a39e86f296da5f0677841f42c",
+                "reference": "0992cc19268b259a39e86f296da5f0677841f42c",
                 "shasum": ""
             },
             "require": {
-                "ext-json": "*",
-                "php": ">=5.5"
+                "php": "^7.1 || ^8.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.0|^5.0|^6.0",
-                "squizlabs/php_codesniffer": "^3.0"
+                "phpstan/phpstan": "^0.12.42",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.3",
+                "scrutinizer/ocular": "1.6.0",
+                "squizlabs/php_codesniffer": "^3.5",
+                "vimeo/psalm": "^3.14"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.x-dev"
+                }
+            },
             "autoload": {
-                "files": [
-                    "src/helpers.php"
-                ],
                 "psr-4": {
-                    "Adbar\\": "src"
+                    "Dflydev\\DotAccessData\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -43,21 +47,39 @@
             ],
             "authors": [
                 {
-                    "name": "Riku Särkinen",
-                    "email": "riku@adbar.io"
+                    "name": "Dragonfly Development Inc.",
+                    "email": "info@dflydev.com",
+                    "homepage": "http://dflydev.com"
+                },
+                {
+                    "name": "Beau Simensen",
+                    "email": "beau@dflydev.com",
+                    "homepage": "http://beausimensen.com"
+                },
+                {
+                    "name": "Carlos Frutos",
+                    "email": "carlos@kiwing.it",
+                    "homepage": "https://github.com/cfrutos"
+                },
+                {
+                    "name": "Colin O'Dell",
+                    "email": "colinodell@gmail.com",
+                    "homepage": "https://www.colinodell.com"
                 }
             ],
-            "description": "PHP dot notation access to arrays",
-            "homepage": "https://github.com/adbario/php-dot-notation",
+            "description": "Given a deep data structure, access data by dot notation.",
+            "homepage": "https://github.com/dflydev/dflydev-dot-access-data",
             "keywords": [
-                "ArrayAccess",
-                "dotnotation"
+                "access",
+                "data",
+                "dot",
+                "notation"
             ],
             "support": {
-                "issues": "https://github.com/adbario/php-dot-notation/issues",
-                "source": "https://github.com/adbario/php-dot-notation/tree/2.x"
+                "issues": "https://github.com/dflydev/dflydev-dot-access-data/issues",
+                "source": "https://github.com/dflydev/dflydev-dot-access-data/tree/v3.0.1"
             },
-            "time": "2019-01-01T23:59:15+00:00"
+            "time": "2021-08-13T13:06:58+00:00"
         },
         {
             "name": "fakerphp/faker",

--- a/src/N98/Magento/Command/Config/Env/CreateCommand.php
+++ b/src/N98/Magento/Command/Config/Env/CreateCommand.php
@@ -2,7 +2,7 @@
 
 namespace N98\Magento\Command\Config\Env;
 
-use Adbar\Dot;
+use Dflydev\DotAccessData\Data;
 use N98\Magento\Command\AbstractMagentoCommand;
 use RecursiveArrayIterator;
 use RecursiveIteratorIterator;
@@ -64,10 +64,10 @@ class CreateCommand extends AbstractMagentoCommand
             $envConfig = include __DIR__ . '/stubs/env.php';
         }
 
-        $env = new Dot($envConfig);
+        $env = new Data($envConfig);
 
         $iterator = new RecursiveIteratorIterator(
-            new RecursiveArrayIterator($env->all()),
+            new RecursiveArrayIterator($env->export()),
             RecursiveIteratorIterator::SELF_FIRST
         );
 
@@ -95,7 +95,7 @@ class CreateCommand extends AbstractMagentoCommand
             }
         }
 
-        file_put_contents($envFilePath, "<?php\n\nreturn " . EnvHelper::exportVariable($env->all()) . ";\n");
+        file_put_contents($envFilePath, "<?php\n\nreturn " . EnvHelper::exportVariable($env->export()) . ";\n");
     }
 
     /**

--- a/src/N98/Magento/Command/System/Check/Env/CheckAbstract.php
+++ b/src/N98/Magento/Command/System/Check/Env/CheckAbstract.php
@@ -2,7 +2,7 @@
 
 namespace N98\Magento\Command\System\Check\Env;
 
-use Adbar\Dot;
+use Dflydev\DotAccessData\Data;
 use N98\Magento\Command\CommandAware;
 use N98\Magento\Command\CommandConfigAware;
 use N98\Magento\Command\System\Check\ResultCollection;
@@ -28,7 +28,7 @@ abstract class CheckAbstract implements SimpleCheck, CommandAware, CommandConfig
     protected $_checkCommand;
 
     /**
-     * @var Dot
+     * @var \Dflydev\DotAccessData\Data
      */
     protected $_dot;
 
@@ -52,7 +52,7 @@ abstract class CheckAbstract implements SimpleCheck, CommandAware, CommandConfig
 
         $envArray = include $this->_envFilePath;
         $this->_env = $envArray;
-        $this->_dot = new Dot($envArray);
+        $this->_dot = new Data($envArray);
 
         $this->checkEnv();
     }


### PR DESCRIPTION
Magerun pull-request check-list:

- [X] Pull request against develop branch (if not, just close and create a new one against it)

Summary: Maintenance of dflydev/dot-access-data seems to be better. We need PHP 8.1 support.

Changes proposed in this pull request:

- Remove adbario/php-dot-notation package
- Add dflydev/dot-access-data
- Update config:env commands
- Update sys:check command