### PR TITLE
Escape shell command before processing by Symfony StringInput (#1396)

### DIFF
--- a/src/N98/Magento/Command/MagentoCoreProxyCommand.php
+++ b/src/N98/Magento/Command/MagentoCoreProxyCommand.php
@@ -56,7 +56,7 @@ class MagentoCoreProxyCommand extends AbstractMagentoCommand
     {
         $config = $this->getCommandConfig();
 
-        $magentoCoreCommandInput = new FilteredStringInput($input->__toString());
+        $magentoCoreCommandInput = new FilteredStringInput(escapeshellcmd($input->__toString()));
         $envVariablesForBinMagento = $_ENV;
 
         if ($config['is_env_variables_filtering_enabled'] === true) {


### PR DESCRIPTION
Magerun pull-request check-list:

- [x] Pull request against develop branch (if not, just close and create a new one against it)

Related to #1397


hanges proposed in this pull request:

Add additional `escapeshellcmd` before the Symfony StringInput removes the quotes
