### PR TITLE
Fix: Make parameters explicitly nullable for PHP 8.4 compatibility

### DIFF
--- a/src/N98/Magento/Command/Developer/Console/Shell.php
+++ b/src/N98/Magento/Command/Developer/Console/Shell.php
@@ -37,7 +37,7 @@ class Shell extends PsyShell
      * @param OutputInterface|null $output
      * @return int
      */
-    public function run(InputInterface $input = null, OutputInterface $output = null): int
+    public function run(?InputInterface $input = null, ?OutputInterface $output = null): int
     {
         $this->registerHelpersFromMainApplication();
 

--- a/src/N98/Util/Http/DownloadException.php
+++ b/src/N98/Util/Http/DownloadException.php
@@ -25,7 +25,7 @@ class DownloadException extends RuntimeException
      * @param int $code The exception code
      * @param \Throwable|null $previous The previous throwable used for exception chaining
      */
-    public function __construct(string $message, string $remoteUrl, int $code = 0, Throwable $previous = null)
+    public function __construct(string $message, string $remoteUrl, int $code = 0, ?Throwable $previous = null)
     {
         parent::__construct($message, $code, $previous);
         $this->remoteUrl = $remoteUrl;


### PR DESCRIPTION
This commit addresses deprecation warnings identified by PHPCompatibility and PHPStan related to implicitly nullable parameters. In PHP 8.4, implicitly marking a parameter as nullable by providing a default null value without using the explicit '?' nullable type hint will be deprecated.

The following changes were made:

- In `src/N98/Util/Http/DownloadException.php`:
    - The `$previous` parameter in the `__construct` method is now explicitly nullable (`?Throwable`).

- In `src/N98/Magento/Command/Developer/Console/Shell.php`:
    - The `$input` parameter in the `run` method is now explicitly nullable (`?InputInterface`).
    - The `$output` parameter in the `run` method is now explicitly nullable (`?OutputInterface`).

These changes ensure that the codebase remains compatible with upcoming PHP versions and adheres to stricter type checking.

Magerun pull-request check-list:

- [x] Pull request against develop branch (if not, just close and create a new one against it)
- [ ] README.md reflects changes (if any)
- [ ] phar fuctional test (in tests/phar-test.sh)

Summary: (some words as summary)

Fixes #1659
