### PR TITLE
Fix: Update Docusaurus editUrl to develop branch

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -62,7 +62,7 @@ const config = {
           routeBasePath: '/',
           sidebarPath: require.resolve('./sidebars.js'),
           editUrl:
-            'https://github.com/netz98/n98-magerun2/edit/main/docs/'
+            'https://github.com/netz98/n98-magerun2/edit/develop/docs/'
         },
         theme: {
           customCss: require.resolve('./src/css/custom.css')


### PR DESCRIPTION
The 'Edit this page' link in the documentation was incorrectly pointing to the 'main' branch.

This commit updates the 'editUrl' in 'docs/docusaurus.config.js' to point to the 'develop' branch, which is the correct default branch for this project.

Magerun pull-request check-list:

- [x] Pull request against develop branch (if not, just close and create a new one against it)
- [ ] README.md reflects changes (if any)
- [ ] phar fuctional test (in tests/phar-test.sh)
