### PR TITLE
Add error handler for possible warnings of autoloader

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,8 +41,7 @@
         "symfony/process": "~4.4",
         "symfony/validator": "~4.4",
         "symfony/yaml": "~5.3",
-        "twig/twig": "~3.3",
-        "typo3/phar-stream-wrapper": "^3.1"
+        "twig/twig": "~3.3"
     },
     "require-dev": {
         "bamarni/symfony-console-autocomplete": "^1.2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "71ec6a216c94c9aa0aa768e3e4b16a70",
+    "content-hash": "19ccf225dfdd7542aadc5acb2413c94d",
     "packages": [
         {
             "name": "dflydev/dot-access-data",
@@ -1760,61 +1760,6 @@
                 }
             ],
             "time": "2022-04-06T06:47:41+00:00"
-        },
-        {
-            "name": "typo3/phar-stream-wrapper",
-            "version": "v3.1.7",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/TYPO3/phar-stream-wrapper.git",
-                "reference": "5cc2f04a4e2f5c7e9cc02a3bdf80fae0f3e11a8c"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/TYPO3/phar-stream-wrapper/zipball/5cc2f04a4e2f5c7e9cc02a3bdf80fae0f3e11a8c",
-                "reference": "5cc2f04a4e2f5c7e9cc02a3bdf80fae0f3e11a8c",
-                "shasum": ""
-            },
-            "require": {
-                "ext-json": "*",
-                "php": "^7.0 || ^8.0"
-            },
-            "require-dev": {
-                "ext-xdebug": "*",
-                "phpspec/prophecy": "^1.10",
-                "symfony/phpunit-bridge": "^5.1"
-            },
-            "suggest": {
-                "ext-fileinfo": "For PHP builtin file type guessing, otherwise uses internal processing"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "v3.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "TYPO3\\PharStreamWrapper\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "Interceptors for PHP's native phar:// stream handling",
-            "homepage": "https://typo3.org/",
-            "keywords": [
-                "phar",
-                "php",
-                "security",
-                "stream-wrapper"
-            ],
-            "support": {
-                "issues": "https://github.com/TYPO3/phar-stream-wrapper/issues",
-                "source": "https://github.com/TYPO3/phar-stream-wrapper/tree/v3.1.7"
-            },
-            "time": "2021-09-20T19:19:13+00:00"
         }
     ],
     "packages-dev": [
@@ -5573,5 +5518,5 @@
     "platform-overrides": {
         "php": "7.3.0"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.2.0"
 }

--- a/src/N98/Magento/Application.php
+++ b/src/N98/Magento/Application.php
@@ -490,9 +490,7 @@ class Application extends BaseApplication
 
         // Magento was found -> register core cli commands
         try {
-            \N98\Util\PharWrapper::init();
-            $this->requireOnce($magentoRootFolder . '/app/bootstrap.php');
-            \N98\Util\PharWrapper::ensurePharWrapperIsRegistered();
+            \N98\Magento\Application\Magento2Initializer::loadMagentoBootstrap($magentoRootFolder);
         } catch (Exception $ex) {
             $this->renderThrowable($ex, $output);
             $output->writeln(
@@ -518,24 +516,6 @@ class Application extends BaseApplication
             }
             $this->add($coreCliApplicationCommand);
         }
-    }
-
-    /**
-     * use require-once inside a function with it's own variable scope w/o any other variables
-     * and $this unbound.
-     *
-     * @param string $path
-     */
-    private function requireOnce($path)
-    {
-        $requireOnce = function () {
-            require_once func_get_arg(0);
-        };
-        if (50400 <= PHP_VERSION_ID) {
-            $requireOnce->bindTo(null);
-        }
-
-        $requireOnce($path);
     }
 
     /**

--- a/src/N98/Magento/Application/Magento2Initializer.php
+++ b/src/N98/Magento/Application/Magento2Initializer.php
@@ -3,8 +3,12 @@
 namespace N98\Magento\Application;
 
 use Composer\Autoload\ClassLoader;
+use Magento\Framework\App\Bootstrap;
 use Magento\Framework\Autoload\AutoloaderRegistry;
+use Magento\Store\Model\Store;
+use Magento\Store\Model\StoreManager;
 use N98\Magento\Framework\App\Magerun;
+use N98\Util\PharWrapper;
 
 /**
  * Class Magento2Initializer
@@ -48,11 +52,11 @@ class Magento2Initializer
         }
 
         $params = $_SERVER;
-        $params[\Magento\Store\Model\StoreManager::PARAM_RUN_CODE] = 'admin';
-        $params[\Magento\Store\Model\Store::CUSTOM_ENTRY_POINT_PARAM] = true;
+        $params[StoreManager::PARAM_RUN_CODE] = 'admin';
+        $params[Store::CUSTOM_ENTRY_POINT_PARAM] = true;
         $params['entryPoint'] = basename(__FILE__);
 
-        $bootstrap = \Magento\Framework\App\Bootstrap::create(BP, $params);
+        $bootstrap = Bootstrap::create(BP, $params);
         /** @var \Magento\Framework\App\Cron $app */
         $app = $bootstrap->createApplication(Magerun::class, []);
         /* @var $app \N98\Magento\Framework\App\Magerun */
