### PR TITLE
Use phar file path as fallback

### DIFF
--- a/src/N98/Magento/Application/MagentoDetector.php
+++ b/src/N98/Magento/Application/MagentoDetector.php
@@ -51,7 +51,15 @@ class MagentoDetector
         /* @var $magentoHelper MagentoHelper */
         $magentoHelper = $helperSet->get('magento');
 
-        return new DetectionResult($magentoHelper, $folder, $subFolders); // @TODO must be refactored
+        $result = new DetectionResult($magentoHelper, $folder, $subFolders);
+        if ($result->isDetected()) {
+            return $result;
+        }
+
+        // try to detect magento at the location of n98-magerun2.phar
+        $folder = $this->resolveRootDirOption(dirname($_SERVER['argv'][0]));
+
+        return new DetectionResult($magentoHelper, $folder, $subFolders);
     }
 
     /**


### PR DESCRIPTION
If no root dir could be detected, try to use
the current directory of the phar file instead.

Magerun pull-request check-list:

- [x] Pull request against develop branch (if not, just close and create a new one against it)
- [ ] README.md reflects changes (if any)
- [ ] phar fuctional test (in tests/phar-test.sh)

Summary: Added additional check for root directory as fallback in `\N98\Magento\Application\MagentoDetector` class.

Related to #1305

Has to be tested very good.