### PR TITLE
Allow to define the PHP version for installations in ddev

### DIFF
--- a/.ddev/commands/web/install-magento-ce
+++ b/.ddev/commands/web/install-magento-ce
@@ -11,6 +11,14 @@ fi
 
 CURRENT_DIR=$(dirname "$0")
 
+if [ -x PHP_BIN ]; then
+  PHP_BIN="php"
+fi
+
+if [ -x $TZ ]; then
+  TZ="UTC"
+fi
+
 MAGENTO_VERSION=$1
 MAGENTO_DB_NAME="magento_${MAGENTO_VERSION//[-.]/_}"
 MAGENTO_ROOT_DIR="/opt/magento-test-environments/magento_${MAGENTO_VERSION//[-.]/_}"
@@ -36,7 +44,7 @@ check_if_db_exists() {
 }
 
 install_magento() {
-	if [ -d "$MAGENTO_ROOT_DIR" ]; then
+	if [ -f "$MAGENTO_ROOT_DIR" ]; then
 		echo "Magento in $MAGENTO_ROOT_DIR already exists. Skip installation"
 		exit 0
 	fi
@@ -49,7 +57,7 @@ install_magento() {
 		check_if_db_exists
 
 		if [ ! -d $MAGENTO_ROOT_DIR ]; then
-			composer --no-interaction create-project --repository-url=https://repo.magento.com/ magento/project-community-edition="$MAGENTO_VERSION" "$MAGENTO_ROOT_DIR"
+			"$PHP_BIN" /usr/local/bin/composer --no-interaction create-project --repository-url=https://repo.magento.com/ magento/project-community-edition="$MAGENTO_VERSION" "$MAGENTO_ROOT_DIR"
 		fi
 
 		cd $MAGENTO_ROOT_DIR
@@ -60,7 +68,7 @@ install_magento() {
 
 		# build magento setup arguments
 		MAGENTO_SETUP_ARGS=(
-			"php" "bin/magento" "setup:install"
+			"$PHP_BIN" "bin/magento" "setup:install"
 			"--no-interaction"
 			"--db-host=db"
 			"--db-user=db"

--- a/.ddev/commands/web/install-magento-ce-git
+++ b/.ddev/commands/web/install-magento-ce-git
@@ -9,6 +9,14 @@ if [ $# -ne 2 ]; then
 	exit 1
 fi
 
+if [ -x PHP_BIN ]; then
+  PHP_BIN="php"
+fi
+
+if [ -x $TZ ]; then
+  TZ="UTC"
+fi
+
 CURRENT_DIR=$(dirname "$0")
 GIT_BRANCH=$1
 NORMALIZED_GIT_BRANCH=${GIT_BRANCH/[-_.\/]/-}
@@ -50,7 +58,7 @@ install_magento() {
 
 		if [ ! -d $MAGENTO_ROOT_DIR ]; then
 			git clone --branch "${GIT_BRANCH}" https://github.com/magento/magento2 $MAGENTO_ROOT_DIR
-			composer --no-interaction install
+			"$PHP_BIN" /usr/local/bin/composer --no-interaction install
 		fi
 
 		cd $MAGENTO_ROOT_DIR
@@ -61,7 +69,7 @@ install_magento() {
 
 		# build magento setup arguments
 		MAGENTO_SETUP_ARGS=(
-			"php" "bin/magento" "setup:install"
+			"$PHP_BIN" "bin/magento" "setup:install"
 			"--no-interaction"
 			"--db-host=db"
 			"--db-user=db"

--- a/.ddev/homeadditions/.bash_aliases
+++ b/.ddev/homeadditions/.bash_aliases
@@ -1,0 +1,4 @@
+# ddev command in container
+alias install-magento-ce="/mnt/ddev_config/commands/web/install-magento-ce"
+alias install-magento-ce-git="/mnt/ddev_config/commands/web/install-magento-ce-git"
+


### PR DESCRIPTION
Changes proposed in this pull request:

- Add support to define a `PHP_BIN` environment variable

Examples:

```
ddev ssh
composer self-update --1
PHP_BIN=php7.4 install-magento-ce 2.3.7 no
composer self-update 2.2.17
php7.4 bin/n98-magerun2 --root-dir=/opt/magento-test-environments/magento_2_3_7 sys:info
```
