### PR TITLE
Allow for xdebug ^3.0 - check if xdebug_is_enabled function exists

### DIFF
--- a/src/N98/Magento/Command/Installer/SubCommand/PreCheckPhp.php
+++ b/src/N98/Magento/Command/Installer/SubCommand/PreCheckPhp.php
@@ -50,10 +50,10 @@ class PreCheckPhp extends AbstractSubCommand
      */
     protected function checkXDebug()
     {
-        if (\extension_loaded('xdebug') && 
-            function_exists('xdebug_is_enabled') && 
-            \xdebug_is_enabled() && 
-            ini_get('xdebug.max_nesting_level') != -1 && 
+        if (\extension_loaded('xdebug') &&
+            function_exists('xdebug_is_enabled') &&
+            \xdebug_is_enabled() &&
+            ini_get('xdebug.max_nesting_level') != -1 &&
             \ini_get('xdebug.max_nesting_level') < 200
         ) {
             $errorMessage = 'Please change PHP ini setting "xdebug.max_nesting_level". '

--- a/src/N98/Magento/Command/Installer/SubCommand/PreCheckPhp.php
+++ b/src/N98/Magento/Command/Installer/SubCommand/PreCheckPhp.php
@@ -50,9 +50,11 @@ class PreCheckPhp extends AbstractSubCommand
      */
     protected function checkXDebug()
     {
-        if (\extension_loaded('xdebug') &&
-            \xdebug_is_enabled() && ini_get('xdebug.max_nesting_level') != -1
-            && \ini_get('xdebug.max_nesting_level') < 200
+        if (\extension_loaded('xdebug') && 
+            function_exists('xdebug_is_enabled') && 
+            \xdebug_is_enabled() && 
+            ini_get('xdebug.max_nesting_level') != -1 && 
+            \ini_get('xdebug.max_nesting_level') < 200
         ) {
             $errorMessage = 'Please change PHP ini setting "xdebug.max_nesting_level". '
                             . 'Please change it to a value >= 200. '


### PR DESCRIPTION
Magerun pull-request check-list:

- [x] Pull request against develop branch (if not, just close and create a new one against it)
- [ ] phar fuctional test (in tests/phar-test.sh)

Summary: (some words as summary)

Fixes #934

Changes proposed in this pull request:

- Check if the function xdebug_is_enabled exists - To allow xdebug ^3.0