### PR TITLE
Add new Magento versions to installer and test setup

### DIFF
--- a/.github/workflows/magento_platform_tests.yml
+++ b/.github/workflows/magento_platform_tests.yml
@@ -78,7 +78,17 @@ jobs:
             use-git-repository: false
             git-repository: ""
 
-          - magento-version: magento-ce-2.4.6-p2
+          - magento-version: magento-ce-2.4.6-p4
+            operating-system: ubuntu-latest
+            php-version: '8.2'
+            mysql-version: '8.0'
+            elasticsearch-version: 7.16.0
+            composer-version: '2.2.17'
+            use-git-repository: false
+            git-repository: ""
+            git-branch: ""
+
+          - magento-version: magento-ce-2.4.6-p4
             operating-system: ubuntu-latest
             php-version: '8.1'
             mysql-version: '8.0'
@@ -88,7 +98,7 @@ jobs:
             git-repository: ""
             git-branch: ""
 
-          - magento-version: magento-ce-2.4.5-p1
+          - magento-version: magento-ce-2.4.5-p6
             operating-system: ubuntu-latest
             php-version: '8.1'
             mysql-version: '8.0'

--- a/config.yaml
+++ b/config.yaml
@@ -406,6 +406,11 @@ commands:
         version: 2.4.3-p3
         options:
           repository-url: https://mirror.mage-os.org
+      - name: magento-ce-2.4.6-p4
+        package: magento/project-community-edition
+        version: 2.4.6-p4
+        options:
+          repository-url: https://repo.magento.com
       - name: magento-ce-2.4.6-p2
         package: magento/project-community-edition
         version: 2.4.6-p2
@@ -426,9 +431,19 @@ commands:
         version: 2.4.5-p1
         options:
           repository-url: https://repo.magento.com
+      - name: magento-ce-2.4.5-p6
+        package: magento/project-community-edition
+        version: 2.4.5-p6
+        options:
+          repository-url: https://repo.magento.com
       - name: magento-ce-2.4.5
         package: magento/project-community-edition
         version: 2.4.5
+        options:
+          repository-url: https://repo.magento.com
+      - name: magento-ce-2.4.4-p7
+        package: magento/project-community-edition
+        version: 2.4.4-p7
         options:
           repository-url: https://repo.magento.com
       - name: magento-ce-2.4.4-p2


### PR DESCRIPTION
Magerun pull-request check-list:

- [x] Pull request against develop branch (if not, just close and create a new one against it)
- [ ] README.md reflects changes (if any)
- [ ] phar fuctional test (in tests/phar-test.sh)

Changes proposed in this pull request:

- Add Magento 2.4.6-p4 and 2.4.5-p6 to installer
- Add PHP 8.2 test setup