### PR TITLE
Add fallback for phar wrapper restore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 RECENT CHANGES
 ==============
 
+5.0.x
+-----
+
+- Fallback logic for phar stream wrapper
+
+unrelesed
+
 5.0.2
 -----
 - Fix: #966: InstalledVersions.php could not be opened

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,8 @@
         "symfony/process": "~4.4",
         "symfony/validator": "~4.4",
         "symfony/yaml": "~5.3",
-        "twig/twig": "~3.3"
+        "twig/twig": "~3.3",
+        "typo3/phar-stream-wrapper": "^3.1"
     },
     "require-dev": {
         "bamarni/symfony-console-autocomplete": "^1.2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "19ccf225dfdd7542aadc5acb2413c94d",
+    "content-hash": "71ec6a216c94c9aa0aa768e3e4b16a70",
     "packages": [
         {
             "name": "dflydev/dot-access-data",
@@ -1760,6 +1760,61 @@
                 }
             ],
             "time": "2022-04-06T06:47:41+00:00"
+        },
+        {
+            "name": "typo3/phar-stream-wrapper",
+            "version": "v3.1.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/TYPO3/phar-stream-wrapper.git",
+                "reference": "5cc2f04a4e2f5c7e9cc02a3bdf80fae0f3e11a8c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/TYPO3/phar-stream-wrapper/zipball/5cc2f04a4e2f5c7e9cc02a3bdf80fae0f3e11a8c",
+                "reference": "5cc2f04a4e2f5c7e9cc02a3bdf80fae0f3e11a8c",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "php": "^7.0 || ^8.0"
+            },
+            "require-dev": {
+                "ext-xdebug": "*",
+                "phpspec/prophecy": "^1.10",
+                "symfony/phpunit-bridge": "^5.1"
+            },
+            "suggest": {
+                "ext-fileinfo": "For PHP builtin file type guessing, otherwise uses internal processing"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "v3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "TYPO3\\PharStreamWrapper\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Interceptors for PHP's native phar:// stream handling",
+            "homepage": "https://typo3.org/",
+            "keywords": [
+                "phar",
+                "php",
+                "security",
+                "stream-wrapper"
+            ],
+            "support": {
+                "issues": "https://github.com/TYPO3/phar-stream-wrapper/issues",
+                "source": "https://github.com/TYPO3/phar-stream-wrapper/tree/v3.1.7"
+            },
+            "time": "2021-09-20T19:19:13+00:00"
         }
     ],
     "packages-dev": [
@@ -5518,5 +5573,5 @@
     "platform-overrides": {
         "php": "7.3.0"
     },
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/src/N98/Magento/Application/Magento2Initializer.php
+++ b/src/N98/Magento/Application/Magento2Initializer.php
@@ -34,11 +34,7 @@ class Magento2Initializer
     public function init($magentoRootFolder)
     {
         $this->requireOnce($magentoRootFolder . '/app/bootstrap.php');
-
-        // Magento 2.3.1 removes phar stream wrapper.
-        if (!in_array('phar', \stream_get_wrappers(), true)) {
-            \stream_wrapper_restore('phar');
-        }
+        $this->pharWrapperFix();
 
         $magentoAutoloader = AutoloaderRegistry::getAutoloader();
 
@@ -82,5 +78,18 @@ class Magento2Initializer
         }
 
         $requireOnce($path);
+    }
+
+    /**
+     * Magento 2.3.1 removes the phar wrapper
+     */
+    private function pharWrapperFix()
+    {
+        // Magento 2.3.1 removes phar stream wrapper.
+        if (!in_array('phar', \stream_get_wrappers(), true)) {
+            if (!\stream_wrapper_restore('phar')) {
+                stream_wrapper_register('phar', \TYPO3\PharStreamWrapper\PharStreamWrapper::class);
+            }
+        }
     }
 }


### PR DESCRIPTION
Magerun pull-request check-list:

- [X] Pull request against develop branch (if not, just close and create a new one against it)

Summary: (some words as summary)

Fixes initialize issue if phar wrapper cannot be restored

Changes proposed in this pull request:

- Re-introduce typo3/phar-stream-wrapper package
- Call typo3 phar wrapper if `stream_wrapper_restore` call fails.
