### PR TITLE
Fix PHP 8.4 deprecation warnings for implicitly nullable types (#1654)

### DIFF
--- a/src/N98/Magento/Application.php
+++ b/src/N98/Magento/Application.php
@@ -345,7 +345,7 @@ class Application extends BaseApplication
      * @return int
      * @throws Exception
      */
-    public function run(InputInterface $input = null, OutputInterface $output = null): int
+    public function run(?InputInterface $input = null, ?OutputInterface $output = null): int
     {
         if (null === $input) {
             $input = new ArgvInput();
@@ -403,8 +403,8 @@ class Application extends BaseApplication
      */
     public function init(
         array $initConfig = [],
-        InputInterface $input = null,
-        OutputInterface $output = null
+        ?InputInterface $input = null,
+        ?OutputInterface $output = null
     ) {
         if ($this->_isInitialized) {
             return;
@@ -653,7 +653,7 @@ class Application extends BaseApplication
      * @param OutputInterface $output [optional]
      * @throws Exception
      */
-    public function reinit($initConfig = [], InputInterface $input = null, OutputInterface $output = null)
+    public function reinit($initConfig = [], ?InputInterface $input = null, ?OutputInterface $output = null)
     {
         $this->_isInitialized = false;
         $this->detectionResult = null;

--- a/src/N98/Magento/Application/Config.php
+++ b/src/N98/Magento/Application/Config.php
@@ -64,7 +64,7 @@ class Config
      * @param bool $isPharMode
      * @param OutputInterface $output [optional]
      */
-    public function __construct(array $initConfig = [], $isPharMode = false, OutputInterface $output = null)
+    public function __construct(array $initConfig = [], $isPharMode = false, ?OutputInterface $output = null)
     {
         $this->initConfig = $initConfig;
         $this->isPharMode = (bool) $isPharMode;

--- a/src/N98/Magento/Application/ConfigFile.php
+++ b/src/N98/Magento/Application/ConfigFile.php
@@ -75,7 +75,7 @@ final class ConfigFile
      *
      * @return void
      */
-    public function applyVariables($magentoRootFolder, SplFileInfo $file = null)
+    public function applyVariables($magentoRootFolder, ?SplFileInfo $file = null)
     {
         $replace = [
             '%module%' => $file ? $file->getPath() : '',

--- a/src/N98/Magento/Application/ConfigurationLoader.php
+++ b/src/N98/Magento/Application/ConfigurationLoader.php
@@ -279,7 +279,7 @@ class ConfigurationLoader
      *
      * @return string
      */
-    protected function applyVariables($rawConfig, $magentoRootFolder, SplFileInfo $file = null)
+    protected function applyVariables($rawConfig, $magentoRootFolder, ?SplFileInfo $file = null)
     {
         $replace = [
             '%module%' => $file ? $file->getPath() : '',

--- a/src/N98/Magento/Command/SelfUpdateCommand.php
+++ b/src/N98/Magento/Command/SelfUpdateCommand.php
@@ -218,7 +218,7 @@ EOT
         string $localFilename,
         bool $isDryRun,
         bool $loadUnstable,
-        string $forcedVersion = null
+        ?string $forcedVersion = null
     ) {
         try {
             $this->downloadNewPhar($output, $remotePharDownloadUrl, $tempFilename);
@@ -550,7 +550,7 @@ EOT
     private function getChangelog(
         OutputInterface $output,
         bool $loadUnstable,
-        string $forcedVersion = null
+        ?string $forcedVersion = null
     ): string {
         $changelog = '';
 

--- a/src/N98/Util/Console/Helper/DatabaseHelper.php
+++ b/src/N98/Util/Console/Helper/DatabaseHelper.php
@@ -65,7 +65,7 @@ class DatabaseHelper extends AbstractHelper implements CommandAware
      * @throws FileSystemException
      * @return void
      */
-    public function detectDbSettings(OutputInterface $output)
+    public function detectDbSettings(?OutputInterface $output)
     {
         if (null !== $this->dbSettings) {
             return;
@@ -120,7 +120,7 @@ class DatabaseHelper extends AbstractHelper implements CommandAware
      * @throws RuntimeException pdo mysql extension is not installed
      * @throws FileSystemException
      */
-    public function getConnection(OutputInterface $output = null, bool $reconnect = false)
+    public function getConnection(?OutputInterface $output = null, bool $reconnect = false)
     {
         $output = $this->fallbackOutput($output);
 
@@ -573,7 +573,7 @@ class DatabaseHelper extends AbstractHelper implements CommandAware
      * @return array
      * @throws InvalidArgumentException if item is not an array or string
      */
-    private function resolveTablesArray(array $carry = null, $item = null)
+    private function resolveTablesArray(?array $carry = null, $item = null)
     {
         if (is_string($item)) {
             $item = preg_split('~\s+~', $item, -1, PREG_SPLIT_NO_EMPTY);
@@ -857,7 +857,7 @@ class DatabaseHelper extends AbstractHelper implements CommandAware
      *
      * @return OutputInterface
      */
-    private function fallbackOutput(OutputInterface $output = null)
+    private function fallbackOutput(?OutputInterface $output = null)
     {
         if (null !== $output) {
             return $output;

--- a/src/N98/Util/Console/Helper/MagentoHelper.php
+++ b/src/N98/Util/Console/Helper/MagentoHelper.php
@@ -75,7 +75,7 @@ class MagentoHelper extends AbstractHelper implements DetectionResultInterface, 
      * @param InputInterface $input
      * @param OutputInterface $output
      */
-    public function __construct(InputInterface $input = null, OutputInterface $output = null)
+    public function __construct(?InputInterface $input = null, ?OutputInterface $output = null)
     {
         if (null === $input) {
             $input = new ArgvInput();


### PR DESCRIPTION
Magerun pull-request check-list:

- [x] Pull request against develop branch (if not, just close and create a new one against it)
- [ ] README.md reflects changes (if any)
- [ ] phar fuctional test (in tests/phar-test.sh)

This commit addresses several PHP 8.4 deprecation warnings by adding explicit nullable type hints (`?`) to parameters that can be null.

The following files and methods were updated:

- `src/N98/Magento/Application.php`:
    - `run()`: `$input`, `$output`
    - `init()`: `$input`, `$output`
    - `reinit()`: `$input`, `$output`
- `src/N98/Magento/Application/Config.php`:
    - `__construct()`: `$output`
- `src/N98/Magento/Application/ConfigurationLoader.php`:
    - `applyVariables()`: `$file`
- `src/N98/Magento/Application/ConfigFile.php`:
    - `applyVariables()`: `$file`
- `src/N98/Util/Console/Helper/MagentoHelper.php`:
    - `__construct()`: `$input`, `$output`
- `src/N98/Magento/Command/SelfUpdateCommand.php`:
    - `updatePhar()`: `$forcedVersion`
    - `getChangelog()`: `$forcedVersion`
- `src/N98/Util/Console/Helper/DatabaseHelper.php`:
    - `getConnection()`: `$output`
    - `detectDbSettings()`: `$output`
    - `fallbackOutput()`: `$output`
    - `resolveTablesArray()`: `$carry`
