### PR TITLE
#957 Exclude system_config_snapshot from stripped dumps

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -189,7 +189,7 @@ commands:
 
       - id: stripped
         description: Standard definition for a stripped dump (logs, sessions, dotmailer)
-        tables: "@log @sessions @dotmailer @newrelic_reporting @temp"
+        tables: "@log @sessions @dotmailer @newrelic_reporting @temp system_config_snapshot"
 
       - id: sales
         description: Sales data (orders, invoices, creditmemos etc)


### PR DESCRIPTION
* The table caches the configuration and might leak confidential
data, for example if such data is kept in env.php

Magerun pull-request check-list:

- [x] Pull request against develop branch (if not, just close and create a new one against it)
- [-] README.md reflects changes (if any)
- [-] phar fuctional test (in tests/phar-test.sh)

Summary: (some words as summary)

Fixes #957 