### PR TITLE
Fix not correct routes for route:list command

### DIFF
--- a/src/N98/Magento/Command/Route/ListCommand.php
+++ b/src/N98/Magento/Command/Route/ListCommand.php
@@ -142,6 +142,7 @@ class ListCommand extends AbstractMagentoCommand
 
                         if (isset($moduleActions[$module][$area])) {
                             foreach ($moduleActions[$module][$area] as $action) {
+                                $action = preg_replace('/_([^_]*)$/', '/$1', str_replace('/', '_', $action));
                                 $moduleRouteAction = $moduleRoute;
                                 $moduleRouteAction[] = $route['frontName'] . '/' . $action;
 


### PR DESCRIPTION
Magerun pull-request check-list:

- [x ] Pull request against develop branch (if not, just close and create a new one against it)
- [ ] README.md reflects changes (if any)
- [ ] phar fuctional test (in tests/phar-test.sh)

Summary: fix not correct routes for route:list command

Fixes #1258 

Changes proposed in this pull request:

- route changed from `multishipping/checkout/address/editaddress` to `multishipping/checkout_address/editaddress`

