### PR TITLE
Make SQL definer replacement optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -783,6 +783,7 @@ Options:
 | `--git-friendly`           | Use one insert statement, but with line breaks instead of separate insert statements.      |
 | `--human-readable`         | Use a single insert with column names per row.                                             |
 | `--include`                | Tables to include entirely to the dump (default: all tables are included)                  |
+| `--keep-definer`           | Do not replace DEFINER in dump with CURRENT_USER                                           |
 | `--keep-column-statistics` | Retains `column statistics` table in `mysqldump`                                           |
 | `--no-single-transaction`  | Do not use single-transaction (not recommended, this is blocking)                          |
 | `--no-tablespaces`         | Use this option if you want to create a dump without having the PROCESS privilege.         |

--- a/src/N98/Magento/Command/Database/DumpCommand.php
+++ b/src/N98/Magento/Command/Database/DumpCommand.php
@@ -147,7 +147,7 @@ class DumpCommand extends AbstractDatabaseCommand
                 'keep-definer',
                 null,
                 InputOption::VALUE_NONE,
-                'Do not remove DEFINER from dump'
+                'Do not replace DEFINER in dump with CURRENT_USER'
             )
             ->setDescription('Dumps database with mysqldump cli client');
 


### PR DESCRIPTION
Magerun pull-request check-list:

- [X] Pull request against develop branch (if not, just close and create a new one against it)
- [X] README.md reflects changes (if any)
- [ ] phar fuctional test (in tests/phar-test.sh)

Summary: 
Even when magerun db dump command is executed with _--only-command_ option a piped definer replacement is added to its output. In some scenarios it is a bit not intuitive or undesirable, e.g. when dump is imported on the same database or _--only-command_ output is further processed in separate script. 

Changes proposed in this pull request:

- Added flag _keep-definer_ to allow a pure mysql command to be outputted or executed. 
