### PR TITLE
Add mage-os 1.0.0 to build and config

### DIFF
--- a/.github/workflows/magento_platform_tests.yml
+++ b/.github/workflows/magento_platform_tests.yml
@@ -51,7 +51,7 @@ jobs:
           #  git-repository: https://github.com/magento/magento2.git
           #  git-branch: 2.4-develop
 
-          - magento-version: mage-os-2.4.5-p1
+          - magento-version: mage-os-1.0.0
             operating-system: ubuntu-latest
             php-version: '8.1'
             mysql-version: '8.0'
@@ -60,7 +60,16 @@ jobs:
             use-git-repository: false
             git-repository: ""
 
-          - magento-version: mage-os-2.4.3-p1
+          - magento-version: mage-os-magento-mirror-2.4.5-p1
+            operating-system: ubuntu-latest
+            php-version: '8.1'
+            mysql-version: '8.0'
+            elasticsearch-version: '7.9.0'
+            composer-version: '2.2.17'
+            use-git-repository: false
+            git-repository: ""
+
+          - magento-version: mage-os-magento-mirror-2.4.3-p1
             operating-system: ubuntu-latest
             php-version: '7.4'
             mysql-version: '8.0'

--- a/config.yaml
+++ b/config.yaml
@@ -354,42 +354,47 @@ commands:
 
   N98\Magento\Command\Installer\InstallCommand:
     magento-packages:
-      - name: mage-os-2.4.5-p1
+      - name: mage-os-1.0.0
+        package: mage-os/project-community-edition
+        version: 1.0.0
+        options:
+          repository-url: https://repo.mage-os.org
+      - name: mage-os-magento-mirror-2.4.5-p1
         package: magento/project-community-edition
         version: 2.4.5-p1
         options:
           repository-url: https://mirror.mage-os.org
-      - name: mage-os-2.4.5
+      - name: mage-os-magento-mirror-2.4.5
         package: magento/project-community-edition
         version: 2.4.5
         options:
           repository-url: https://mirror.mage-os.org
-      - name: mage-os-2.4.4-p2
+      - name: mage-os-magento-mirror-2.4.4-p2
         package: magento/project-community-edition
         version: 2.4.4-p2
         options:
           repository-url: https://mirror.mage-os.org
-      - name: mage-os-2.4.4-p1
+      - name: mage-os-magento-mirror-2.4.4-p1
         package: magento/project-community-edition
         version: 2.4.4-p1
         options:
           repository-url: https://mirror.mage-os.org
-      - name: mage-os-2.4.4
+      - name: mage-os-magento-mirror-2.4.4
         package: magento/project-community-edition
         version: 2.4.4
         options:
           repository-url: https://mirror.mage-os.org
-      - name: mage-os-2.4.3-p1
+      - name: mage-os-magento-mirror-2.4.3-p1
         package: magento/project-community-edition
         version: 2.4.3-p1
         options:
           repository-url: https://mirror.mage-os.org
-      - name: mage-os-2.4.3-p2
+      - name: mage-os-magento-mirror-2.4.3-p2
         package: magento/project-community-edition
         version: 2.4.3-p2
         options:
           repository-url: https://mirror.mage-os.org
-      - name: mage-os-2.4.3-p3
+      - name: mage-os-magento-mirror-2.4.3-p3
         package: magento/project-community-edition
         version: 2.4.3-p3
         options:


### PR DESCRIPTION
Magerun pull-request check-list:

- [x] Pull request against develop branch (if not, just close and create a new one against it)

Changes proposed in this pull request:

- Rename old mage-os config entries and prefix them with "mageos-magento-mirror" to distinguish between the mage-os release and the Magento mirror.

- Add Mage-OS 1.0.0 release to installer
- - Add Mage-OS 1.0.0 release regular platform check
