### PR TITLE
Allow use of pipefail where supported

### DIFF
--- a/src/N98/Util/Exec.php
+++ b/src/N98/Util/Exec.php
@@ -38,7 +38,7 @@ class Exec
             throw new RuntimeException($message);
         }
 
-        if (OperatingSystem::isBashCompatibleShell() && self::isPipefailOptionAvailable()) {
+        if (self::isPipefailOptionAvailable()) {
             $command = self::SET_O_PIPEFAIL . $command;
         }
 

--- a/src/N98/Util/OperatingSystem.php
+++ b/src/N98/Util/OperatingSystem.php
@@ -165,6 +165,7 @@ class OperatingSystem
     }
 
     /**
+     * @deprecated 5.1.1 No longer used by internal code
      * @return bool
      */
     public static function isBashCompatibleShell()


### PR DESCRIPTION
Magerun pull-request check-list:

- [x] Pull request against develop branch (if not, just close and create a new one against it)
- [x] README.md reflects changes (if any)
- [x] phar fuctional test (in tests/phar-test.sh)

Summary: Allow use of pipefail where supported

This is related to #929. It doesn't fix it fully, but does make the symptom go away a lot of the time.

Changes proposed in this pull request:

This pull request removes the check for "bash compatible" shells, relying on the actual feature check for the feature we want to use.

We use docker heavily, and in our set-up, when we run PHP commands there is no `SHELL` environment variable, so the "is this shell bash-compatible" check does not pass. Removing this check allows the `pipefail` feature detection to actually work. I've tested this with shells that do and do not support the feature, and the existing feature detection responds as expected. We're having trouble where command failures aren't being detected in our CI/CD platform because of this bug.