### PR TITLE
Make errors visisble in generation:flush command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ RECENT CHANGES
 - Imp: #1179: New github:pr command (by Christian Münch)
 - Imp: #1182: Add debug output if Magento Core Commands cannot be used (by Christian Münch)
 - Imp: #1185: Do less compatibility checks (by Christian Münch)
+- Imp: Print an error if generation:flush command cannot delete a directory (by Christian Münch)
 - Imp: Update 3rd party dependencies (php-cs-fixer, psysh, phpstan, phpunit, requests, symfony)
 
 7.0.3

--- a/src/N98/Magento/Command/Generation/FlushCommand.php
+++ b/src/N98/Magento/Command/Generation/FlushCommand.php
@@ -59,8 +59,11 @@ class FlushCommand extends AbstractMagentoCommand
             }
 
             /* @var $directory \Symfony\Component\Finder\SplFileInfo */
-            $filesystem->recursiveRemoveDirectory($directory->getPathname());
-            $output->writeln('<info>Removed <comment>' . $directory->getBasename() . '</comment> folder</info>');
+            if ($filesystem->recursiveRemoveDirectory($directory->getPathname())) {
+                $output->writeln('<info>Removed <comment>' . $directory->getBasename() . '</comment> folder</info>');
+            } else {
+                $output->writeln('<error>Failed to remove <comment>' . $directory->getBasename() . '</comment> folder</error>');
+            }
         }
 
         return Command::SUCCESS;


### PR DESCRIPTION
Magerun pull-request check-list:

- [X] Pull request against develop branch (if not, just close and create a new one against it)

Changes proposed in this pull request:

- Check return status of `\N98\Util\Filesystem::recursiveRemoveDirectory`
- Print error message if directory cannot be removed