### PR TITLE
Prevent `Deprecated Functionality` under PHP 8,1 and default to all s…

### DIFF
--- a/src/N98/Magento/Command/System/Url/ListCommand.php
+++ b/src/N98/Magento/Command/System/Url/ListCommand.php
@@ -109,7 +109,10 @@ HELP;
             $input->setOption('add-cmspages', true);
         }
 
-        $stores = explode(',', $input->getArgument('stores'));
+        $stores = explode(',', (string) $input->getArgument('stores'));
+        if (empty($stores) {
+            $stores = array_keys($this->storeManager->getStores());
+        }
 
         $urls = [];
 


### PR DESCRIPTION
…tores

While running the command `sys:url:list` under PHP 8.1 but not passing any `stores` as input argument, I got an error message `Deprecated Functionality: explode(): Passing null to parameter #2 ($string) of type string is deprecated in phar:///usr/local/bin/magerun2/src/N98/Magento/Command/System/Url/ListCommand.php on line 11`. The reason for this is that the call `$input->getArgument('stores')` returns `null` while `explode()` requires a string as second argument. This PR fixes that.

But while we're at it, the input argument `stores` is empty, so it makes more sense to default to a list of all stores. This PR adds that too.

Magerun pull-request check-list:

- [ ] Pull request against develop branch (if not, just close and create a new one against it)
- [ ] README.md reflects changes (if any)
- [ ] phar fuctional test (in tests/phar-test.sh)

Summary: (some words as summary)

Fixes # .

Changes proposed in this pull request:

- ...

- ...

- ...
