### PR TITLE
Refactor: Replace pbergman/tree-helper with N98_Util_Console_Helper_T…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,6 @@
         "fakerphp/faker": "~1.16",
         "laminas/laminas-filter": "^2.12",
         "n98/junit-xml": "~1.0",
-        "pbergman/tree-helper": "^1.0",
         "psr/container": "~1.1.2",
         "psr/log": "^2.0",
         "psy/psysh": "~0.7",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fd0ffb163b8a4548bc77092ebb1113ec",
+    "content-hash": "ac3013fb809a020a2a506fdfd9fc7c42",
     "packages": [
         {
             "name": "dflydev/dot-access-data",
@@ -469,54 +469,6 @@
                 "source": "https://github.com/nikic/PHP-Parser/tree/v5.4.0"
             },
             "time": "2024-12-30T11:07:19+00:00"
-        },
-        {
-            "name": "pbergman/tree-helper",
-            "version": "1.0.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/pbergman/tree-printer.git",
-                "reference": "38ef106ebd8d0f0e807f47a15eb193b579c9dfdb"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/pbergman/tree-printer/zipball/38ef106ebd8d0f0e807f47a15eb193b579c9dfdb",
-                "reference": "38ef106ebd8d0f0e807f47a15eb193b579c9dfdb",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.4.0",
-                "symfony/console": ">=2.6"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-0": {
-                    "PBergman": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Philip Bergman",
-                    "email": "pbergman@live.nl"
-                }
-            ],
-            "description": "A symfony console helper to print a tree",
-            "keywords": [
-                "array",
-                "builder",
-                "console",
-                "symfony",
-                "tree"
-            ],
-            "support": {
-                "issues": "https://github.com/pbergman/tree-printer/issues",
-                "source": "https://github.com/pbergman/tree-printer/tree/1.0.2"
-            },
-            "time": "2022-02-08T08:28:24+00:00"
         },
         {
             "name": "psr/container",
@@ -6788,9 +6740,9 @@
         "ext-posix": "*",
         "ext-zip": "*"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "platform-overrides": {
         "php": "8.1.0"
     },
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/src/N98/Magento/Command/Config/Data/AclCommand.php
+++ b/src/N98/Magento/Command/Config/Data/AclCommand.php
@@ -4,7 +4,7 @@ namespace N98\Magento\Command\Config\Data;
 
 use Magento\Framework\Acl\AclResource\Config\Reader\Filesystem as AclConfigReader;
 use N98\Magento\Command\AbstractMagentoCommand;
-use PBergman\Console\Helper\TreeHelper;
+use N98\Util\Console\Helper\TreeHelper;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;

--- a/src/N98/Util/Console/Helper/TreeHelper.php
+++ b/src/N98/Util/Console/Helper/TreeHelper.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace N98\Util\Console\Helper;
+
+use Symfony\Component\Console\Output\OutputInterface;
+
+class TreeHelper
+{
+    /**
+     * @var string
+     */
+    private $title;
+
+    /**
+     * @var array
+     */
+    private $tree = [];
+
+    /**
+     * @var array
+     */
+    private $currentNode;
+
+    /**
+     * @var array
+     */
+    private $parents = [];
+
+    public function __construct()
+    {
+        $this->currentNode = &$this->tree;
+    }
+
+    /**
+     * @param string $title
+     */
+    public function setTitle($title)
+    {
+        $this->title = $title;
+    }
+
+    /**
+     * @param string $value
+     */
+    public function newNode($value)
+    {
+        $node = ['value' => $value, 'children' => []];
+        $this->currentNode[] = $node;
+        $this->parents[] = &$this->currentNode; // Store reference to parent
+        $this->currentNode = &$this->currentNode[count($this->currentNode) - 1]['children'];
+    }
+
+    /**
+     * @param string $value
+     */
+    public function addValue($value)
+    {
+        $this->currentNode[] = ['value' => $value, 'children' => []];
+    }
+
+    public function end()
+    {
+        if (!empty($this->parents)) {
+            $this->currentNode = &$this->parents[count($this->parents) - 1];
+            array_pop($this->parents);
+        } else {
+            // Already at the root, or tree is empty
+            $this->currentNode = &$this->tree;
+        }
+    }
+
+    /**
+     * @param OutputInterface $output
+     */
+    public function printTree(OutputInterface $output)
+    {
+        if ($this->title) {
+            $output->writeln($this->title);
+        }
+        $this->printNode($output, $this->tree);
+    }
+
+    /**
+     * @param OutputInterface $output
+     * @param array $nodes
+     * @param string $prefix
+     * @param bool $isLast
+     */
+    private function printNode(OutputInterface $output, array $nodes, $prefix = '', $isLast = false)
+    {
+        foreach ($nodes as $key => $node) {
+            $isCurrentLast = ($key == count($nodes) - 1);
+            $connector = $isCurrentLast ? '└─ ' : '├─ ';
+            $output->writeln($prefix . $connector . $node['value']);
+
+            $childPrefix = $prefix . ($isCurrentLast ? '   ' : '│  ');
+            if (!empty($node['children'])) {
+                $this->printNode($output, $node['children'], $childPrefix, $isCurrentLast);
+            }
+        }
+    }
+}

--- a/tests/N98/Util/Console/Helper/TreeHelperTest.php
+++ b/tests/N98/Util/Console/Helper/TreeHelperTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace N98\Util\Console\Helper;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class TreeHelperTest extends TestCase
+{
+    public function testTreePrinting()
+    {
+        $treeHelper = new TreeHelper();
+        $treeHelper->setTitle("Test Tree");
+
+        // Root 1
+        $treeHelper->newNode("Root 1");
+        $treeHelper->addValue("Leaf 1.1");
+        // Node 1.2
+        $treeHelper->newNode("Node 1.2");
+        $treeHelper->addValue("Leaf 1.2.1");
+        $treeHelper->end(); // End Node 1.2
+        $treeHelper->addValue("Leaf 1.3");
+        $treeHelper->end(); // End Root 1
+
+        // Root 2
+        $treeHelper->newNode("Root 2");
+        $treeHelper->addValue("Leaf 2.1");
+        $treeHelper->end(); // End Root 2
+
+        $output = [];
+        $outputMock = $this->createMock(OutputInterface::class);
+        $outputMock->method('writeln')
+            ->willReturnCallback(function ($messages) use (&$output) {
+                $output[] = $messages;
+            });
+
+        $treeHelper->printTree($outputMock);
+
+        $expectedOutput = [
+            "Test Tree",
+            "├─ Root 1",
+            "│  ├─ Leaf 1.1",
+            "│  ├─ Node 1.2",
+            "│  │  └─ Leaf 1.2.1",
+            "│  └─ Leaf 1.3",
+            "└─ Root 2",
+            "   └─ Leaf 2.1",
+        ];
+
+        $this->assertEquals($expectedOutput, $output);
+    }
+}


### PR DESCRIPTION
…reeHelper

The Composer package "pbergman/tree-helper" was outdated and not compatible with PHP 8.4. This change introduces a new `N98\Util\Console\Helper\TreeHelper` class that replicates the necessary functionality used in `AclCommand.php`.

Key changes:
- Added `src/N98/Util/Console/Helper/TreeHelper.php` with a custom tree rendering implementation.
- Updated `src/N98/Magento/Command/Config/Data/AclCommand.php` to use the new helper.
- Added unit tests for the new `TreeHelper` class in `tests/N98/Util/Console/Helper/TreeHelperTest.php`.
- Removed the "pbergman/tree-helper" package from `composer.json` and `composer.lock`.

Magerun pull-request check-list:

- [ ] Pull request against develop branch (if not, just close and create a new one against it)
- [ ] README.md reflects changes (if any)
- [ ] phar fuctional test (in tests/phar-test.sh)

Summary: (some words as summary)

Fixes # .

Changes proposed in this pull request:

- ...

- ...

- ...
