### PR TITLE
fix: enhance TTY handling in proxy command to ensure proper terminal …

### DIFF
--- a/src/N98/Magento/Command/MagentoCoreProxyCommand.php
+++ b/src/N98/Magento/Command/MagentoCoreProxyCommand.php
@@ -79,7 +79,10 @@ class MagentoCoreProxyCommand extends AbstractMagentoCommand
         );
 
         $process->setTimeout($config['timeout']);
-        $process->setTty($input->isInteractive() && Process::isTtySupported());
+        // Enable TTY only if input is interactive and output is a terminal (not piped)
+        $isInteractive = $input->isInteractive();
+        $isOutputTerminal = function_exists('posix_isatty') && posix_isatty(STDOUT);
+        $process->setTty($isInteractive && $isOutputTerminal && Process::isTtySupported());
 
         if (OutputInterface::VERBOSITY_VERBOSE <= $output->getVerbosity()) {
             $output->writeln(sprintf('<debug>Execute: <comment>%s</comment></debug>', $process->getCommandLine()));

--- a/tests/bats/functional_core_commands.bats
+++ b/tests/bats/functional_core_commands.bats
@@ -245,6 +245,20 @@ setup() {
   assert_output --partial "List of enabled modules"
 }
 
+@test "Command: module:status - #1422" {
+  # Issue: 1422 - cannot be grepped without -n option
+
+  # With non interactive shell
+  run bash -c "$BIN 'module:status' --no-interaction | grep 'Magento_Catalog'"
+  assert_success
+  assert_output --partial "Magento_Catalog"
+
+  # With interactive shell
+  run bash -c "$BIN 'module:status' | grep 'Magento_Catalog'"
+  assert_success
+  assert_output --partial "Magento_Catalog"
+}
+
 @test "Command: queue:consumers:list" {
   run $BIN "queue:consumers:list"
   assert_output --partial "async.operations.all"


### PR DESCRIPTION
Thank you for contributing to n98-magerun2! 🚀

Before you submit your pull request, please review the checklist below:

- [x] This pull request targets the `develop` branch (if not, please close and re-open against it)
- [ ] Documentation in the `docs/docs` directory reflects any relevant changes *(do not update the README.md for documentation)*
- [ ] All tests pass, including the phar functional test (`tests/phar-test.sh`)
- [x] I have read and followed the [Contribution Guide](https://netz98.github.io/n98-magerun2/contributing/) (highly recommended for all contributors!)

💡 _Hint: The [Contribution Guide](https://netz98.github.io/n98-magerun2/contributing/) contains helpful tips and requirements for submitting a successful pull request._

---

## Related Issue(s)

- #1422 

## Summary

I've updated the TTY logic in MagentoCoreProxyCommand so that TTY is only enabled if both the input is interactive and the output is a terminal (not being piped). This means you can now use commands like n98-magerun2 module:status | grep friendly without needing to add the -n flag, matching the behavior of bin/magento.


