### PR TITLE
Fixed casing of DecryptCommand class

### DIFF
--- a/src/N98/Magento/Command/Developer/DecryptCommand.php
+++ b/src/N98/Magento/Command/Developer/DecryptCommand.php
@@ -13,7 +13,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  * Class DecryptCommand
  * @package N98\Magento\Command\Developer
  */
-class decryptCommand extends AbstractMagentoCommand
+class DecryptCommand extends AbstractMagentoCommand
 {
     /**
      * @var \Magento\Framework\Encryption\EncryptorInterface


### PR DESCRIPTION
Magerun pull-request check-list:

- [x] Pull request against develop branch (if not, just close and create a new one against it)
- [ ] README.md reflects changes (if any)
- [ ] phar fuctional test (in tests/phar-test.sh)

Summary: (some words as summary)

Fixed a typo in the class name

Changes proposed in this pull request:

Fixed typo, so composer's optimised autoloader no longer complains:

```
$ composer dump-autoload -o
Generating optimized autoload files
Class N98\Magento\Command\Developer\decryptCommand located in ./src/N98/Magento/Command/Developer/DecryptCommand.php does not comply with psr-4 autoloading standard (rule: N98\ => ./src/N98). Skipping.
...
```