### PR TITLE
Some mariadb client tools does not support ssl-mode option

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -18,7 +18,7 @@ hooks:
 use_dns_when_possible: true
 composer_version: 2.2.17
 web_environment:
-    - MAGERUN_SETUP_TEST_DEFAULT_MAGENTO_VERSION=2.4.7
+    - MAGERUN_SETUP_TEST_DEFAULT_MAGENTO_VERSION=2.4.7-p2
     - N98_MAGERUN2_BIN=/var/www/html/bin/n98-magerun2
 nodejs_version: "16"
 
@@ -58,7 +58,7 @@ nodejs_version: "16"
 # "ddev xhprof" to enable xhprof and "ddev xhprof off" to disable it work better,
 # as leaving xhprof enabled all the time is a big performance hit.
 
-# webserver_type: nginx-fpm, apache-fpm, or nginx-gunicorn 
+# webserver_type: nginx-fpm, apache-fpm, or nginx-gunicorn
 
 # timezone: Europe/Berlin
 # This is the timezone used in the containers and by PHP;
@@ -100,7 +100,7 @@ nodejs_version: "16"
 # Please take care with this because it can cause great confusion.
 
 # upload_dirs: "custom/upload/dir"
-#    
+#
 # upload_dirs:
 #   - custom/upload/dir
 #   - ../private

--- a/.ddev/docker-compose.elastic.yaml
+++ b/.ddev/docker-compose.elastic.yaml
@@ -1,4 +1,3 @@
-version: '3.6'
 services:
 
   # see: https://github.com/drud/ddev-contrib/blob/master/docker-compose-services/elasticsearch/docker-compose.elasticsearch.yaml

--- a/.ddev/docker-compose.magento-volumes.yaml
+++ b/.ddev/docker-compose.magento-volumes.yaml
@@ -1,4 +1,3 @@
-version: '3.6'
 services:
   web:
     volumes:

--- a/src/N98/Magento/Command/Database/DumpCommand.php
+++ b/src/N98/Magento/Command/Database/DumpCommand.php
@@ -3,6 +3,7 @@
 namespace N98\Magento\Command\Database;
 
 use InvalidArgumentException;
+use Magento\Framework\Exception\FileSystemException;
 use N98\Magento\Command\Database\Compressor\Compressor;
 use N98\Util\Console\Enabler;
 use N98\Util\Console\Helper\DatabaseHelper;
@@ -207,7 +208,7 @@ HELP;
 
  Separate each table to strip by a space.
  You can use wildcards like * and ? in the table names to strip multiple
- tables. In addition you can specify pre-defined table groups, that start
+ tables. In addition, you can specify pre-defined table groups, that start
  with an @ symbol.
 
  Example: "dataflow_batch_export unimportant_module_* @log"
@@ -263,7 +264,7 @@ HELP;
      * @param OutputInterface $output
      *
      * @return int
-     * @throws \Magento\Framework\Exception\FileSystemException
+     * @throws FileSystemException
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
@@ -290,7 +291,7 @@ HELP;
      * @param InputInterface $input
      * @param OutputInterface $output
      * @return Execs
-     * @throws \Magento\Framework\Exception\FileSystemException
+     * @throws FileSystemException
      */
     private function createExecs(InputInterface $input, OutputInterface $output)
     {
@@ -432,7 +433,7 @@ HELP;
      * @param InputInterface $input
      * @param OutputInterface $output
      * @return array
-     * @throws \Magento\Framework\Exception\FileSystemException
+     * @throws FileSystemException
      */
     private function stripTables(InputInterface $input, OutputInterface $output)
     {
@@ -455,7 +456,7 @@ HELP;
      * @param InputInterface $input
      * @param OutputInterface $output
      * @return array
-     * @throws \Magento\Framework\Exception\FileSystemException
+     * @throws FileSystemException
      */
     private function excludeTables(InputInterface $input, OutputInterface $output)
     {
@@ -487,7 +488,7 @@ HELP;
     /**
      * @param string $list space separated list of tables
      * @return array
-     * @throws \Magento\Framework\Exception\FileSystemException
+     * @throws FileSystemException
      */
     private function resolveDatabaseTables($list)
     {


### PR DESCRIPTION
Magerun pull-request check-list:

- [x] Pull request against develop branch (if not, just close and create a new one against it)

Summary: The client tools provided by MariaDB are not the same as the MySQL client tools. One difference is the missing `mysqldump --ssl-mode` parameter

Fixes #1526 

Changes proposed in this pull request:

Added a check which calls mysqldump help and grep the output for `--ssl-mode` option. If the option does not exist, we do not add the option to the connection string used in the `db:dump` and `db:import` command.