### PR TITLE
Add composer runtime infos (installed.php) to phar

### DIFF
--- a/.github/workflows/magento_platform_tests.yml
+++ b/.github/workflows/magento_platform_tests.yml
@@ -270,6 +270,7 @@ jobs:
       - name: Run phar functional tests
         run: |
           composer self-update --2
+          composer global remove hirak/prestissimo
           bash ./build.sh
           bash tests/phar-test.sh "./n98-magerun2.phar" "$GITHUB_WORKSPACE/magento"
           composer self-update --rollback &> /dev/null || true

--- a/.github/workflows/magento_platform_tests.yml
+++ b/.github/workflows/magento_platform_tests.yml
@@ -272,4 +272,4 @@ jobs:
           composer self-update --2
           bash ./build.sh
           bash tests/phar-test.sh "./n98-magerun2.phar" "$GITHUB_WORKSPACE/magento"
-          composer self-update --rollback
+          composer self-update --rollback &> /dev/null || true

--- a/.github/workflows/magento_platform_tests.yml
+++ b/.github/workflows/magento_platform_tests.yml
@@ -20,6 +20,7 @@ jobs:
     runs-on: ${{ matrix.operating-system }}
     strategy:
       matrix:
+        php-versions: ['7.3', '7.4', '8.1']
         include:
           - magento-version: magento-ce-2.4-develop
             operating-system: ubuntu-latest
@@ -267,10 +268,23 @@ jobs:
       - name: Run PHPUnit (Production Mode)
         run: vendor/bin/phpunit --debug --process-isolation
 
-      - name: Run phar functional tests
+      - name: Setup PHP for Composer
+        uses: shivammathur/setup-php@v2
+        with:
+          tools: composer:2
+          php-version: '7.4'
+
+      - name: Build phar file
         run: |
           composer self-update --2
           composer global remove hirak/prestissimo
           bash ./build.sh
-          bash tests/phar-test.sh "./n98-magerun2.phar" "$GITHUB_WORKSPACE/magento"
           composer self-update --rollback &> /dev/null || true
+
+      - name: Setup PHP for Composer
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-version }}
+
+      - name: Run phar functional tests
+        run: bash tests/phar-test.sh "./n98-magerun2.phar" "$GITHUB_WORKSPACE/magento"

--- a/.github/workflows/magento_platform_tests.yml
+++ b/.github/workflows/magento_platform_tests.yml
@@ -269,5 +269,7 @@ jobs:
 
       - name: Run phar functional tests
         run: |
+          composer self-update --2
           bash ./build.sh
           bash tests/phar-test.sh "./n98-magerun2.phar" "$GITHUB_WORKSPACE/magento"
+          composer self-update --rollback

--- a/.github/workflows/magento_platform_tests.yml
+++ b/.github/workflows/magento_platform_tests.yml
@@ -20,7 +20,6 @@ jobs:
     runs-on: ${{ matrix.operating-system }}
     strategy:
       matrix:
-        php-versions: ['7.3', '7.4', '8.1']
         include:
           - magento-version: magento-ce-2.4-develop
             operating-system: ubuntu-latest

--- a/.github/workflows/phar_build_and_update.yml
+++ b/.github/workflows/phar_build_and_update.yml
@@ -12,6 +12,7 @@ jobs:
     - name: Setup PHP
       uses: shivammathur/setup-php@v2
       with:
+        tools: composer:2
         php-version: '7.4'
 
     - name: Checkout PR

--- a/.github/workflows/phar_build_and_update.yml
+++ b/.github/workflows/phar_build_and_update.yml
@@ -53,7 +53,6 @@ jobs:
     - name: Test self-update command
       run: php ./n98-magerun2.phar self-update --unstable
 
-
     # Add a test script to composer.json, for instance: "test": "vendor/bin/phpunit"
     # Docs: https://getcomposer.org/doc/articles/scripts.md
 

--- a/box.json.dist
+++ b/box.json.dist
@@ -4,7 +4,8 @@
     "datetime": "release-date",
     "files": [
         "config.yaml",
-        "src/bootstrap.php"
+        "src/bootstrap.php",
+        "vendor/composer/installed.php"
     ],
     "force-autodiscovery": true,
     "directories": [

--- a/build.sh
+++ b/build.sh
@@ -75,9 +75,8 @@ function create_new_phar() {
   # which will then create a no reproducable phar file with a differenz MD5
   $COMPOSER_BIN config autoloader-suffix N98MagerunNTS
 
-  # Required for some Github Action edge cases where the file vendor/composer/installed.php
-  # could not be found if previous Magerun installation was done with Composer 1
-  $COMPOSER_BIN dump-autoload
+  # Run install again to get the latest install.php and install.json file
+  $COMPOSER_BIN install
 
   $PHP_BIN $BOX_BIN compile
 

--- a/build.sh
+++ b/build.sh
@@ -75,6 +75,10 @@ function create_new_phar() {
   # which will then create a no reproducable phar file with a differenz MD5
   $COMPOSER_BIN config autoloader-suffix N98MagerunNTS
 
+  # Required for some Github Action edge cases where the file vendor/composer/installed.php
+  # could not be found if previous Magerun installation was done with Composer 1
+  $COMPOSER_BIN dump-autoload
+
   $PHP_BIN $BOX_BIN compile
 
   # unset composer suffix


### PR DESCRIPTION
Magerun pull-request check-list:

- [X] Pull request against develop branch (if not, just close and create a new one against it)
- [X] phar fuctional test (in tests/phar-test.sh)

Summary: Add installed.php to phar file

Changes proposed in this pull request:

- Add path `vendor/composer/installed.php` to box.json.dist file
- Create the phar file in the Github Actions always with Composer 2