### PR TITLE
Fix issue when running db:dump with gzip on PHP 8.1 with --stdout and…

### DIFF
--- a/src/N98/Magento/Command/Database/Compressor/Gzip.php
+++ b/src/N98/Magento/Command/Database/Compressor/Gzip.php
@@ -59,6 +59,10 @@ class Gzip extends AbstractCompressor
      */
     public function getFileName($fileName, $pipe = true)
     {
+        if ($fileName === null) {
+            $fileName = '';
+        }
+
         if (!strlen($fileName)) {
             return $fileName;
         }


### PR DESCRIPTION
Summary: 
Added a fix when using db:dump with the gzip flag to --stout. 

Fixes #999 when using with gzip.
