### PR TITLE
Replace strftime function calls (#969)

### DIFF
--- a/src/N98/Magento/Command/System/Cron/RunCommand.php
+++ b/src/N98/Magento/Command/System/Cron/RunCommand.php
@@ -25,7 +25,7 @@ class RunCommand extends AbstractCronCommand
             ->setDescription('Runs a cronjob by job code');
         $help = <<<HELP
 If no `job` argument is passed you can select a job from a list.
-See it in action: http://www.youtube.com/watch?v=QkzkLgrfNaM
+See it in action: https://www.youtube.com/watch?v=QkzkLgrfNaM
 HELP;
         $this->setHelp($help);
     }
@@ -59,7 +59,7 @@ HELP;
         $schedule
             ->setJobCode($jobCode)
             ->setStatus(Schedule::STATUS_RUNNING)
-            ->setExecutedAt(strftime('%Y-%m-%d %H:%M:%S', $this->getCronTimestamp()))
+            ->setFinishedAt(date('Y-m-d H:i:s', $this->getCronTimestamp()))
             ->save();
 
         try {
@@ -67,13 +67,13 @@ HELP;
 
             $schedule
                 ->setStatus(Schedule::STATUS_SUCCESS)
-                ->setFinishedAt(strftime('%Y-%m-%d %H:%M:%S', $this->getCronTimestamp()))
+                ->setFinishedAt(date('Y-m-d H:i:s', $this->getCronTimestamp()))
                 ->save();
         } catch (Exception $e) {
             $schedule
                 ->setStatus(Schedule::STATUS_ERROR)
                 ->setMessages($e->getMessage())
-                ->setFinishedAt(strftime('%Y-%m-%d %H:%M:%S', $this->getCronTimestamp()))
+                ->setFinishedAt(date('Y-m-d H:i:s', $this->getCronTimestamp()))
                 ->save();
         }
 

--- a/src/N98/Magento/Command/System/Cron/ScheduleCommand.php
+++ b/src/N98/Magento/Command/System/Cron/ScheduleCommand.php
@@ -53,8 +53,8 @@ HELP;
         $schedule
             ->setJobCode($jobCode)
             ->setStatus(Schedule::STATUS_PENDING)
-            ->setCreatedAt(strftime('%Y-%m-%d %H:%M:%S', $createdAtTime))
-            ->setScheduledAt(strftime('%Y-%m-%d %H:%M', $scheduledAtTime))
+            ->setCreatedAt(date('Y-m-d H:i:s', $createdAtTime))
+            ->setScheduledAt(date('Y-m-d H:i', $scheduledAtTime))
             ->save();
 
         $output->writeln('<info>done</info>');


### PR DESCRIPTION
Magerun pull-request check-list:

- [X] Pull request against develop branch (if not, just close and create a new one against it)

Summary: Replace deprecated strftime calls

Fixes #969

Changes proposed in this pull request:

- Use date function instead of strftime

Reference: https://php.watch/versions/8.1/strftime-gmstrftime-deprecated
