### PR TITLE
docs: Correct issue link for patch version stripping

### DIFF
--- a/src/N98/Magento/Command/Developer/Module/DetectComposerDependenciesCommand.php
+++ b/src/N98/Magento/Command/Developer/Module/DetectComposerDependenciesCommand.php
@@ -360,7 +360,7 @@ class DetectComposerDependenciesCommand extends AbstractMagentoCommand
 
             /**
              * remove patch level (e.g. -p5) from version
-             * @link https://github.com/netz98/n98-magerun2/issues/1358
+             * @link https://github.com/netz98/n98-magerun2/issues/1357
              */
             $version = preg_replace('/-p[0-9]+$/', '', $version);
 


### PR DESCRIPTION
The comment above the code that removes patch level suffixes (e.g., -p5) from Magento module versions in the
dev:module:detect-composer-dependencies command output incorrectly linked to issue #1358.

The underlying code for removing patch versions was already in place and functioning as intended.

Before you submit your pull request, please review the checklist below:

- [x] This pull request targets the `develop` branch (if not, please close and re-open against it)
- [ ] Documentation in the `docs/docs` directory reflects any relevant changes *(do not update the README.md for documentation)*
- [ ] All tests pass, including the phar functional test (`tests/phar-test.sh`)
- [x] I have read and followed the [Contribution Guide](https://netz98.github.io/n98-magerun2/contributing/) (highly recommended for all contributors!)

💡 _Hint: The [Contribution Guide](https://netz98.github.io/n98-magerun2/contributing/) contains helpful tips and requirements for submitting a successful pull request._

---

## Related Issue(s)

#1358 

