### PR TITLE
Do not load config or init Magento for self-update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ RECENT CHANGES
 
 - Add: Magento 2.4.6
 - Imp: New internal proxy command to call Magento Core Commands
+- Imp: Disabled Magento and config initialization if self-update command runs  
 - Del: Support for PHP 7.3
 - Del: Remove internal test setup for Composer 1 based Magento installations
 - Fix: Initialize Magento only once which should prevent several issues with DB and config.


### PR DESCRIPTION
Magerun pull-request check-list:

- [X] Pull request against develop branch (if not, just close and create a new one against it)

Changes proposed in this pull request:

- Do not try to detect Magento root directory if self-update command should be run
- Prevent custom config loading for self-update
- Do not detect Magento version for self-update