### PR TITLE
Add `Updated At` to `config:store:get` output

### DIFF
--- a/src/N98/Magento/Command/Config/Store/GetCommand.php
+++ b/src/N98/Magento/Command/Config/Store/GetCommand.php
@@ -142,6 +142,7 @@ HELP;
                     $item->getValue(),
                     $input->getOption('decrypt') ? 'decrypt' : ''
                 ),
+                'updated_at' => $item->getUpdatedAt()
             ];
         }
 
@@ -172,13 +173,14 @@ HELP;
                 $row['scope'],
                 $row['scope_id'],
                 $this->renderTableValue($row['value'], $format),
+                $row['updated_at']
             ];
         }
 
         /* @var $tableHelper \N98\Util\Console\Helper\TableHelper */
         $tableHelper = $this->getHelper('table');
         $tableHelper
-            ->setHeaders(['Path', 'Scope', 'Scope-ID', 'Value'])
+            ->setHeaders(['Path', 'Scope', 'Scope-ID', 'Value', 'Updated At'])
             ->setRows($formattedTable)
             ->renderByFormat($output, $formattedTable, $format);
     }

--- a/tests/N98/Magento/Command/Config/Store/GetCommandTest.php
+++ b/tests/N98/Magento/Command/Config/Store/GetCommandTest.php
@@ -140,7 +140,7 @@ class GetCommandTest extends TestCase
             'path'     => 'n98_magerun/foo/bar',
             '--format' => 'csv',
         ];
-        $this->assertDisplayContains($input, 'Path,Scope,Scope-ID,Value');
+        $this->assertDisplayContains($input, 'Path,Scope,Scope-ID,Value,Updated At');
         $this->assertDisplayContains($input, 'n98_magerun/foo/bar,default,0,1234');
 
         /**


### PR DESCRIPTION
I find this useful to see straight away when looking at the config

```
$ ./bin/n98-magerun2 --root-dir=/Users/lukerodgers/src/project config:store:get 'tax/cart_display/zero_tax'
+---------------------------+---------+----------+-------+---------------------+
| Path                      | Scope   | Scope-ID | Value | Updated At          |
+---------------------------+---------+----------+-------+---------------------+
| tax/cart_display/zero_tax | default | 0        | 1     | 2022-03-03 09:01:59 |
| tax/cart_display/zero_tax | stores  | 1        | 0     | 2022-03-03 19:10:12 |
| tax/cart_display/zero_tax | stores  | 5        | 0     | 2022-03-03 19:10:26 |
| tax/cart_display/zero_tax | stores  | 8        | 0     | 2022-03-03 19:10:20 |
| tax/cart_display/zero_tax | stores  | 9        | 0     | 2022-03-03 19:10:15 |
+---------------------------+---------+----------+-------+---------------------+
```

Magerun pull-request check-list:

- [x] Pull request against develop branch (if not, just close and create a new one against it)
- [x] README.md reflects changes (if any)
- [ ] phar fuctional test (in tests/phar-test.sh)
