### PR TITLE
Change netz98 to valantic CEC

### DIFF
--- a/MIT-LICENSE.txt
+++ b/MIT-LICENSE.txt
@@ -1,6 +1,6 @@
-Copyright (c) 2012 netz98 new media GmbH
+Copyright (c) 2024 valantic CEC Deutschland GmbH
 
-http://www.netz98.de
+https://www.valantic.com
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ The base-installation is now complete and you can verify it:
 The command should execute successfully and show you the version number
 of N98-Magerun like:
 
-`n98-magerun2 version 4.8.0 by netz98 GmbH`
+`n98-magerun2 version 4.8.0 by valantic CEC`
 
 You now have successfully installed Magerun! You can tailor the
 installation further like installing it system-wide and enable

--- a/src/N98/Magento/Api/ModuleListIterator.php
+++ b/src/N98/Magento/Api/ModuleListIterator.php
@@ -1,7 +1,6 @@
 <?php
 /*
  * @author Tom Klingenberg <t.klingenberg@netz98.de>
- * @copyright Copyright (c) 2016 netz98 new media GmbH (http://www.netz98.de)
  *
  * @see PROJECT_LICENSE.txt
  */

--- a/src/N98/Magento/Api/ModuleListVersionIterator.php
+++ b/src/N98/Magento/Api/ModuleListVersionIterator.php
@@ -1,9 +1,6 @@
 <?php
 /*
  * @author Tom Klingenberg <t.klingenberg@netz98.de>
- * @copyright Copyright (c) 2016 netz98 new media GmbH (http://www.netz98.de)
- *
- * @see PROJECT_LICENSE.txt
  */
 
 namespace N98\Magento\Api;

--- a/src/N98/Magento/Api/ModuleVersion.php
+++ b/src/N98/Magento/Api/ModuleVersion.php
@@ -1,7 +1,6 @@
 <?php
 /*
  * @author Tom Klingenberg <t.klingenberg@netz98.de>
- * @copyright Copyright (c) 2016 netz98 new media GmbH (http://www.netz98.de)
  *
  * @see PROJECT_LICENSE.txt
  */

--- a/src/N98/Magento/Application.php
+++ b/src/N98/Magento/Application.php
@@ -183,7 +183,7 @@ class Application extends BaseApplication
 
     public function getLongVersion()
     {
-        return parent::getLongVersion() . ' (commit: @git_commit_short@) by <info>netz98 GmbH</info>';
+        return parent::getLongVersion() . ' (commit: @git_commit_short@) by <info>valantic CEC</info>';
     }
 
     /**

--- a/src/N98/Magento/Application/AutoloaderDecorator.php
+++ b/src/N98/Magento/Application/AutoloaderDecorator.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * @copyright Copyright (c) 1999-2017 netz98 GmbH (http://www.netz98.de)
- *
- * @see PROJECT_LICENSE.txt
- */
 
 namespace N98\Magento\Application;
 

