### PR TITLE
feat: add zstd and lz4 compression support and auto compression detec…

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -167,7 +167,7 @@ nodejs_version: "16"
 # The mailhog port is not normally bound on the host at all, instead being routed
 # through ddev-router, but it can be bound directly to localhost if specified here.
 
-# webimage_extra_packages: [php7.4-tidy, php-bcmath]
+webimage_extra_packages: ['lz4', 'zstd']
 # Extra Debian packages that are needed in the webimage can be added here
 
 # dbimage_extra_packages: [telnet,netcat]

--- a/.github/workflows/linux-setup.sh
+++ b/.github/workflows/linux-setup.sh
@@ -9,5 +9,8 @@ set -x
 # bats (for testing)
 git clone --branch v1.2.1 https://github.com/bats-core/bats-core.git /tmp/bats-core && pushd /tmp/bats-core >/dev/null && sudo ./install.sh /usr/local
 
+sudo apt-get update
+sudo apt-get -y install zstd lz4
+
 # Show info to simplify debugging
 lsb_release -a

--- a/src/N98/Magento/Command/Database/AbstractDatabaseCommand.php
+++ b/src/N98/Magento/Command/Database/AbstractDatabaseCommand.php
@@ -101,9 +101,9 @@ abstract class AbstractDatabaseCommand extends AbstractMagentoCommand
      * @return Compressor
      * @deprecated Since 1.1.12; use AbstractCompressor::create() instead
      */
