### PR TITLE
Automatic php version and framework dependency detection

### DIFF
--- a/res/twig/dev/console/make/module/composer.json.twig
+++ b/res/twig/dev/console/make/module/composer.json.twig
@@ -6,8 +6,8 @@
         "proprietary"
     ],
     "require": {
-        "php": "7.0.2|7.0.4|~7.0.6|~7.1.0",
-        "magento/framework": "100.0.*|100.1.*|101.0.*"
+        "php": "{{ php_version }}",
+        "magento/framework": "{{ magento_framework_version }}"
     },
     "autoload": {
         "files": [
@@ -15,6 +15,6 @@
         ],
         "psr-4": {
             "{{ namespace }}\\": ""
-        }
+        }}
     }
 }

--- a/src/N98/Magento/Command/Developer/Console/MakeModuleCommand.php
+++ b/src/N98/Magento/Command/Developer/Console/MakeModuleCommand.php
@@ -11,6 +11,7 @@ use Magento\Framework\Filesystem\Directory\WriteInterface;
 use Magento\Framework\Module\ModuleListInterface;
 use Magento\Framework\Module\Status;
 use N98\Magento\Command\Developer\Console\Structure\ModuleNameStructure;
+use N98\Util\ComposerLock;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputArgument;
@@ -30,6 +31,11 @@ class MakeModuleCommand extends AbstractGeneratorCommand
      * @var string
      */
     private $modulesBaseDir;
+    /**
+     *
+     * @var ComposerLock
+     */
+    private $magentoComposerLock;
 
     protected function configure()
     {
@@ -55,6 +61,10 @@ class MakeModuleCommand extends AbstractGeneratorCommand
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        $this->magentoComposerLock = new ComposerLock(
+            $this->getMagerunApplication()->getMagentoRootFolder()
+        );
+
         $moduleName = new ModuleNameStructure($input->getArgument('modulename'));
 
         $this->modulesBaseDir = $input->getOption('modules-base-dir');
@@ -151,6 +161,8 @@ FILE_BODY;
             [
                 'vendor'    => $moduleName->getVendorName(),
                 'module'    => $moduleName->getShortModuleName(),
+                'php_version' => '~' . PHP_MAJOR_VERSION . '.' . PHP_MINOR_VERSION . '.0',
+                'magento_framework_version' => '~' . $this->magentoComposerLock->getPackageByName('magento/framework')->version,
                 'namespace' => str_replace('\\', '\\\\', $this->getModuleNamespace($moduleName->getFullModuleName())),
             ]
         );

--- a/src/N98/Magento/Command/Developer/Module/DetectComposerDependenciesCommand.php
+++ b/src/N98/Magento/Command/Developer/Module/DetectComposerDependenciesCommand.php
@@ -8,6 +8,7 @@ use Magento\Framework\Component\ComponentRegistrar;
 use Magento\Framework\Component\ComponentRegistrarInterface;
 use Magento\Framework\Filesystem\Io\File;
 use N98\Magento\Command\AbstractMagentoCommand;
+use N98\Util\ComposerLock;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -377,22 +378,8 @@ class DetectComposerDependenciesCommand extends AbstractMagentoCommand
 
     private function loadProjectComposerPackagesByLockFile(string $magentoRootPath)
     {
-        $packages = [];
-
-        $packagesConfig = json_decode(
-            \file_get_contents($magentoRootPath . '/composer.lock'),
-            false,
-            512,
-            JSON_THROW_ON_ERROR
-        );
-
-        if (isset($packagesConfig)) {
-            $packages = array_merge($packages, $packagesConfig->packages);
-        }
-
-        if (isset($packagesConfig->{'packages-dev'})) {
-            $packages = array_merge($packages, $packagesConfig->{'packages-dev'});
-        }
+        $composerLock = new ComposerLock($magentoRootPath);
+        $packages = $composerLock->getPackages();
 
         $this->localInstalledPackagesFromLockFile = [];
 

--- a/src/N98/Util/ComposerLock.php
+++ b/src/N98/Util/ComposerLock.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * @copyright Copyright (c) netz98 GmbH (https://www.netz98.de)
+ *
+ * @see PROJECT_LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace N98\Util;
+
+use Traversable;
+
+class ComposerLock implements \IteratorAggregate
+{
+    /**
+     * @var object
+     */
+    private $composerJsonData;
+
+    /**
+     * @param $directoryOfComposerFile
+     */
+    public function __construct($directoryOfComposerFile)
+    {
+        $this->directoryOfComposerFile = $directoryOfComposerFile;
+    }
+
+    private function load()
+    {
+        if (!empty($this->composerJsonData)) {
+            return;
+        }
+
+        if (file_exists($this->directoryOfComposerFile . '/composer.lock')) {
+            $this->composerJsonData = json_decode(
+                file_get_contents($this->directoryOfComposerFile . '/composer.lock'),
+                false,
+                512,
+                JSON_THROW_ON_ERROR
+            );
+        } else {
+            $this->composerJsonData = [];
+        }
+    }
+
+    public function getData()
+    {
+        $this->load();
+
+        return $this->composerJsonData;
+    }
+
+    public function getPackages(): array
+    {
+        $this->load();
+
+        $packages = [];
+
+        if (isset($this->composerJsonData->packages)) {
+            $packages = $this->composerJsonData->packages;
+        }
+
+        if (isset($packagesConfig->{'packages-dev'})) {
+            $packages = array_merge($packages, $this->composerJsonData->{'dev-packages'});
+        }
+
+        return $packages;
+    }
+
+    public function getPackageByName(string $packageName)
+    {
+        foreach ($this->getPackages() as $package) {
+            if ($package->name === $packageName) {
+                return $package;
+            }
+        }
+
+        return null;
+    }
+
+    public function getIterator(): Traversable
+    {
+        return new \ArrayIterator($this->getData());
+    }
+}

--- a/tests/N98/Util/ComposerLockTest.php
+++ b/tests/N98/Util/ComposerLockTest.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * @copyright Copyright (c) netz98 GmbH (https://www.netz98.de)
+ *
+ * @see PROJECT_LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace N98\Util;
+
+class ComposerLockTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @test
+     * @return void
+     */
+    public function itShouldBeIteratable()
+    {
+        $lock = new ComposerLock(__DIR__ . '/_files/sample-project/composer');
+        $this->assertIsIterable($lock);
+    }
+
+    /**
+     * @test
+     * @return void
+     */
+    public function itShouldReturnPackages()
+    {
+        $lock = new ComposerLock(__DIR__ . '/_files/sample-project/composer');
+        $this->assertIsArray($lock->getPackages());
+
+        $this->assertEquals('1.1.1', $lock->getPackageByName('psr/container')->version);
+    }
+
+}


### PR DESCRIPTION
Introduces a abstraction to read data of composer.lock. Use current php version and actual installed version of magento/framework as version of dependencies for new generated module.

Magerun pull-request check-list:

- [X] Pull request against develop branch (if not, just close and create a new one against it)
- [X] README.md reflects changes (if any)
- [X] phar fuctional test (in tests/phar-test.sh)

Changes proposed in this pull request:

- Introduce new ComposerLock abstraction
- Use ComposerLock in dependency check command
- Process new variables in twig templates of make:module dev console command
