### PR TITLE
Try own GPG key after the import

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -68,6 +68,7 @@ jobs:
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.GPG_PASSPHRASE }}
+          trust_level: 5
 
       - name: GPG sign phar file (detached)
         run: |


### PR DESCRIPTION
We should trust our own key in the deployment process.