-    protected function getCompressor($type)
+    protected function getCompressor($type, InputInterface $input)
     {
-        return AbstractCompressor::create($type);
+        return AbstractCompressor::create($type, $input);
     }
 
     /**

--- a/src/N98/Magento/Command/Database/AbstractDatabaseCommand.php
+++ b/src/N98/Magento/Command/Database/AbstractDatabaseCommand.php
@@ -89,8 +89,8 @@ abstract class AbstractDatabaseCommand extends AbstractMagentoCommand
         $messages = [];
         $messages[] = '';
         $messages[] = '<info>Compression option</info>';
-        $messages[] = ' Supported compression: gzip';
-        $messages[] = ' The gzip cli tool has to be installed.';
+        $messages[] = ' Supported compression: gzip, lz4, zstd';
+        $messages[] = ' The gzip/lz4/zstd cli tool has to be installed.';
         $messages[] = ' Additionally, for data-to-csv option tar cli tool has to be installed too.';
 
         return implode(PHP_EOL, $messages);

--- a/src/N98/Magento/Command/Database/Compressor/AbstractCompressor.php
+++ b/src/N98/Magento/Command/Database/Compressor/AbstractCompressor.php
@@ -3,6 +3,7 @@
 namespace N98\Magento\Command\Database\Compressor;
 
 use InvalidArgumentException;
+use N98\Util\BinaryString;
 use N98\Util\OperatingSystem;
 use Symfony\Component\Console\Input\InputInterface;
 
@@ -54,17 +55,17 @@ abstract class AbstractCompressor implements Compressor
     public static function tryGetCompressionType(string $filename)
     {
         switch (true) {
-            case str_ends_with($filename, '.sql'):
+            case BinaryString::endsWith($filename, '.sql'):
                 return 'none';
-            case str_ends_with($filename, '.sql.zstd'):
-            case str_ends_with($filename, '.tar.zstd'):
+            case BinaryString::endsWith($filename, '.sql.zstd'):
+            case BinaryString::endsWith($filename, '.tar.zstd'):
                 return 'zstd';
-            case str_ends_with($filename, '.sql.lz4'):
-            case str_ends_with($filename, '.tar.lz4'):
+            case BinaryString::endsWith($filename, '.sql.lz4'):
+            case BinaryString::endsWith($filename, '.tar.lz4'):
                 return 'lz4';
-            case str_ends_with($filename, '.sql.gz'):
-            case str_ends_with($filename, '.tgz'):
-            case str_ends_with($filename, '.gz'):
+            case BinaryString::endsWith($filename, '.sql.gz'):
+            case BinaryString::endsWith($filename, '.tgz'):
+            case BinaryString::endsWith($filename, '.gz'):
                 return 'gzip';
             default:
                 return null;

--- a/src/N98/Magento/Command/Database/Compressor/LZ4.php
+++ b/src/N98/Magento/Command/Database/Compressor/LZ4.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace N98\Magento\Command\Database\Compressor;
+
+/**
+ * Class LZ4
+ * @package N98\Magento\Command\Database\Compressor
+ */
+class LZ4 extends AbstractCompressor
+{
+    /**
+     * Returns the command line for compressing the dump file.
+     *
+     * @param string $command
+     * @param bool $pipe
+     * @return string
+     */
+    public function getCompressingCommand($command, $pipe = true)
+    {
+        if ($pipe) {
+            return $command . ' | lz4 -c ';
+        } else {
+            return sprintf(
+                "tar -I 'lz4' -cf %s",
+                $command,
+            );
+        }
+    }
+
+    /**
+     * Returns the command line for decompressing the dump file.
+     *
+     * @param string $command
+     * @param string $fileName Filename (shell argument escaped)
+     * @param bool $pipe
+     * @return string
+     */
+    public function getDecompressingCommand($command, $fileName, $pipe = true)
+    {
+        if ($pipe) {
+            if ($this->hasPipeViewer()) {
+                return 'pv -cN lz4 ' . escapeshellarg($fileName) . ' | lz4 -d | pv -cN mysql | ' . $command;
+            }
+
+            return 'lz4 -dc < ' . escapeshellarg($fileName) . ' | ' . $command;
+        } else {
+            if ($this->hasPipeViewer()) {
+                return 'pv -cN tar -zxf ' . escapeshellarg($fileName) . ' && pv -cN mysql | ' . $command;
+            }
+
+            return 'tar -zxf ' . escapeshellarg($fileName) . ' -C ' . dirname($fileName) . ' && ' . $command . ' < '
+                . escapeshellarg(substr($fileName, 0, -4));
+        }
+    }
+
+    /**
+     * Returns the file name for the compressed dump file.
+     *
+     * @param string $fileName
+     * @param bool $pipe
+     * @return string
+     */
+    public function getFileName($fileName, $pipe = true)
+    {
+        if ($fileName === null) {
+            $fileName = '';
+        }
+
+        if (!strlen($fileName)) {
+            return $fileName;
+        }
+
+        if ($pipe) {
+            if (substr($fileName, -4, 4) === '.lz4') {
+                return $fileName;
+            } elseif (substr($fileName, -4, 4) === '.sql') {
+                $fileName .= '.lz4';
+            } else {
+                $fileName .= '.sql.lz4';
+            }
+        } elseif (substr($fileName, -8, 8) === '.tar.lz4') {
+            return $fileName;
+        } else {
+            $fileName .= '.tar.lz4';
+        }
+
+        return $fileName;
+    }
+}

