### PR TITLE
The delete option should work only without filters (#1359)

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -12,7 +12,7 @@ return (new PhpCsFixer\Config())
         'array_syntax' => ['syntax' => 'short'],
         'concat_space' => ['spacing' => 'one'],
         'include' => true,
-        'new_with_braces' => true,
+        'new_with_parentheses' => true,
         'no_empty_statement' => true,
         'no_extra_blank_lines' => true,
         'no_leading_import_slash' => true,

--- a/src/N98/Magento/Command/Customer/DeleteCommand.php
+++ b/src/N98/Magento/Command/Customer/DeleteCommand.php
@@ -323,11 +323,12 @@ class DeleteCommand extends AbstractCustomerCommand
      * @param OutputInterface $output
      * @return int
      */
-    protected function deleteAllCustomers($force, QuestionHelper $questionHelper, InputInterface $input, OutputInterface $output): int
-    {
-// check if force is set
-        // if not, ask for confirmation
-
+    protected function deleteAllCustomers(
+        $force,
+        QuestionHelper $questionHelper,
+        InputInterface $input,
+        OutputInterface $output
+    ): int {
         if (!$force) {
             $question = new ConfirmationQuestion(
                 '<question>WARNING: You are about to delete ALL customers. Are you sure?</question> <comment>[n]</comment>: ',


### PR DESCRIPTION
Currently the delete option is confusing and has to be combined with a filter.
If someone wants to delete all customers we do not need any filter.

Magerun pull-request check-list:

- [X] Pull request against develop branch (if not, just close and create a new one against it)
- [ ] README.md reflects changes (if any)
- [ ] phar fuctional test (in tests/phar-test.sh)

Related to: #1359

Refactoring of  `customer:delete` command.

Changes proposed in this pull request:

- Allow to specify the `--all` option without any filter option.
- Combine the `--all` flag with `--force` flag.
- Remove `--all` check in filters