### PR TITLE
Fix short options registration of core commanda (#1295)

### DIFF
--- a/src/N98/Magento/Command/MagentoCoreProxyCommand.php
+++ b/src/N98/Magento/Command/MagentoCoreProxyCommand.php
@@ -144,7 +144,7 @@ class MagentoCoreProxyCommand extends AbstractMagentoCommand
         foreach ($options as $option) {
             // remove "--" at start
             $normalizedName = substr($option['name'], 2);
-            $normalizedShortcut = substr($option['name'], 1);
+            $normalizedShortcut = substr($option['shortcut'], 1);
 
             if (
                 in_array(


### PR DESCRIPTION
Magerun pull-request check-list:

- [x] Pull request against develop branch (if not, just close and create a new one against it)

Related to #1295

Changes proposed in this pull request:

- Register the right shortcut of core commands instead of the option name