--- a/src/N98/Magento/Command/Database/Compressor/Zstandard.php
+++ b/src/N98/Magento/Command/Database/Compressor/Zstandard.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace N98\Magento\Command\Database\Compressor;
+
+use Symfony\Component\Console\Input\InputInterface;
+
+/**
+ * Class Zstandard
+ * @package N98\Magento\Command\Database\Compressor
+ */
+class Zstandard extends AbstractCompressor
+{
+    protected int $compressionLevel;
+
+    protected string $extraArgs;
+
+    /**
+     * @param InputInterface|null $input
+     */
+    public function __construct(InputInterface $input = null)
+    {
+        $this->compressionLevel = $input ? (int)$input->getOption('zstd-level') : 10;
+        $this->extraArgs = $input ? (string)$input->getOption('zstd-extra-args') : '';
+
+        parent::__construct($input);
+    }
+
+    /**
+     * Returns the command line for compressing the dump file.
+     *
+     * @param string $command
+     * @param bool $pipe
+     * @return string
+     */
+    public function getCompressingCommand($command, $pipe = true)
+    {
+        if ($pipe) {
+            return sprintf(
+                "%s | zstd -c -%s %s",
+                $command,
+                $this->compressionLevel,
+                $this->extraArgs,
+            );
+        } else {
+            return sprintf(
+                "tar -I 'zstd %s -%s' -cf %s",
+                $this->extraArgs,
+                $this->compressionLevel,
+                $command,
+            );
+        }
+    }
+
+    /**
+     * Returns the command line for decompressing the dump file.
+     *
+     * @param string $command
+     * @param string $fileName Filename (shell argument escaped)
+     * @param bool $pipe
+     * @return string
+     */
+    public function getDecompressingCommand($command, $fileName, $pipe = true)
+    {
+        if ($pipe) {
+            if ($this->hasPipeViewer()) {
+                return 'pv -cN zstd ' . escapeshellarg($fileName) . ' | zstd -d | pv -cN mysql | ' . $command;
+            }
+
+            return 'zstd -dc < ' . escapeshellarg($fileName) . ' | ' . $command;
+        } else {
+            if ($this->hasPipeViewer()) {
+                return 'pv -cN tar -zxf ' . escapeshellarg($fileName) . ' && pv -cN mysql | ' . $command;
+            }
+
+            return 'tar -zxf ' . escapeshellarg($fileName) . ' -C ' . dirname($fileName) . ' && ' . $command . ' < '
+                . escapeshellarg(substr($fileName, 0, -4));
+        }
+    }
+
+    /**
+     * Returns the file name for the compressed dump file.
+     *
+     * @param string $fileName
+     * @param bool $pipe
+     * @return string
+     */
+    public function getFileName($fileName, $pipe = true)
+    {
+        if ($fileName === null) {
+            $fileName = '';
+        }
+
+        if (!strlen($fileName)) {
+            return $fileName;
+        }
+
+        if ($pipe) {
+            if (substr($fileName, -5, 5) === '.zstd') {
+                return $fileName;
+            } elseif (substr($fileName, -4, 4) === '.sql') {
+                $fileName .= '.zstd';
+            } else {
+                $fileName .= '.sql.zstd';
+            }
+        } elseif (substr($fileName, -9, 9) === '.tar.zstd') {
+            return $fileName;
+        } else {
+            $fileName .= '.tar.zstd';
+        }
+
+        return $fileName;
+    }
+}

--- a/src/N98/Magento/Command/Database/DumpCommand.php
+++ b/src/N98/Magento/Command/Database/DumpCommand.php
@@ -39,8 +39,8 @@ class DumpCommand extends AbstractDatabaseCommand
         $this
             ->setName('db:dump')
             ->addArgument('filename', InputArgument::OPTIONAL, 'Dump filename')
