### PR TITLE
Write errors of proxy command to stderr

### DIFF
--- a/src/N98/Magento/Command/MagentoCoreProxyCommand.php
+++ b/src/N98/Magento/Command/MagentoCoreProxyCommand.php
@@ -15,6 +15,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\ConsoleOutputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Process\Process;
 
@@ -86,8 +87,14 @@ class MagentoCoreProxyCommand extends AbstractMagentoCommand
             $output->writeln(sprintf('<debug>  - TTY: <comment>%b</comment></debug>', $process->isTty()));
         }
 
-        $process->run(function ($type, $buffer) use ($output) {
-            $output->write($buffer);
+        $errOutput = $output instanceof ConsoleOutputInterface ? $output->getErrorOutput() : $output;
+
+        $process->run(function ($type, $buffer) use ($output, $errOutput) {
+            if (Process::ERR === $type) {
+                $errOutput->write($buffer);
+            } else {
+                $output->write($buffer);
+            }
         });
 
         return $process->getExitCode();


### PR DESCRIPTION
Magerun pull-request check-list:

- [x] Pull request against develop branch (if not, just close and create a new one against it)

Changes proposed in this pull request:

If a Magento Core command is started by a proxy command in n98-magerun2 we did not respect the stdout/stderr.
The PR mirrors the stdout and stderr.