### PR TITLE
Added 2 new commands to manage sales sequences

### DIFF
--- a/README.md
+++ b/README.md
@@ -1237,6 +1237,29 @@ n98-magerun2.phar admin:user:change-status [user] [--activate] [--deactivate]
 _Note: It is possible for a user to exist with a username that matches
 the email of a different user. In this case the first matched user will be changed._
 
+### Add Sales Sequences for a given store
+Create sales sequences in the database if they are missing, this will recreate profiles to.
+
+```sh
+n98-magerun2.phar sales:sequence:add [store] 
+```
+
+If store is omitted, it'll run for all stores.  
+
+_Note: It is possible a sequence already exists, in this case nothing will happen, only missing tables are created._
+
+### Remove Sales Sequences for a given store
+Remove sales sequences from the database, warning, you cannot undo this, make sure you have database backups.
+
+```sh
+n98-magerun2.phar sales:sequence:remove [store] 
+```
+
+If store is omitted, it'll run for all stores. When the option `no-interaction` is given, it will run immediately without any interaction.
+Otherwise it will remind you and ask if you know what you're doing and ask for each store you are running it on.
+
+_Note: ._
+
 ### Script Repository
 
 You can organize your scripts in a repository.

--- a/config.yaml
+++ b/config.yaml
@@ -168,6 +168,8 @@ commands:
     - N98\Magento\Command\ScriptCommand
     - N98\Magento\Command\SelfUpdateCommand
     - N98\Magento\Command\Route\ListCommand
+    - N98\Magento\Command\Sales\SequenceAddCommand
+    - N98\Magento\Command\Sales\SequenceRemoveCommand
 
   disabled:
     - dummy

--- a/src/N98/Magento/Command/Sales/SequenceAddCommand.php
+++ b/src/N98/Magento/Command/Sales/SequenceAddCommand.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace N98\Magento\Command\Sales;
+
+use Magento\Framework\Event;
+use Magento\Framework\Event\Observer;
+use N98\Magento\Command\AbstractMagentoCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class SequenceAddCommand extends AbstractMagentoCommand
+{
+
+    protected function configure()
+    {
+        $this->setName('sales:sequence:add')
+            ->setDescription('Add the sequence tables and metadata for given store or all stores')
+            ->addArgument('store', InputArgument::OPTIONAL, 'Store code');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $this->detectMagento($output);
+        if (!$this->initMagento()) {
+            return Command::FAILURE;
+        }
+
+        $storeCode = $input->getArgument('store');
+
+        $di = $this->getObjectManager();
+
+        $storeManager = $di->get('Magento\Store\Model\StoreManagerInterface');
+        $sequenceCreator = $di->get('Magento\SalesSequence\Observer\SequenceCreatorObserver');
+
+        $stores = [$storeManager->getStore($storeCode)];
+        if (!$storeCode) {
+            $stores = $storeManager->getStores();
+        }
+
+        /** @var \Magento\Store\Api\StoreInterface $store */
+        foreach ($stores as $store) {
+            $output->writeln(sprintf('<info>Updating sequence for store <comment>%s</comment> (<comment>%s #%d</comment>)</info>', $store->getName(), $store->getCode(), $store->getId()));
+
+            $event = new Event(['store' => $store]);
+            $event->setName('store_add');
+
+            $observer = new Observer([
+                'store' => $store,
+                'event' => $event
+            ]);
+
+            $sequenceCreator->execute($observer);
+        }
+
+        return self::SUCCESS;
+    }
+}

--- a/src/N98/Magento/Command/Sales/SequenceRemoveCommand.php
+++ b/src/N98/Magento/Command/Sales/SequenceRemoveCommand.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace N98\Magento\Command\Sales;
+
+use Magento\Framework\Event;
+use Magento\Framework\Event\Observer;
+use N98\Magento\Command\AbstractMagentoCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\QuestionHelper;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
+
+class SequenceRemoveCommand extends AbstractMagentoCommand
+{
+
+    protected function configure()
+    {
+        $this->setName('sales:sequence:remove')
+            ->setDescription('Remove sequence tables and metadata for given store or all stores')
+            ->addArgument('store', InputArgument::OPTIONAL, 'Store code');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $this->detectMagento($output);
+        if (!$this->initMagento()) {
+            return Command::FAILURE;
+        }
+
+        $storeCode = $input->getArgument('store');
+        $interaction = ! $input->getOption('no-interaction');
+
+        /** @var $questionHelper QuestionHelper */
+        $questionHelper = $this->getHelper('question');
+
+        if ($interaction) {
+            $question = new ConfirmationQuestion(
+                '<error>Only continue if you know what you\'re doing!</error> ' .
+                '<question>Do you know what you are doing?</question> <comment>[n]</comment>: ',
+                false
+            );
+            $shouldContinue = $questionHelper->ask(
+                $input,
+                $output,
+                $question
+            );
+
+            if (! $shouldContinue) {
+                return self::INVALID;
+            }
+        }
+
+        $di = $this->getObjectManager();
+
+        $storeManager = $di->get('Magento\Store\Model\StoreManagerInterface');
+        $sequenceRemoval = $di->get('Magento\SalesSequence\Observer\SequenceRemovalObserver');
+
+        $stores = [$storeManager->getStore($storeCode)];
+        if (!$storeCode) {
+            $stores = $storeManager->getStores();
+        }
+
+        /** @var \Magento\Store\Api\StoreInterface $store */
+        foreach ($stores as $store) {
+
+            if ($interaction) {
+                $question = new ConfirmationQuestion(
+                    sprintf(
+                        '<question>Are you sure to remove sequence for ' .
+                            '<comment>%s (%s #%d)</comment>?</question> ' .
+                            '<comment>[n]</comment>: ',
+                        $store->getName(),
+                        $store->getCode(),
+                        $store->getId()
+                    ),
+                    false
+                );
+                $shouldRemove = $questionHelper->ask(
+                    $input,
+                    $output,
+                    $question
+                );
+
+                if (! $shouldRemove) {
+                    continue;
+                }
+            }
+
+            $output->writeln(sprintf('<info>Removing sequence for store <comment>%s</comment> (<comment>%s #%d</comment>)</info>', $store->getName(), $store->getCode(), $store->getId()));
+
+            $event = new Event(['store' => $store]);
+            $event->setName('store_remove');
+
+            $observer = new Observer([
+                'store' => $store,
+                'event' => $event
+            ]);
+
+            $sequenceRemoval->execute($observer);
+        }
+
+        return self::SUCCESS;
+    }
+}


### PR DESCRIPTION
+ add sequences
+ remove sequences

somethings the store_add trigger is not always triggered for whatever reason, this makes it possible to create them.

Related Stack Overflows, issues, etcetera:
- https://magento.stackexchange.com/a/149280
- https://github.com/magento/magento2/issues/12318

Magerun pull-request check-list:

- [x] Pull request against develop branch (if not, just close and create a new one against it)
- [x] README.md reflects changes (if any)
- [ ] phar fuctional test (in tests/phar-test.sh)

Summary: (some words as summary)

Fixes # .

Changes proposed in this pull request:

- ...

- ...

- ...
