### PR TITLE
Catch errors if command list cannot be loaded from core magento

### DIFF
--- a/src/N98/Magento/Application.php
+++ b/src/N98/Magento/Application.php
@@ -504,12 +504,22 @@ class Application extends BaseApplication
             return;
         }
 
-        $provider = new MagentoCoreCommandProvider(
-            $magentoRootFolder,
-            new MagentoCoreProxyCommandFactory()
-        );
+        try {
+            $provider = new MagentoCoreCommandProvider(
+                $magentoRootFolder,
+                new MagentoCoreProxyCommandFactory()
+            );
+            $coreCommands = $provider->getCommands();
+        } catch (\Exception $e) {
+            $output->writeln(
+                [
+                    '<error>Magento Core Commands cannot be loaded. Please verify if "bin/magento" is running.</error>',
+                    '<info>Only n98-magerun2 commands are available until the issue is fixed.</info>'
+                ]
+            );
 
-        $coreCommands = $provider->getCommands();
+            return;
+        }
 
         foreach ($coreCommands as $coreCommand) {
             if (OutputInterface::VERBOSITY_DEBUG <= $output->getVerbosity()) {

--- a/src/N98/Magento/Application/MagentoCoreCommandProvider.php
+++ b/src/N98/Magento/Application/MagentoCoreCommandProvider.php
@@ -88,6 +88,13 @@ class MagentoCoreCommandProvider
 
             $data = \json_decode($process->getOutput(), true);
 
+            // invalid JSON returned
+            if (!$data) {
+                throw new \RuntimeException(
+                    'Cannot decode the result of bin/magento'
+                );
+            }
+
             // cleanup some commands -> first entry is the help command
             $this->commandData = $this->removeCommands($data['commands'], ['help', 'list']);
         }


### PR DESCRIPTION
Magerun pull-request check-list:

- [X] Pull request against develop branch (if not, just close and create a new one against it)

Changes proposed in this pull request:

- Skip loading of core commands if their is an error in Magento but provide n98-magerun2 commands.
