### PR TITLE
Feat: Create Docusaurus structure for Command Reference

### DIFF
--- a/docs/docs/command-reference/admin/index.md
+++ b/docs/docs/command-reference/admin/index.md
@@ -1,0 +1,16 @@
+---
+title: Admin Commands
+sidebar_label: Admin
+---
+
+# Admin Commands
+
+Commands for managing Magento admin user accounts and related settings.
+
+## Commands
+
+- [admin:user:list](./admin-user-list.md)
+- [admin:user:create](./admin-user-create.md)
+- [admin:user:change-password](./admin-user-change-password.md)
+- [admin:notifications](./admin-notifications.md)
+---

--- a/docs/docs/command-reference/cache/index.md
+++ b/docs/docs/command-reference/cache/index.md
@@ -1,0 +1,17 @@
+---
+title: Cache Commands
+sidebar_label: Cache
+---
+
+# Cache Commands
+
+Commands for interacting with and managing Magento's various cache systems.
+
+## Commands
+
+- [cache:clean](./cache-clean.md)
+- [cache:disable](./cache-disable.md)
+- [cache:enable](./cache-enable.md)
+- [cache:flush](./cache-flush.md)
+- [cache:list](./cache-list.md)
+---

--- a/docs/docs/command-reference/config/index.md
+++ b/docs/docs/command-reference/config/index.md
@@ -1,0 +1,16 @@
+---
+title: Config Commands
+sidebar_label: Config
+---
+
+# Config Commands
+
+Commands for managing Magento store configurations and environment settings.
+
+## Commands
+
+- [config:store:get](./config-store-get.md)
+- [config:store:set](./config-store-set.md)
+- [config:env:set](./config-env-set.md)
+- [config:search](./config-search.md)
+---

--- a/docs/docs/command-reference/customer/index.md
+++ b/docs/docs/command-reference/customer/index.md
@@ -1,0 +1,16 @@
+---
+title: Customer Commands
+sidebar_label: Customer
+---
+
+# Customer Commands
+
+Commands for managing Magento customer accounts.
+
+## Commands
+
+- [customer:create](./customer-create.md)
+- [customer:list](./customer-list.md)
+- [customer:info](./customer-info.md)
+- [customer:change-password](./customer-change-password.md)
+---

--- a/docs/docs/command-reference/db/index.md
+++ b/docs/docs/command-reference/db/index.md
@@ -1,0 +1,17 @@
+---
+title: Database Commands
+sidebar_label: Database
+---
+
+# Database Commands
+
+Commands for database operations such as dumps, imports, and queries.
+
+## Commands
+
+- [db:dump](./db-dump.md)
+- [db:import](./db-import.md)
+- [db:query](./db-query.md)
+- [db:create](./db-create.md)
+- [db:info](./db-info.md)
+---

--- a/docs/docs/command-reference/dev/index.md
+++ b/docs/docs/command-reference/dev/index.md
@@ -1,0 +1,16 @@
+---
+title: Developer Commands
+sidebar_label: Developer
+---
+
+# Developer Commands
+
+Commands tailored for Magento developers, including code generation and debugging tools.
+
+## Commands
+
+- [dev:module:create](./dev-module-create.md)
+- [dev:console](./dev-console.md)
+- [dev:translate:admin](./dev-translate-admin.md)
+- [dev:theme:list](./dev-theme-list.md)
+---

--- a/docs/docs/command-reference/eav/index.md
+++ b/docs/docs/command-reference/eav/index.md
@@ -1,0 +1,15 @@
+---
+title: EAV Commands
+sidebar_label: EAV
+---
+
+# EAV Commands
+
+Commands for managing EAV (Entity-Attribute-Value) attributes.
+
+## Commands
+
+- [eav:attribute:list](./eav-attribute-list.md)
+- [eav:attribute:view](./eav-attribute-view.md)
+- [eav:attribute:remove](./eav-attribute-remove.md)
+---

--- a/docs/docs/command-reference/generation/index.md
+++ b/docs/docs/command-reference/generation/index.md
@@ -1,0 +1,13 @@
+---
+title: Generation Commands
+sidebar_label: Generation
+---
+
+# Generation Commands
+
+Commands related to Magento's code generation processes.
+
+## Commands
+
+- [generation:flush](./generation-flush.md)
+---

