### PR TITLE
Use defined PHP binary for calls to bin/magento (#1149)

### DIFF
--- a/src/N98/Magento/Command/MagentoCoreProxyCommand.php
+++ b/src/N98/Magento/Command/MagentoCoreProxyCommand.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace N98\Magento\Command;
 
 use N98\Magento\Application\Console\Input\FilteredStringInput;
+use N98\Util\OperatingSystem;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputInterface;
@@ -57,7 +58,7 @@ class MagentoCoreProxyCommand extends AbstractMagentoCommand
         $magentoCoreCommandInput = new FilteredStringInput($input->__toString());
 
         $process = Process::fromShellCommandline(
-            $this->magentoRootDir . '/bin/magento ' . $magentoCoreCommandInput->__toString(),
+            OperatingSystem::getPhpBinary() . ' ' . $this->magentoRootDir . '/bin/magento ' . $magentoCoreCommandInput->__toString(),
             $this->magentoRootDir
         );
 


### PR DESCRIPTION
Magerun pull-request check-list:

- [X] Pull request against develop branch (if not, just close and create a new one against it)

Fixes #1149

Changes proposed in this pull request:

- Use the defined PHP binary for every call to bin/magento
