### PR TITLE
docs: add hint and links for config commands

### DIFF
--- a/docs/docs/extending/configuration.md
+++ b/docs/docs/extending/configuration.md
@@ -14,7 +14,8 @@ Configs can be loaded on different levels:
 
 All configs will be merged in the following order: `buildin -> system -> user -> project`
 
-To verify which config is loaded, you can use the command `magerun:config:show`.
+To verify which config is loaded, you can use the command [`magerun:config:show`](../command-docs/magerun/magerun-config-show.md).
+The commands [`magerun:config:info`](../command-docs/magerun/magerun-config-info.md) and [`magerun:config:dump`](../command-docs/magerun/magerun-config-dump.md) are also useful to debug all configuration changes.
 
 ## Example Config 
 


### PR DESCRIPTION
Added a hint to the `magerun:config:info` and magerun:config:dump commands to the documentation page "docs/docs/extending/configuration.md". These commands are useful for debugging configuration changes.

Also added links to the documentation for `magerun:config:show`, `magerun:config:info`, and `magerun:config:dump` commands.

Magerun pull-request check-list:

- [x] Pull request against develop branch (if not, just close and create a new one against it)
- [ ] README.md reflects changes (if any)
- [ ] phar fuctional test (in tests/phar-test.sh)