@@ -63,10 +67,17 @@ class Magento2Initializer
 
     public static function loadMagentoBootstrap($magentoRootFolder)
     {
-        \N98\Util\PharWrapper::init();
-        $oldErrorHandler = set_error_handler(function() { return true; }, E_WARNING);
-        require_once $magentoRootFolder . '/app/bootstrap.php';
-        set_error_handler($oldErrorHandler, E_WARNING);
-        \N98\Util\PharWrapper::ensurePharWrapperIsRegistered();
+        static $loaded;
+
+        if (!$loaded) {
+            PharWrapper::init();
+            $oldErrorHandler = set_error_handler(function () {
+                return true;
+            }, E_WARNING);
+            require_once $magentoRootFolder . '/app/bootstrap.php';
+            set_error_handler($oldErrorHandler, E_WARNING);
+            PharWrapper::ensurePharWrapperIsRegistered();
+            $loaded = true;
+        }
     }
 }

--- a/src/N98/Magento/Application/Magento2Initializer.php
+++ b/src/N98/Magento/Application/Magento2Initializer.php
@@ -33,9 +33,7 @@ class Magento2Initializer
      */
     public function init($magentoRootFolder)
     {
-        \N98\Util\PharWrapper::init();
-        $this->requireOnce($magentoRootFolder . '/app/bootstrap.php');
-        \N98\Util\PharWrapper::ensurePharWrapperIsRegistered();
+        self::loadMagentoBootstrap($magentoRootFolder);
 
         $magentoAutoloader = AutoloaderRegistry::getAutoloader();
 
@@ -63,21 +61,12 @@ class Magento2Initializer
         return $app;
     }
 
-    /**
-     * use require-once inside a function with it's own variable scope w/o any other variables
-     * and $this unbound.
-     *
-     * @param string $path
-     */
-    private function requireOnce($path)
+    public static function loadMagentoBootstrap($magentoRootFolder)
     {
-        $requireOnce = function () {
-            require_once func_get_arg(0);
-        };
-        if (50400 <= PHP_VERSION_ID) {
-            $requireOnce->bindTo(null);
-        }
-
-        $requireOnce($path);
+        \N98\Util\PharWrapper::init();
+        $oldErrorHandler = set_error_handler(function() { return true; }, E_WARNING);
+        require_once $magentoRootFolder . '/app/bootstrap.php';
+        set_error_handler($oldErrorHandler, E_WARNING);
+        \N98\Util\PharWrapper::ensurePharWrapperIsRegistered();
     }
 }

--- a/src/N98/Util/PharWrapper.php
+++ b/src/N98/Util/PharWrapper.php
@@ -26,9 +26,7 @@ class PharWrapper
     {
         // Magento 2.3.1 removes phar stream wrapper.
         if (!in_array('phar', \stream_get_wrappers(), true)) {
-            if (!\stream_wrapper_restore('phar')) {
-                stream_wrapper_register('phar', \TYPO3\PharStreamWrapper\PharStreamWrapper::class);
-            }
+            \stream_wrapper_restore('phar');
         }
     }
 }


### PR DESCRIPTION
Magerun pull-request check-list:

- [X] Pull request against develop branch (if not, just close and create a new one against it)

Summary: Add error handler for autoloader warnings

Fixes: warnings in some older Magento versions

Changes proposed in this pull request:

- Refactor app/bootstrap.php inclusion
- Catch all warnings provided during app/boostrap.php inclusion (only this warnings)
- Restore phar wrapper logic and remove typo3/phar-stream-wrapper package