-            ->addOption('zstd-level', null, InputOption::VALUE_OPTIONAL, '', 10)
-            ->addOption('zstd-extra-args', null, InputOption::VALUE_OPTIONAL, '', '')
+            ->addOption('zstd-level', null, InputOption::VALUE_OPTIONAL, 'Set the level of compression the higher the smaller the result', 10)
+            ->addOption('zstd-extra-args', null, InputOption::VALUE_OPTIONAL, 'Set custom extra options that zstd supports', '')
             ->addOption(
                 'add-time',
                 't',

--- a/src/N98/Magento/Command/Database/DumpCommand.php
+++ b/src/N98/Magento/Command/Database/DumpCommand.php
@@ -39,6 +39,8 @@ class DumpCommand extends AbstractDatabaseCommand
         $this
             ->setName('db:dump')
             ->addArgument('filename', InputArgument::OPTIONAL, 'Dump filename')
+            ->addOption('zstd-level', null, InputOption::VALUE_OPTIONAL, '', 10)
+            ->addOption('zstd-extra-args', null, InputOption::VALUE_OPTIONAL, '', '')
             ->addOption(
                 'add-time',
                 't',
@@ -296,7 +298,7 @@ HELP;
     private function createExecs(InputInterface $input, OutputInterface $output)
     {
         $execs = new Execs('mysqldump');
-        $execs->setCompression($input->getOption('compression'));
+        $execs->setCompression($input->getOption('compression'), $input);
         $execs->setFileName($this->getFileName($input, $output, $execs->getCompressor()));
 
         if (!$input->getOption('no-single-transaction')) {

--- a/src/N98/Magento/Command/Database/Execs.php
+++ b/src/N98/Magento/Command/Database/Execs.php
@@ -6,6 +6,7 @@
 namespace N98\Magento\Command\Database;
 
 use N98\Magento\Command\Database\Compressor\AbstractCompressor;
+use Symfony\Component\Console\Input\InputInterface;
 
 /**
  * One or multiple commands to execute, with support for Compressors
@@ -47,9 +48,9 @@ class Execs
     /**
      * @param string $type of compression: "gz" | "gzip" | "none" | null
      */
-    public function setCompression($type)
+    public function setCompression($type, InputInterface $input = null)
     {
-        $this->compressor = AbstractCompressor::create($type);
+        $this->compressor = AbstractCompressor::create($type, $input);
     }
 
     /**

--- a/tests/bats/functional_magerun_commands.bats
+++ b/tests/bats/functional_magerun_commands.bats
@@ -225,6 +225,38 @@ function cleanup_files_in_magento() {
   run $BIN "db:dump" --print-only-filename db.sql
   assert_output --partial "db.sql"
 
+  run $BIN "db:dump" --print-only-filename -c gz db.sql
+  assert_output --partial "db.sql.gz"
+  assert [ "$status" -eq 0 ]
+
+  run $BIN "db:dump" --print-only-filename -c gzip db.sql
+  assert_output --partial "db.sql.gz"
+  assert [ "$status" -eq 0 ]
+
+  run $BIN "db:dump" --print-only-filename --compression gzip db.sql
+  assert_output --partial "db.sql.gz"
+  assert [ "$status" -eq 0 ]
+
+  run $BIN "db:dump" --print-only-filename --compression gz db.sql
+  assert_output --partial "db.sql.gz"
+  assert [ "$status" -eq 0 ]
+
+  run $BIN "db:dump" --print-only-filename -c lz4 db.sql
+  assert_output --partial "db.sql.lz4"
+  assert [ "$status" -eq 0 ]
+
+  run $BIN "db:dump" --print-only-filename --compression lz4 db.sql
+  assert_output --partial "db.sql.lz4"
+  assert [ "$status" -eq 0 ]
+
+  run $BIN "db:dump" --print-only-filename -c zstd db.sql
+  assert_output --partial "db.sql.zstd"
+  assert [ "$status" -eq 0 ]
+
+  run $BIN "db:dump" --print-only-filename --compression zstd db.sql
+  assert_output --partial "db.sql.zstd"
+  assert [ "$status" -eq 0 ]
+
   run $BIN "db:dump" --only-command db.sql
   assert_output --partial "mysqldump"
 }


### PR DESCRIPTION
…t on db import

Magerun pull-request check-list:

- [x] Pull request against develop branch (if not, just close and create a new one against it)
- [x] README.md reflects changes (if any)
- [x] phar fuctional test (in tests/phar-test.sh)

Summary: Add zstd and lz4 compression support + that compression on import get detected instead of manuel needed to be added

Fixes # .

Changes proposed in this pull request:

- Add zstd compression for db dumps/import

- Add lz4 compression for db dumps/import

- add auto detecet for decompression of sql file