--- a/docs/docs/command-reference/index.md
+++ b/docs/docs/command-reference/index.md
@@ -1,0 +1,27 @@
+---
+title: Command Reference
+sidebar_label: Overview
+---
+
+# Command Reference
+
+Welcome to the n98-magerun2 Command Reference. This section provides a detailed overview of all available commands, categorized by namespace.
+
+## Command Category/Namespace Overview
+
+This table will help you navigate to the relevant group of commands based on their functionality.
+
+| Category/Namespace | Description                                                                 | Example Commands                                                                   |
+| :----------------- | :-------------------------------------------------------------------------- | :--------------------------------------------------------------------------------- |
+| admin              | Commands for managing Magento admin user accounts and related settings.     | `admin:user:list`, `admin:user:create`, `admin:user:change-password`, `admin:notifications` |
+| cache              | Commands for interacting with and managing Magento's various cache systems. | `cache:clean`, `cache:disable`, `cache:enable`, `cache:flush`, `cache:list`            |
+| config             | Commands for managing Magento store configurations and environment settings.  | `config:store:get`, `config:store:set`, `config:env:set`, `config:search`              |
+| customer           | Commands for managing Magento customer accounts.                            | `customer:create`, `customer:list`, `customer:info`, `customer:change-password`      |
+| db                 | Commands for database operations such as dumps, imports, and queries.       | `db:dump`, `db:import`, `db:query`, `db:create`, `db:info`                         |
+| dev                | Commands tailored for Magento developers, including code generation and debugging tools. | `dev:module:create`, `dev:console`, `dev:translate:admin`, `dev:theme:list`            |
+| eav                | Commands for managing EAV (Entity-Attribute-Value) attributes.            | `eav:attribute:list`, `eav:attribute:view`, `eav:attribute:remove`                 |
+| generation         | Commands related to Magento's code generation processes.                    | `generation:flush`                                                                 |
+| index              | Commands for managing Magento's indexers.                                   | `index:list`, `index:trigger:recreate`                                             |
+| install            | Command for installing Magento.                                             | `install`                                                                          |
+| script             | Command for running sequences of n98-magerun2 commands from a file.       | `script`                                                                           |
+| sys                | Commands for system-level information, checks, and maintenance tasks.     | `sys:info`, `sys:check`, `sys:maintenance`, `sys:cron:list`, `sys:store:list`        |

--- a/docs/docs/command-reference/index/index.md
+++ b/docs/docs/command-reference/index/index.md
@@ -1,0 +1,14 @@
+---
+title: Index Commands
+sidebar_label: Index
+---
+
+# Index Commands
+
+Commands for managing Magento's indexers.
+
+## Commands
+
+- [index:list](./index-list.md)
+- [index:trigger:recreate](./index-trigger-recreate.md)
+---

--- a/docs/docs/command-reference/install/index.md
+++ b/docs/docs/command-reference/install/index.md
@@ -1,0 +1,13 @@
+---
+title: Install Commands
+sidebar_label: Install
+---
+
+# Install Commands
+
+Command for installing Magento.
+
+## Commands
+
+- [install](./install.md)
+---

--- a/docs/docs/command-reference/script/index.md
+++ b/docs/docs/command-reference/script/index.md
@@ -1,0 +1,13 @@
+---
+title: Script Commands
+sidebar_label: Script
+---
+
+# Script Commands
+
+Command for running sequences of n98-magerun2 commands from a file.
+
+## Commands
+
+- [script](./script.md)
+---

--- a/docs/docs/command-reference/sys/index.md
+++ b/docs/docs/command-reference/sys/index.md
@@ -1,0 +1,17 @@
+---
+title: System Commands
+sidebar_label: System
+---
+
+# System Commands
+
+Commands for system-level information, checks, and maintenance tasks.
+
+## Commands
+
+- [sys:info](./sys-info.md)
+- [sys:check](./sys-check.md)
+- [sys:maintenance](./sys-maintenance.md)
+- [sys:cron:list](./sys-cron-list.md)
+- [sys:store:list](./sys-store-list.md)
+---


### PR DESCRIPTION
I've established the basic directory and file structure for the new n98-magerun2 Command Reference within your Docusaurus site.

Key changes I made:
- I added a main landing page at `docs/docs/command-reference/index.md` with an overview table of command categories.
- I created subdirectories for each command category (admin, cache, config, etc.).
- I added an `index.md` file to each category subdirectory, populated with a title, description, and placeholder links for example commands.

This structure is designed to work with Docusaurus's autogenerated sidebar feature and provides the foundation for adding detailed documentation for each command.
