### PR TITLE
docs: fix description of command detect-composer-dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -980,11 +980,11 @@ The source code of one or more modules can be scanned for dependencies.
 n98-magerun2.phar dev:module:detect-composer-dependencies [--only-missing] <directory>
 ```
 
+The `--only-missing` option will filter the output so that only the missing dependencies are listed.
+
 ---
 
 ### Translations
-
-The `--only-missing` option will filter the output so that only the missing dependencies are listed.
 
 Enable/disable inline translation feature for Magento Admin:
 


### PR DESCRIPTION
Magerun pull-request check-list:

- [x] Pull request against develop branch (if not, just close and create a new one against it)
- [x] README.md reflects changes (if any)
- [ ] phar fuctional test (in tests/phar-test.sh)

Summary: 

The description of the command was under the wrong headline. I just moved the option description towards the correct command (instead of translations). Because it only effects readme, I skipped functional test

Changes proposed in this pull request:
- simple change in readme