### PR TITLE
feat: add new options to display admin store urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -578,6 +578,7 @@ n98-magerun2.phar config:store:delete [--scope[="..."]] [--scope-id[="..."]] [--
 | `--scope-id` | The config value's scope ID                          |
 | `--all`      | Delete all entries by path                           |
 
+
 ### Display ACL Tree
 
 ```sh
@@ -1166,6 +1167,17 @@ between module version changes.
 
 ```sh
 n98-magerun2.phar sys:setup:downgrade-versions
+```
+
+### List all configured store URLs
+
+The default behavior is to show the base URL of all stores except the admin store.
+If you want to show the base URL of the admin store as well, use the `--with-admin-store` option.
+If you want to show the admin login URL as well, use the `--with-admin-login-url` option.
+The options `--with-admin-store` and `--with-admin-login-url` cannot be combined, because both print a url for the same store.
+
+```sh
+n98-magerun2.phar sys:store:config:base-url:list [--with-admin-store] [--with-admin-login-url] [--format[="..."]]
 ```
 
 ---

--- a/src/N98/Magento/Command/System/Store/Config/BaseUrlListCommand.php
+++ b/src/N98/Magento/Command/System/Store/Config/BaseUrlListCommand.php
@@ -2,6 +2,12 @@
 
 namespace N98\Magento\Command\System\Store\Config;
 
+use InvalidArgumentException;
+use Magento\Backend\Setup\ConfigOptionsList as BackendConfigOptionsList;
+use Magento\Framework\App\DeploymentConfig;
+use Magento\Framework\UrlInterface;
+use Magento\Store\Model\Store;
+use Magento\Store\Model\StoreManagerInterface;
 use N98\Magento\Command\AbstractMagentoCommand;
 use N98\Util\Console\Helper\Table\Renderer\RendererFactory;
 use Symfony\Component\Console\Command\Command;
@@ -20,11 +26,18 @@ class BaseUrlListCommand extends AbstractMagentoCommand
      */
     protected $storeManager;
 
+    /**
+     * @var \Magento\Framework\App\DeploymentConfig
+     */
+    private DeploymentConfig $deploymentConfig;
+
     protected function configure()
     {
         $this
             ->setName('sys:store:config:base-url:list')
             ->setDescription('Lists all base urls')
+            ->addOption('with-admin-store', null, InputOption::VALUE_NONE, 'Include admin store')
+            ->addOption('with-admin-login-url', null, InputOption::VALUE_NONE, 'Include admin login url')
             ->addOption(
                 'format',
                 null,
@@ -36,9 +49,12 @@ class BaseUrlListCommand extends AbstractMagentoCommand
     /**
      * @param \Magento\Store\Model\StoreManagerInterface $storeManager
      */
-    public function inject(\Magento\Store\Model\StoreManagerInterface $storeManager)
-    {
+    public function inject(
+        StoreManagerInterface $storeManager,
+        DeploymentConfig $deploymentConfig
+    ) {
         $this->storeManager = $storeManager;
+        $this->deploymentConfig = $deploymentConfig;
     }
 
     /**
@@ -49,6 +65,13 @@ class BaseUrlListCommand extends AbstractMagentoCommand
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        // with-admin-login-url and with-admin-store cannot be set at the same time
+        if ($input->getOption('with-admin-login-url') && $input->getOption('with-admin-store')) {
+            throw new InvalidArgumentException(
+                'You cannot use --with-admin-login-url and --with-admin-store at the same time.'
+            );
+        }
+
         $table = [];
         $this->detectMagento($output, true);
 
@@ -57,12 +80,31 @@ class BaseUrlListCommand extends AbstractMagentoCommand
         }
         $this->initMagento();
 
-        foreach ($this->storeManager->getStores() as $store) {
-            $table[$store->getId()] = [
-                $store->getId(),
+        foreach ($this->storeManager->getStores(true) as $store) {
+
+            if ($store->getCode() == Store::ADMIN_CODE && $input->getOption('with-admin-login-url')) {
+                $adminUri = $this->deploymentConfig->get(BackendConfigOptionsList::CONFIG_PATH_BACKEND_FRONTNAME);
+
+                $table[] = [
+                    $store->getId(),
+                    $store->getCode(),
+                    $store->getBaseUrl(UrlInterface::URL_TYPE_WEB) . $adminUri,
+                    $store->getBaseUrl(UrlInterface::URL_TYPE_WEB, true) . $adminUri,
+                ];
+                continue;
+            }
+
+            if ($store->getCode() == Store::ADMIN_CODE && !$input->getOption('with-admin-store')) {
+                continue;
+            }
+
+            $storeId = $store->getId();
+
+            $table[$storeId] = [
+                $storeId,
                 $store->getCode(),
-                $store->getBaseUrl(\Magento\Framework\UrlInterface::URL_TYPE_WEB),
-                $store->getBaseUrl(\Magento\Framework\UrlInterface::URL_TYPE_WEB, true),
+                $store->getBaseUrl(UrlInterface::URL_TYPE_WEB),
+                $store->getBaseUrl(UrlInterface::URL_TYPE_WEB, true),
             ];
         }
 

--- a/tests/bats/functional_magerun_commands.bats
+++ b/tests/bats/functional_magerun_commands.bats
@@ -579,7 +579,7 @@ function cleanup_files_in_magento() {
 
   # Check if validation works
   run $BIN "sys:store:config:base-url:list --with-admin-store --with-admin-admin-login-url"
-  assert [ "$status" -eq 0 ]
+  assert [ "$status" -eq 1 ]
 }
 
 @test "Command: sys:store:list" {

--- a/tests/bats/functional_magerun_commands.bats
+++ b/tests/bats/functional_magerun_commands.bats
@@ -570,6 +570,16 @@ function cleanup_files_in_magento() {
 @test "Command: sys:store:config:base-url:list" {
   run $BIN "sys:store:config:base-url:list"
   assert_output --partial "unsecure_baseurl"
+
+  run $BIN "sys:store:config:base-url:list --with-admin-store"
+  assert_output --partial "admin"
+
+  run $BIN "sys:store:config:base-url:list --with-admin-admin-login-url"
+  assert_output --partial "admin"
+
+  # Check if validation works
+  run $BIN "sys:store:config:base-url:list --with-admin-store --with-admin-admin-login-url"
+  assert [ "$status" -eq 0 ]
 }
 
 @test "Command: sys:store:list" {


### PR DESCRIPTION
Magerun pull-request check-list:

- [x] Pull request against develop branch (if not, just close and create a new one against it)
- [x] README.md reflects changes (if any)
- [x] phar fuctional test (in tests/phar-test.sh)

Summary: Extends the `sys:store:config:base-url:list` command by adding url for the admin store

Fixes possible #1545

Changes proposed in this pull request:

- add new option `--with-admin-store` to add the store with ID 0 to the list
- add new option `--with-admin-login-url` to print the whole URL of store 0 appended by admin login url
