### PR TITLE
Add Quick Start and update installation docs

### DIFF
--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -77,6 +77,12 @@ We offer a special dist package to install the phar file via Composer.
 See (https://packagist.org/packages/n98/magerun2-dist) for more details.
 The main advantage of the dist package is that there are no package dependencies.
 
+```bash
+composer require n98/magerun2-dist
+```
+
+For details on building the phar file yourself, see the [Development Guidelines](./intro.md#n98-magerun2-development-guidelines).
+
 ## Install with Composer (Source Package) - not recommended
 
 The installation via Composer is **not recommended**,

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -68,6 +68,18 @@ When you're ready, head over to the installation instructions to add n98-magerun
 
 ---
 
+## 🚀 Quick Start
+
+Ready to get n98-magerun2 up and running?
+
+1.  **Review Compatibility**: Check the [Compatibility Page](./compatibility.md) to ensure it works with your Magento and PHP versions.
+2.  **Install**: Follow our [Installation Guide](./installation.md) to add n98-magerun2 to your system or project.
+3.  **Explore Commands**: Once installed, run `n98-magerun2 list` to see all available commands, or browse the [Command Documentation](./command-docs/).
+
+This will get you started quickly with the most important first steps.
+
+---
+
 # n98-magerun2 Development Guidelines
 
 This document provides essential information for developers working on the n98-magerun2 project.


### PR DESCRIPTION
This commit introduces a new "Quick Start" section to the main introduction page (`docs/docs/intro.md`) to help you get started more easily. It includes links to compatibility, installation, and command documentation.

Additionally, the `docs/docs/installation.md` page has been updated:
- Added the `composer require n98/magerun2-dist` command snippet to the "Install the phar via Composer" section.
- Added a link to the "n98-magerun2 Development Guidelines" (in intro.md) for those of you interested in building the phar file yourselves.

Magerun pull-request check-list:

- [x] Pull request against develop branch (if not, just close and create a new one against it)
- [ ] README.md reflects changes (if any)
- [ ] phar fuctional test (in tests/phar-test.sh)