### PR TITLE
Bugfix/1414 customer create area code already set fix

### DIFF
--- a/tests/bats/functional_magerun_commands.bats
+++ b/tests/bats/functional_magerun_commands.bats
@@ -28,6 +28,24 @@ function cleanup_files_in_magento() {
   rm -Rf "${N98_MAGERUN2_TEST_MAGENTO_ROOT:?}/$1"
 }
 
+@test "Issue: 1414" {
+  tempfilename=$(mktemp)
+  # Generate random numbers for email uniqueness
+  random1=$((RANDOM % 1000))
+  random2=$((RANDOM % 1000))
+
+  # Use the random numbers to create unique email addresses
+  email1="customer${random1}@example.com"
+  email2="customer${random2}@example.com"
+
+  # Use the unique email addresses in the script command
+  printf "customer:create ${email1} Password1234# Foo Bar 1\ncustomer:create ${email2} Password1234# Foo Bar" > $tempfilename
+  run $BIN script $tempfilename
+  assert_output --partial "successfully created"
+  assert [ "$status" -eq 0 ]
+}
+
+
 @test "Command: admin:user:list" {
 	run $BIN "admin:user:list"
 	assert_output --partial "username"


### PR DESCRIPTION
Magerun pull-request check-list:

- [x] Pull request against develop branch (if not, just close and create a new one against it)
- [x] phar fuctional test (in tests/phar-test.sh)

Possible fix for #1414

Changes proposed in this pull request:

Catch "area code already set" exception (only this one) and ignore it.
I was not able to find a better solution.
Added a functional test to prevent regression.