--- a/src/N98/Magento/Application/Console/Input/FilteredStringInput.php
+++ b/src/N98/Magento/Application/Console/Input/FilteredStringInput.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * @copyright Copyright (c) netz98 GmbH (https://www.netz98.de)
- *
- * @see PROJECT_LICENSE.txt
- */
 
 declare(strict_types=1);
 

--- a/src/N98/Magento/Application/MagentoCoreCommandProvider.php
+++ b/src/N98/Magento/Application/MagentoCoreCommandProvider.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * @copyright Copyright (c) netz98 GmbH (https://www.netz98.de)
- *
- * @see PROJECT_LICENSE.txt
- */
 
 declare(strict_types=1);
 

--- a/src/N98/Magento/Command/Composer/MagentoComposer.php
+++ b/src/N98/Magento/Command/Composer/MagentoComposer.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * @copyright Copyright (c) netz98 GmbH (https://www.netz98.de)
- *
- * @see PROJECT_LICENSE.txt
- */
 
 declare(strict_types=1);
 

--- a/src/N98/Magento/Command/Composer/RedeployBasePackagesCommand.php
+++ b/src/N98/Magento/Command/Composer/RedeployBasePackagesCommand.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * @copyright Copyright (c) netz98 GmbH (https://www.netz98.de)
- *
- * @see PROJECT_LICENSE.txt
- */
 
 declare(strict_types=1);
 

--- a/src/N98/Magento/Command/Config/SearchCommand.php
+++ b/src/N98/Magento/Command/Config/SearchCommand.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * @copyright Copyright (c) netz98 GmbH (https://www.netz98.de)
- *
- * @see PROJECT_LICENSE.txt
- */
 
 declare(strict_types=1);
 

--- a/src/N98/Magento/Command/Developer/Console/Config/AbstractSimpleConfigFileGeneratorCommand.php
+++ b/src/N98/Magento/Command/Developer/Console/Config/AbstractSimpleConfigFileGeneratorCommand.php
@@ -1,18 +1,4 @@
 <?php
-/**
- * netz98 magento module
- *
- * LICENSE
- *
- * This source file is subject of netz98.
- * You may be not allowed to change the sources
- * without authorization of netz98 new media GmbH.
- *
- * @copyright  Copyright (c) 1999-2016 netz98 new media GmbH (http://www.netz98.de)
- * @author netz98 new media GmbH <info@netz98.de>
- * @category N98
- * @package N98\Magento\Command\Developer\Console
- */
 
 namespace N98\Magento\Command\Developer\Console\Config;
 

--- a/src/N98/Magento/Command/Developer/Console/Config/MakeConfigCrontabCommand.php
+++ b/src/N98/Magento/Command/Developer/Console/Config/MakeConfigCrontabCommand.php
@@ -1,18 +1,4 @@
 <?php
-/**
- * netz98 magento module
- *
- * LICENSE
- *
- * This source file is subject of netz98.
- * You may be not allowed to change the sources
- * without authorization of netz98 new media GmbH.
- *
- * @copyright  Copyright (c) 1999-2016 netz98 new media GmbH (http://www.netz98.de)
- * @author netz98 new media GmbH <info@netz98.de>
- * @category N98
- * @package N98\Magento\Command\Developer\Console
- */
 
 namespace N98\Magento\Command\Developer\Console\Config;
 

--- a/src/N98/Magento/Command/Developer/Console/Config/MakeConfigDiCommand.php
+++ b/src/N98/Magento/Command/Developer/Console/Config/MakeConfigDiCommand.php
@@ -1,18 +1,4 @@
 <?php
-/**
- * netz98 magento module
- *
- * LICENSE
- *
- * This source file is subject of netz98.
- * You may be not allowed to change the sources
- * without authorization of netz98 new media GmbH.
- *
- * @copyright  Copyright (c) 1999-2016 netz98 new media GmbH (http://www.netz98.de)
- * @author netz98 new media GmbH <info@netz98.de>
- * @category N98
- * @package N98\Magento\Command\Developer\Console
- */
 
 namespace N98\Magento\Command\Developer\Console\Config;
 

--- a/src/N98/Magento/Command/Developer/Console/Config/MakeConfigEventsCommand.php
+++ b/src/N98/Magento/Command/Developer/Console/Config/MakeConfigEventsCommand.php
@@ -1,18 +1,4 @@
 <?php
-/**
- * netz98 magento module
- *
- * LICENSE
- *
- * This source file is subject of netz98.
- * You may be not allowed to change the sources
- * without authorization of netz98 new media GmbH.
- *
- * @copyright  Copyright (c) 1999-2016 netz98 new media GmbH (http://www.netz98.de)
- * @author netz98 new media GmbH <info@netz98.de>
- * @category N98
- * @package N98\Magento\Command\Developer\Console
- */
 
 namespace N98\Magento\Command\Developer\Console\Config;
 

--- a/src/N98/Magento/Command/Developer/Console/Config/MakeConfigFieldsetCommand.php
+++ b/src/N98/Magento/Command/Developer/Console/Config/MakeConfigFieldsetCommand.php
@@ -1,18 +1,4 @@
 <?php
-/**
- * netz98 magento module
- *
- * LICENSE
- *
- * This source file is subject of netz98.
- * You may be not allowed to change the sources
- * without authorization of netz98 new media GmbH.
- *
- * @copyright  Copyright (c) 1999-2016 netz98 new media GmbH (http://www.netz98.de)
- * @author netz98 new media GmbH <info@netz98.de>
- * @category N98
- * @package N98\Magento\Command\Developer\Console
- */
 
 namespace N98\Magento\Command\Developer\Console\Config;
 

--- a/src/N98/Magento/Command/Developer/Console/Config/MakeConfigMenuCommand.php
+++ b/src/N98/Magento/Command/Developer/Console/Config/MakeConfigMenuCommand.php
@@ -1,18 +1,4 @@
 <?php
-/**
- * netz98 magento module
- *
- * LICENSE
- *
- * This source file is subject of netz98.
- * You may be not allowed to change the sources
- * without authorization of netz98 new media GmbH.
- *
- * @copyright  Copyright (c) 1999-2016 netz98 new media GmbH (http://www.netz98.de)
- * @author netz98 new media GmbH <info@netz98.de>
- * @category N98
- * @package N98\Magento\Command\Developer\Console
- */
 
 namespace N98\Magento\Command\Developer\Console\Config;
 

--- a/src/N98/Magento/Command/Developer/Console/Config/MakeConfigRoutesCommand.php
+++ b/src/N98/Magento/Command/Developer/Console/Config/MakeConfigRoutesCommand.php
@@ -1,18 +1,4 @@
 <?php
-/**
- * netz98 magento module
- *
- * LICENSE
- *
- * This source file is subject of netz98.
- * You may be not allowed to change the sources
- * without authorization of netz98 new media GmbH.
- *
- * @copyright  Copyright (c) 1999-2016 netz98 new media GmbH (http://www.netz98.de)
- * @author netz98 new media GmbH <info@netz98.de>
- * @category N98
- * @package N98\Magento\Command\Developer\Console
- */
 
 namespace N98\Magento\Command\Developer\Console\Config;
 

--- a/src/N98/Magento/Command/Developer/Console/Config/MakeConfigSystemCommand.php
+++ b/src/N98/Magento/Command/Developer/Console/Config/MakeConfigSystemCommand.php
@@ -1,18 +1,4 @@
 <?php
-/**
- * netz98 magento module
- *
- * LICENSE
- *
- * This source file is subject of netz98.
- * You may be not allowed to change the sources
- * without authorization of netz98 new media GmbH.
- *
- * @copyright  Copyright (c) 1999-2016 netz98 new media GmbH (http://www.netz98.de)
- * @author netz98 new media GmbH <info@netz98.de>
- * @category N98
- * @package N98\Magento\Command\Developer\Console
- */
 
 namespace N98\Magento\Command\Developer\Console\Config;
 

--- a/src/N98/Magento/Command/Developer/Console/Config/MakeConfigWebapiCommand.php
+++ b/src/N98/Magento/Command/Developer/Console/Config/MakeConfigWebapiCommand.php
@@ -1,18 +1,4 @@
 <?php
-/**
- * netz98 magento module
- *
- * LICENSE
- *
- * This source file is subject of netz98.
- * You may be not allowed to change the sources
- * without authorization of netz98 new media GmbH.
- *
- * @copyright  Copyright (c) 1999-2016 netz98 new media GmbH (http://www.netz98.de)
- * @author netz98 new media GmbH <info@netz98.de>
- * @category N98
- * @package N98\Magento\Command\Developer\Console
- */
 
 namespace N98\Magento\Command\Developer\Console\Config;
 

--- a/src/N98/Magento/Command/Developer/Console/Config/MakeConfigWidgetCommand.php
+++ b/src/N98/Magento/Command/Developer/Console/Config/MakeConfigWidgetCommand.php
@@ -1,18 +1,4 @@
 <?php
-/**
- * netz98 magento module
- *
- * LICENSE
- *
- * This source file is subject of netz98.
- * You may be not allowed to change the sources
- * without authorization of netz98 new media GmbH.
- *
- * @copyright  Copyright (c) 1999-2016 netz98 new media GmbH (http://www.netz98.de)
- * @author netz98 new media GmbH <info@netz98.de>
- * @category N98
- * @package N98\Magento\Command\Developer\Console
- */
 
 namespace N98\Magento\Command\Developer\Console\Config;
 

--- a/src/N98/Magento/Command/Developer/Console/MakeThemeCommand.php
+++ b/src/N98/Magento/Command/Developer/Console/MakeThemeCommand.php
@@ -1,8 +1,4 @@
 <?php
-/**
- * Copyright © 2016 netz98 new media GmbH. All rights reserved.
- * See COPYING.txt for license details.
- */
 
 namespace N98\Magento\Command\Developer\Console;
 

--- a/src/N98/Magento/Command/Developer/Console/Renderer/PHPCode/PHPCodeRendererInterface.php
+++ b/src/N98/Magento/Command/Developer/Console/Renderer/PHPCode/PHPCodeRendererInterface.php
@@ -1,8 +1,4 @@
 <?php
-/**
- * Copyright © 2016 netz98 new media GmbH. All rights reserved.
- * See COPYING.txt for license details.
- */
 
 namespace N98\Magento\Command\Developer\Console\Renderer\PHPCode;
 

--- a/src/N98/Magento/Command/Developer/Console/Structure/ModuleNameStructure.php
+++ b/src/N98/Magento/Command/Developer/Console/Structure/ModuleNameStructure.php
@@ -1,8 +1,4 @@
 <?php
-/**
- * Copyright © 2016 netz98 new media GmbH. All rights reserved.
- * See COPYING.txt for license details.
- */
 
 namespace N98\Magento\Command\Developer\Console\Structure;
 

--- a/src/N98/Magento/Command/Developer/Console/Structure/ThemeNameStructure.php
+++ b/src/N98/Magento/Command/Developer/Console/Structure/ThemeNameStructure.php
@@ -1,8 +1,4 @@
 <?php
-/**
- * Copyright © 2016 netz98 new media GmbH. All rights reserved.
- * See COPYING.txt for license details.
- */
 
 namespace N98\Magento\Command\Developer\Console\Structure;
 

--- a/src/N98/Magento/Command/Github/PatchFileContent/Creator.php
+++ b/src/N98/Magento/Command/Github/PatchFileContent/Creator.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * @copyright Copyright (c) netz98 GmbH (https://www.netz98.de)
- *
- * @see PROJECT_LICENSE.txt
- */
 
 declare(strict_types=1);
 

--- a/src/N98/Magento/Command/Github/PatchFileContent/Processor/AppCodeProcessor.php
+++ b/src/N98/Magento/Command/Github/PatchFileContent/Processor/AppCodeProcessor.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * @copyright Copyright (c) netz98 GmbH (https://www.netz98.de)
- *
- * @see PROJECT_LICENSE.txt
- */
 
 declare(strict_types=1);
 

--- a/src/N98/Magento/Command/Github/PatchFileContent/Processor/AppDesignProcessor.php
+++ b/src/N98/Magento/Command/Github/PatchFileContent/Processor/AppDesignProcessor.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * @copyright Copyright (c) netz98 GmbH (https://www.netz98.de)
- *
- * @see PROJECT_LICENSE.txt
- */
 
 declare(strict_types=1);
 

--- a/src/N98/Magento/Command/Github/PatchFileContent/Processor/I18nProcessor.php
+++ b/src/N98/Magento/Command/Github/PatchFileContent/Processor/I18nProcessor.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * @copyright Copyright (c) netz98 GmbH (https://www.netz98.de)
- *
- * @see PROJECT_LICENSE.txt
- */
 
 declare(strict_types=1);
 

--- a/src/N98/Magento/Command/Github/PatchFileContent/Processor/LibProcessor.php
+++ b/src/N98/Magento/Command/Github/PatchFileContent/Processor/LibProcessor.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * @copyright Copyright (c) netz98 GmbH (https://www.netz98.de)
- *
- * @see PROJECT_LICENSE.txt
- */
 
 declare(strict_types=1);
 

--- a/src/N98/Magento/Command/Github/PatchFileContent/Processor/ProcessorInterface.php
+++ b/src/N98/Magento/Command/Github/PatchFileContent/Processor/ProcessorInterface.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * @copyright Copyright (c) netz98 GmbH (https://www.netz98.de)
- *
- * @see PROJECT_LICENSE.txt
- */
 
 declare(strict_types=1);
 

--- a/src/N98/Magento/Command/Github/PullRequestInfoTable.php
+++ b/src/N98/Magento/Command/Github/PullRequestInfoTable.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * @copyright Copyright (c) netz98 GmbH (https://www.netz98.de)
- *
- * @see PROJECT_LICENSE.txt
- */
 
 declare(strict_types=1);
 

--- a/src/N98/Magento/Command/Indexer/RecreateTriggersCommand.php
+++ b/src/N98/Magento/Command/Indexer/RecreateTriggersCommand.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * @copyright Copyright (c) 1999-2017 netz98 GmbH (http://www.netz98.de)
- *
- * @see PROJECT_LICENSE.txt
- */
 
 namespace N98\Magento\Command\Indexer;
 

--- a/src/N98/Magento/Command/Integration/IntegrationDataTrait.php
+++ b/src/N98/Magento/Command/Integration/IntegrationDataTrait.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * @copyright Copyright (c) netz98 GmbH (https://www.netz98.de)
- *
- * @see PROJECT_LICENSE.txt
- */
 
 declare(strict_types=1);
 

--- a/src/N98/Magento/Command/MagentoCoreProxyCommand.php
+++ b/src/N98/Magento/Command/MagentoCoreProxyCommand.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * @copyright Copyright (c) netz98 GmbH (https://www.netz98.de)
- *
- * @see PROJECT_LICENSE.txt
- */
 
 declare(strict_types=1);
 

--- a/src/N98/Magento/Command/MagentoCoreProxyCommandFactory.php
+++ b/src/N98/Magento/Command/MagentoCoreProxyCommandFactory.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * @copyright Copyright (c) netz98 GmbH (https://www.netz98.de)
- *
- * @see PROJECT_LICENSE.txt
- */
 
 declare(strict_types=1);
 

--- a/src/N98/Magento/Command/Route/ActionPathFormatter.php
+++ b/src/N98/Magento/Command/Route/ActionPathFormatter.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * @copyright Copyright (c) netz98 GmbH (https://www.netz98.de)
- *
- * @see PROJECT_LICENSE.txt
- */
 
 declare(strict_types=1);
 

--- a/src/N98/Magento/Command/System/Check/Hyva/HyvaTrait.php
+++ b/src/N98/Magento/Command/System/Check/Hyva/HyvaTrait.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * @copyright Copyright (c) netz98 GmbH (https://www.netz98.de)
- *
- * @see PROJECT_LICENSE.txt
- */
 
 declare(strict_types=1);
 

--- a/src/N98/Magento/Command/System/Check/Hyva/IncompatibleBundledModulesCheck.php
+++ b/src/N98/Magento/Command/System/Check/Hyva/IncompatibleBundledModulesCheck.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * @copyright Copyright (c) netz98 GmbH (https://www.netz98.de)
- *
- * @see PROJECT_LICENSE.txt
- */
 
 declare(strict_types=1);
 

--- a/src/N98/Magento/Command/System/Check/Hyva/InstallationBasicComposerPackagesCheck.php
+++ b/src/N98/Magento/Command/System/Check/Hyva/InstallationBasicComposerPackagesCheck.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * @copyright Copyright (c) netz98 GmbH (https://www.netz98.de)
- *
- * @see PROJECT_LICENSE.txt
- */
 
 declare(strict_types=1);
 

--- a/src/N98/Magento/Command/System/Check/Hyva/IsCaptchaEnabledCheck.php
+++ b/src/N98/Magento/Command/System/Check/Hyva/IsCaptchaEnabledCheck.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * @copyright Copyright (c) netz98 GmbH (https://www.netz98.de)
- *
- * @see PROJECT_LICENSE.txt
- */
 
 declare(strict_types=1);
 

--- a/src/N98/Magento/Command/System/Check/Hyva/MissingGraphQLPackagesCheck.php
+++ b/src/N98/Magento/Command/System/Check/Hyva/MissingGraphQLPackagesCheck.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * @copyright Copyright (c) netz98 GmbH (https://www.netz98.de)
- *
- * @see PROJECT_LICENSE.txt
- */
 
 declare(strict_types=1);
 

--- a/src/N98/Magento/Command/System/Check/ProjectComposerTrait.php
+++ b/src/N98/Magento/Command/System/Check/ProjectComposerTrait.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * @copyright Copyright (c) netz98 GmbH (https://www.netz98.de)
- *
- * @see PROJECT_LICENSE.txt
- */
 
 declare(strict_types=1);
 

--- a/src/N98/Magento/Command/System/Cron/KillCommand.php
+++ b/src/N98/Magento/Command/System/Cron/KillCommand.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * @copyright Copyright (c) netz98 GmbH (https://www.netz98.de)
- *
- * @see PROJECT_LICENSE.txt
- */
 
 declare(strict_types=1);
 

--- a/src/N98/Util/ComposerLock.php
+++ b/src/N98/Util/ComposerLock.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * @copyright Copyright (c) netz98 GmbH (https://www.netz98.de)
- *
- * @see PROJECT_LICENSE.txt
- */
 
 declare(strict_types=1);
 

--- a/tests/N98/Magento/Command/Github/PatchFileContent/CreatorTest.php
+++ b/tests/N98/Magento/Command/Github/PatchFileContent/CreatorTest.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * @copyright Copyright (c) netz98 GmbH (https://www.netz98.de)
- *
- * @see PROJECT_LICENSE.txt
- */
 
 declare(strict_types=1);
 

--- a/tests/N98/Magento/Command/Github/PatchFileContent/Processor/AppCodeProcessorTest.php
+++ b/tests/N98/Magento/Command/Github/PatchFileContent/Processor/AppCodeProcessorTest.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * @copyright Copyright (c) netz98 GmbH (https://www.netz98.de)
- *
- * @see PROJECT_LICENSE.txt
- */
 
 declare(strict_types=1);
 

--- a/tests/N98/Magento/Command/Github/PatchFileContent/Processor/AppDesignProcessorTest.php
+++ b/tests/N98/Magento/Command/Github/PatchFileContent/Processor/AppDesignProcessorTest.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * @copyright Copyright (c) netz98 GmbH (https://www.netz98.de)
- *
- * @see PROJECT_LICENSE.txt
- */
 
 declare(strict_types=1);
 

--- a/tests/N98/Magento/Command/Github/PatchFileContent/Processor/I18nProcessorTest.php
+++ b/tests/N98/Magento/Command/Github/PatchFileContent/Processor/I18nProcessorTest.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * @copyright Copyright (c) netz98 GmbH (https://www.netz98.de)
- *
- * @see PROJECT_LICENSE.txt
- */
 
 declare(strict_types=1);
 

--- a/tests/N98/Magento/Command/Github/PatchFileContent/Processor/LibProcessorTest.php
+++ b/tests/N98/Magento/Command/Github/PatchFileContent/Processor/LibProcessorTest.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * @copyright Copyright (c) netz98 GmbH (https://www.netz98.de)
- *
- * @see PROJECT_LICENSE.txt
- */
 
 declare(strict_types=1);
 

--- a/tests/N98/Magento/Command/ListCommandTest.php
+++ b/tests/N98/Magento/Command/ListCommandTest.php
@@ -8,7 +8,7 @@ class ListCommandTest extends TestCase
     {
         $this->assertDisplayContains(
             'list',
-            sprintf('n98-magerun2 %s by netz98 GmbH', $this->getApplication()->getVersion())
+            sprintf('n98-magerun2 %s by valantic CEC', $this->getApplication()->getVersion())
         );
     }
 }

--- a/tests/N98/Magento/Command/Route/ActionPathFormatterTest.php
+++ b/tests/N98/Magento/Command/Route/ActionPathFormatterTest.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * @copyright Copyright (c) netz98 GmbH (https://www.netz98.de)
- *
- * @see PROJECT_LICENSE.txt
- */
 
 declare(strict_types=1);
 

--- a/tests/N98/Magento/CoreCommand/AbstractMagentoCoreCommandTestCase.php
+++ b/tests/N98/Magento/CoreCommand/AbstractMagentoCoreCommandTestCase.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * @copyright Copyright (c) netz98 GmbH (https://www.netz98.de)
- *
- * @see PROJECT_LICENSE.txt
- */
 
 declare(strict_types=1);
 

--- a/tests/N98/Magento/CoreCommand/CacheStatusCommandTest.php
+++ b/tests/N98/Magento/CoreCommand/CacheStatusCommandTest.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * @copyright Copyright (c) netz98 GmbH (https://www.netz98.de)
- *
- * @see PROJECT_LICENSE.txt
- */
 
 declare(strict_types=1);
 

--- a/tests/N98/Magento/CoreCommand/DeployModeShowCommandTest.php
+++ b/tests/N98/Magento/CoreCommand/DeployModeShowCommandTest.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * @copyright Copyright (c) netz98 GmbH (https://www.netz98.de)
- *
- * @see PROJECT_LICENSE.txt
- */
 
 declare(strict_types=1);
 

--- a/tests/N98/Magento/CoreCommand/DevDiInfoCommandTest.php
+++ b/tests/N98/Magento/CoreCommand/DevDiInfoCommandTest.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * @copyright Copyright (c) netz98 GmbH (https://www.netz98.de)
- *
- * @see PROJECT_LICENSE.txt
- */
 
 declare(strict_types=1);
 

--- a/tests/N98/Magento/CoreCommand/IndexerInfoCommandTest.php
+++ b/tests/N98/Magento/CoreCommand/IndexerInfoCommandTest.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * @copyright Copyright (c) netz98 GmbH (https://www.netz98.de)
- *
- * @see PROJECT_LICENSE.txt
- */
 
 declare(strict_types=1);
 

--- a/tests/N98/Magento/CoreCommand/InfoCurrencyListCommandTest.php
+++ b/tests/N98/Magento/CoreCommand/InfoCurrencyListCommandTest.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * @copyright Copyright (c) netz98 GmbH (https://www.netz98.de)
- *
- * @see PROJECT_LICENSE.txt
- */
 
 declare(strict_types=1);
 

--- a/tests/N98/Magento/CoreCommand/ModuleStatusCommandTest.php
+++ b/tests/N98/Magento/CoreCommand/ModuleStatusCommandTest.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * @copyright Copyright (c) netz98 GmbH (https://www.netz98.de)
- *
- * @see PROJECT_LICENSE.txt
- */
 
 declare(strict_types=1);
 

--- a/tests/N98/Util/ComposerLockTest.php
+++ b/tests/N98/Util/ComposerLockTest.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * @copyright Copyright (c) netz98 GmbH (https://www.netz98.de)
- *
- * @see PROJECT_LICENSE.txt
- */
 
 declare(strict_types=1);
 

--- a/tests/N98/Util/ProjectComposerTest.php
+++ b/tests/N98/Util/ProjectComposerTest.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * @copyright Copyright (c) netz98 GmbH (https://www.netz98.de)
- *
- * @see PROJECT_LICENSE.txt
- */
 
 declare(strict_types=1);
 

--- a/tests/example-module/src/TestCommand.php
+++ b/tests/example-module/src/TestCommand.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * @copyright Copyright (c) netz98 GmbH (https://www.netz98.de)
- *
- * @see PROJECT_LICENSE.txt
- */
 
 declare(strict_types=1);
 


### PR DESCRIPTION
Magerun pull-request check-list:

- [x] Pull request against develop branch (if not, just close and create a new one against it)
- [x] README.md reflects changes (if any)

Summary:  The company netz98 is part of the valantic Group since 2019. Some days ago the legal entity netz98 GmbH was merged into the valantic Deutschland GmbH.
So we change the license info to reflect this legal changes.