### PR TITLE
Return integer 0 on Cache-ListCommand

### DIFF
--- a/src/N98/Magento/Command/Cache/ListCommand.php
+++ b/src/N98/Magento/Command/Cache/ListCommand.php
@@ -55,7 +55,7 @@ class ListCommand extends AbstractMagentoCommand
     /**
      * @param \Symfony\Component\Console\Input\InputInterface $input
      * @param \Symfony\Component\Console\Output\OutputInterface $output
-     * @return int|void
+     * @return int
      * @throws \Exception
      */
     protected function execute(InputInterface $input, OutputInterface $output)
@@ -86,5 +86,7 @@ class ListCommand extends AbstractMagentoCommand
         $this->getHelper('table')
                 ->setHeaders(['Name', 'Type', 'Enabled'])
                 ->renderByFormat($output, $tableData, $input->getOption('format'));
+
+        return 0;
     }
 }


### PR DESCRIPTION
from logging in gh-actions:

    PHP Fatal error:  Uncaught TypeError: Return value of "N98\Magento\Command\Cache\ListCommand::execute()" must be of the type int, "null" returned. in /home/runner/work/n98-magerun2/n98-magerun2/magento/vendor/symfony/console/Command/Command.php:301
    Stack trace:
    #0 phar:///home/runner/work/n98-magerun2/n98-magerun2/n98-magerun2.phar/src/N98/Magento/Command/AbstractMagentoCommand.php(249): Symfony\Component\Console\Command\Command->run()
    #1 phar:///home/runner/work/n98-magerun2/n98-magerun2/n98-magerun2.phar/src/N98/Magento/Command/Cache/AbstractModifierCommand.php(33): N98\Magento\Command\AbstractMagentoCommand->run()
    #2 phar:///home/runner/work/n98-magerun2/n98-magerun2/n98-magerun2.phar/src/N98/Magento/Command/Cache/AbstractModifierCommand.php(67): N98\Magento\Command\Cache\AbstractModifierCommand->getCacheTypes()
    #3 /home/runner/work/n98-magerun2/n98-magerun2/magento/vendor/symfony/console/Command/Command.php(298): N98\Magento\Command\Cache\AbstractModifierCommand->execute()
    #4 phar:///home/runner/work/n98-magerun2/n98-magerun2/n98-magerun2.phar/src/N98/Magento/Command/AbstractMagentoCommand.php(249): Symfony\Component\Console\Command\Command->run()
    #5 phar:///home/runner/work/n98-magerun2/n98-magerun2/n98-magerun2.phar/vendor/symfony/console/Application.php(1027): N98\Magento\Command\AbstractMagentoCommand->run()
    #6 phar:///home/runner/work/n98-magerun2/n98-magerun2/n98-magerun2.phar/vendor/symfony/console/Application.php(273): Symfony\Component\Console\Application->doRunCommand()
    #7 phar:///home/runner/work/n98-magerun2/n98-magerun2/n98-magerun2.phar/src/N98/Magento/Application.php(235): Symfony\Component\Console\Application->doRun()
    #8 phar:///home/runner/work/n98-magerun2/n98-magerun2/n98-magerun2.phar/vendor/symfony/console/Application.php(149): N98\Magento\Application->doRun()
    #9 phar:///home/runner/work/n98-magerun2/n98-magerun2/n98-magerun2.phar/src/N98/Magento/Application.php(338): Symfony\Component\Console\Application->run()
    #10 /home/runner/work/n98-magerun2/n98-magerun2/n98-magerun2.phar(8): N98\Magento\Application->run()
    #11 {main}
      thrown in /home/runner/work/n98-magerun2/n98-magerun2/magento/vendor/symfony/console/Command/Command.php on line 301

Magerun pull-request check-list:

- [x] Pull request against develop branch (if not, just close and create a new one against it)
- [x] README.md reflects changes (if any)
- [?] phar fuctional test (in tests/phar-test.sh)

Summary: (some words as summary)

Fixes [gh-action-build](https://github.com/netz98/n98-magerun2/runs/7524245463?check_suite_focus=true) (testing).

Changes proposed in this pull request:

- returning an integer to match with strict type checks within vendored symfony base classes.