### PR TITLE
Quotes all arguments used by MagentoCoreProxyCommand (#1406)

### DIFF
--- a/src/N98/Magento/Command/MagentoCoreProxyCommand.php
+++ b/src/N98/Magento/Command/MagentoCoreProxyCommand.php
@@ -72,8 +72,13 @@ class MagentoCoreProxyCommand extends AbstractMagentoCommand
             );
         }
 
+        $shellCommand = escapeshellarg(OperatingSystem::getPhpBinary())
+                      . ' '
+                      . escapeshellarg($this->magentoRootDir . '/bin/magento')
+                      . ' '
+                      . $magentoCoreCommandInput->__toString();
         $process = Process::fromShellCommandline(
-            OperatingSystem::getPhpBinary() . ' ' . $this->magentoRootDir . '/bin/magento ' . $magentoCoreCommandInput->__toString(),
+            $shellCommand,
             $this->magentoRootDir,
             $envVariablesForBinMagento
         );


### PR DESCRIPTION
The PHP binary path can contain spaces which cause issues.

Magerun pull-request check-list:

- [X] Pull request against develop branch (if not, just close and create a new one against it)

Related to #1406 

Changes proposed in this pull request:

Modify MagentoCoreProxyCommand and use the PHP function `escapeshellarg` to quote the path to
the PHP binary and bin/magento.
The following arguments should already be quoted by the Symfony command logic.