### PR TITLE
Add a way to debug errors of bin/magento

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ RECENT CHANGES
 
 - Add: New commands to manage sales sequences (by Jeroen Boersma)
 - Add: New command to redeploy base packages (by Christian Münch)
+- Imp: Add debug output if Magento Core Commands cannot be used (by Christian Münch)
 
 7.0.3
 -----

--- a/src/N98/Magento/Application.php
+++ b/src/N98/Magento/Application.php
@@ -533,9 +533,16 @@ class Application extends BaseApplication
             );
             $coreCommands = $provider->getCommands();
         } catch (\Exception $e) {
+            if (OutputInterface::VERBOSITY_DEBUG <= $output->getVerbosity()) {
+                $output->writeln(
+                    sprintf('<debug>Exception: %s</debug>', $e->getMessage())
+                );
+            }
+
             $output->writeln(
                 [
                     '<error>Magento Core Commands cannot be loaded. Please verify if "bin/magento" is running.</error>',
+                    '<info>Run with <comment>-vvv</comment> option to see the error output.</info>',
                     '<info>Only n98-magerun2 commands are available until the issue is fixed.</info>'
                 ]
             );


### PR DESCRIPTION
Also relates to #1164

Changes proposed in this pull request:

- Add debug output if `bin/magento` is broken