### PR TITLE
Check if job config is set

### DIFF
--- a/src/N98/Magento/Command/System/Cron/AbstractCronCommand.php
+++ b/src/N98/Magento/Command/System/Cron/AbstractCronCommand.php
@@ -97,13 +97,17 @@ abstract class AbstractCronCommand extends AbstractMagentoCommand
         $jobs = $this->cronConfig->getJobs();
 
         foreach ($jobs as $jobGroupCode => $jobGroup) {
-            foreach ($jobGroup as $jobKey => $job) {
+            foreach ($jobGroup as $jobKey => $jobConfig) {
                 $row = [
                     'Job'   => $job['name'] ?? $jobKey,
                     'Group' => $jobGroupCode,
                 ];
 
-                $row += $this->getSchedule($job);
+                if (!is_array($jobConfig)) {
+                    $jobConfig = [];
+                }
+
+                $row += $this->getSchedule($jobConfig);
 
                 $table[] = $row;
             }


### PR DESCRIPTION
Magerun pull-request check-list:

- [X] Pull request against develop branch (if not, just close and create a new one against it)
- [X] phar fuctional test (in tests/phar-test.sh)

Fixes #1028

Changes proposed in this pull request:

Sometimes the job config is empty. In this case we have to fix initialize the jonconfig in the getSchedule method.