### PR TITLE
feat(db): Add view handling to db:dump and db:drop commands (#602)

### DIFF
--- a/docs/docs/command-docs/db/db-drop.md
+++ b/docs/docs/command-docs/db/db-drop.md
@@ -20,8 +20,52 @@ n98-magerun2.phar db:drop [options]
 |--------------------------|-----------------------------------------------------------------------------|
 | `--connection=CONNECTION`| Select DB connection type for Magento configurations with several databases |
 | `-t, --tables`           | Drop all tables instead of dropping the database                            |
-| `-f, --force`            | Force                                                                       |
+| `--drop-views`           | Drop all views in the database                                              |
+| `-f, --force`            | Force execution without confirmation                                        |
 
-**Help:**
+**Help and Usage Scenarios:**
 
-The command prompts before dropping the database. If `--force` option is specified it directly drops the database. The configured user in `app/etc/env.php` must have "DROP" privileges.
+The command prompts before performing any drop operation unless the `--force` option is specified. The configured user in `app/etc/env.php` must have "DROP" privileges.
+
+The `db:drop` command can be used to drop the entire database, only tables, or only views:
+
+*   **Drop entire database:**
+    If run without `--tables` or `--drop-views`, the command will target the entire database.
+    ```sh
+    n98-magerun2.phar db:drop
+    ```
+    With force:
+    ```sh
+    n98-magerun2.phar db:drop --force
+    ```
+    This action drops all tables, views, and other database objects.
+
+*   **Drop only tables:**
+    Use the `--tables` option.
+    ```sh
+    n98-magerun2.phar db:drop --tables
+    ```
+    With force:
+    ```sh
+    n98-magerun2.phar db:drop --tables --force
+    ```
+
+*   **Drop only views:**
+    Use the `--drop-views` option.
+    ```sh
+    n98-magerun2.phar db:drop --drop-views
+    ```
+    With force:
+    ```sh
+    n98-magerun2.phar db:drop --drop-views --force
+    ```
+
+*   **Drop both tables and views (but not other DB objects like procedures, etc.):**
+    Specify both `--tables` and `--drop-views`.
+    ```sh
+    n98-magerun2.phar db:drop --tables --drop-views
+    ```
+    With force:
+    ```sh
+    n98-magerun2.phar db:drop --tables --drop-views --force
+    ```

--- a/docs/docs/command-docs/db/db-dump.md
+++ b/docs/docs/command-docs/db/db-dump.md
@@ -48,12 +48,36 @@ n98-magerun2.phar db:dump [options] [--] [<filename>]
 | `--set-gtid-purged-off`             | Adds --set-gtid-purged=OFF to mysqldump.                                                                                             |
 | `--stdout`                          | Dump to stdout.                                                                                                                      |
 | `-s, --strip=STRIP`                 | Tables to strip (dump only structure of those tables). Multiple values and table groups (e.g. `@log`) allowed.                        |
+| `--views`                           | Explicitly include views in the dump. Views are included by default if not otherwise excluded by name or by `--no-views`.              |
+| `--no-views`                        | Exclude all views from the dump. This overrides any other view inclusion.                                                            |
 | `--zstd-level[=ZSTD-LEVEL]`         | ZSTD compression level. (default: `10`)                                                                                              |
 | `--zstd-extra-args[=ZSTD-EXTRA-ARGS]` | Custom extra options for zstd.                                                                                                       |
 
 (For a full list of strip table groups and other options, use `n98-magerun2.phar help db:dump`)
 
+**View Handling in Dumps:**
+
+By default, `db:dump` includes views if their underlying tables are dumped or if the entire database is dumped. The following options provide more control:
+
+*   `--views`: This option can be used to explicitly state that views should be included. Since views are generally included by default if not otherwise excluded (e.g., by a specific table exclusion pattern that happens to match a view name, or by `--no-views`), this option is mainly for clarity or to ensure views are included if a very broad exclusion pattern might accidentally exclude them.
+*   `--no-views`: This option ensures that **no views** are included in the dump. Their definitions will not be present in the SQL file. This option takes precedence over any other rules that might otherwise include a view (e.g., if a view name matches an `--include` pattern or is part of a table list provided for the dump).
+
 **Examples:**
+
+Dump database without any views:
+```sh
+n98-magerun2.phar db:dump --no-views dump_without_views.sql
+```
+
+Explicitly include views (usually default behavior):
+```sh
+n98-magerun2.phar db:dump --views dump_with_views.sql
+```
+
+If `my_view_name` is a view, and you want to ensure its definition is not dumped, even if it was part of a `--strip` pattern that would normally dump structure:
+```sh
+n98-magerun2.phar db:dump --strip="my_view_name" --no-views dump_stripped_no_view_def.sql
+```
 
 Only the dump command:
 

--- a/src/N98/Magento/Command/Database/DropCommand.php
+++ b/src/N98/Magento/Command/Database/DropCommand.php
@@ -22,13 +22,28 @@ class DropCommand extends AbstractDatabaseCommand
         $this
             ->setName('db:drop')
             ->addOption('tables', 't', InputOption::VALUE_NONE, 'Drop all tables instead of dropping the database')
+            ->addOption('drop-views', null, InputOption::VALUE_NONE, 'Drop all views in the database')
             ->addOption('force', 'f', InputOption::VALUE_NONE, 'Force')
-            ->setDescription('Drop current database');
+            ->setDescription('Drop current database, tables or views');
 
         $help = <<<HELP
-The command prompts before dropping the database. If --force option is specified it
-directly drops the database.
+The command prompts before dropping the database/tables/views.
+If --force option is specified it directly performs the drop operation.
 The configured user in app/etc/env.php must have "DROP" privileges.
+
+Usage:
+  db:drop                                   (Prompts to drop the entire database)
+  db:drop --force                           (Drops the entire database without prompting)
+  db:drop --tables                          (Prompts to drop all tables)
+  db:drop --tables --force                  (Drops all tables without prompting)
+  db:drop --drop-views                      (Prompts to drop all views)
+  db:drop --drop-views --force              (Drops all views without prompting)
+  db:drop --tables --drop-views             (Prompts to drop all tables and all views)
+  db:drop --tables --drop-views --force     (Drops all tables and all views without prompting)
+
+If neither --tables nor --drop-views is specified, the entire database will be dropped.
+If --tables is specified, only tables will be dropped (unless --drop-views is also specified).
+If --drop-views is specified, only views will be dropped (unless --tables is also specified).
 HELP;
         $this->setHelp($help);
     }
@@ -68,9 +83,18 @@ HELP;
         }
 
         if ($shouldDrop) {
+            $droppedSomething = false;
             if ($input->getOption('tables')) {
                 $dbHelper->dropTables($output);
-            } else {
+                $droppedSomething = true;
+            }
+            if ($input->getOption('drop-views')) {
+                $dbHelper->dropViews($output);
+                $droppedSomething = true;
+            }
+
+            // If neither --tables nor --drop-views was specified, then drop the entire database.
+            if (!$droppedSomething) {
                 $dbHelper->dropDatabase($output);
             }
         }

--- a/tests/N98/Util/Console/Helper/DatabaseHelperTest.php
+++ b/tests/N98/Util/Console/Helper/DatabaseHelperTest.php
@@ -171,4 +171,231 @@ class DatabaseHelperTest extends TestCase
         $this->assertContains('directory_country', $tables);
         $this->assertNotContains('catalogrule', $tables);
     }
+
+    /**
+     * @test
+     */
+    public function testGetViewsNoViewsFound()
+    {
+        $statementMock = $this->getMockBuilder(\PDOStatement::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $statementMock->expects($this->once())
+            ->method('execute');
+        $statementMock->expects($this->once())
+            ->method('fetchAll')
+            ->with(\PDO::FETCH_COLUMN)
+            ->willReturn([]);
+
+        $pdoMock = $this->getMockBuilder(\PDO::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $pdoMock->expects($this->once())
+            ->method('prepare')
+            ->with($this->stringContains('SELECT table_name FROM information_schema.VIEWS WHERE table_schema = :dbname'))
+            ->willReturn($statementMock);
+
+        $helper = $this->getMockBuilder(DatabaseHelper::class)
+            ->onlyMethods(['getConnection']) // Mock only getConnection
+            ->getMock();
+        $helper->expects($this->once())
+            ->method('getConnection')
+            ->willReturn($pdoMock);
+
+        // Manually set dbSettings as it's used directly
+        $reflection = new \ReflectionProperty(DatabaseHelper::class, 'dbSettings');
+        $reflection->setAccessible(true);
+        $reflection->setValue($helper, ['dbname' => 'test_db']);
+
+        $this->assertEquals([], $helper->getViews());
+    }
+
+    /**
+     * @test
+     */
+    public function testGetViewsSingleViewFound()
+    {
+        $expectedViews = ['my_single_view'];
+        $statementMock = $this->getMockBuilder(\PDOStatement::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $statementMock->expects($this->once())->method('execute');
+        $statementMock->expects($this->once())
+            ->method('fetchAll')
+            ->with(\PDO::FETCH_COLUMN)
+            ->willReturn($expectedViews);
+
+        $pdoMock = $this->getMockBuilder(\PDO::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $pdoMock->expects($this->once())
+            ->method('prepare')
+            ->willReturn($statementMock);
+
+        $helper = $this->getMockBuilder(DatabaseHelper::class)
+            ->onlyMethods(['getConnection'])
+            ->getMock();
+        $helper->expects($this->once())
+            ->method('getConnection')
+            ->willReturn($pdoMock);
+        $reflection = new \ReflectionProperty(DatabaseHelper::class, 'dbSettings');
+        $reflection->setAccessible(true);
+        $reflection->setValue($helper, ['dbname' => 'test_db']);
+
+
+        $this->assertEquals($expectedViews, $helper->getViews());
+    }
+
+    /**
+     * @test
+     */
+    public function testGetViewsMultipleViewsFound()
+    {
+        $expectedViews = ['view_one', 'view_two', 'view_three'];
+        $statementMock = $this->getMockBuilder(\PDOStatement::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $statementMock->expects($this->once())->method('execute');
+        $statementMock->expects($this->once())
+            ->method('fetchAll')
+            ->with(\PDO::FETCH_COLUMN)
+            ->willReturn($expectedViews);
+
+        $pdoMock = $this->getMockBuilder(\PDO::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $pdoMock->expects($this->once())
+            ->method('prepare')
+            ->willReturn($statementMock);
+
+        $helper = $this->getMockBuilder(DatabaseHelper::class)
+            ->onlyMethods(['getConnection'])
+            ->getMock();
+        $helper->expects($this->once())
+            ->method('getConnection')
+            ->willReturn($pdoMock);
+        $reflection = new \ReflectionProperty(DatabaseHelper::class, 'dbSettings');
+        $reflection->setAccessible(true);
+        $reflection->setValue($helper, ['dbname' => 'test_db']);
+
+        $this->assertEquals($expectedViews, $helper->getViews());
+    }
+
+    /**
+     * @test
+     */
+    public function testDropViewsNoViews()
+    {
+        $outputMock = $this->getMockBuilder(\Symfony\Component\Console\Output\OutputInterface::class)
+            ->getMock();
+        $outputMock->expects($this->once())
+            ->method('writeln')
+            ->with('<comment>No views found to drop.</comment>');
+
+        $helper = $this->getMockBuilder(DatabaseHelper::class)
+            ->onlyMethods(['getViews', 'getConnection']) // Mock getViews and getConnection
+            ->getMock();
+        $helper->expects($this->once())
+            ->method('getViews')
+            ->willReturn([]);
+        $helper->expects($this->never()) // getConnection should not be called if no views
+            ->method('getConnection');
+
+        $helper->dropViews($outputMock);
+    }
+
+    /**
+     * @test
+     */
+    public function testDropViewsWithViews()
+    {
+        $viewsToDrop = ['view_alpha', 'view_beta'];
+        $outputMessages = [];
+
+        $outputMock = $this->getMockBuilder(\Symfony\Component\Console\Output\OutputInterface::class)
+            ->getMock();
+        $outputMock->expects($this->any())
+            ->method('writeln')
+            ->will($this->returnCallback(function ($message) use (&$outputMessages) {
+                $outputMessages[] = $message;
+            }));
+
+        $pdoMock = $this->getMockBuilder(\PDO::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $pdoMock->expects($this->exactly(4)) // SET FOREIGN_KEY_CHECKS=0, DROP VIEW 1, DROP VIEW 2, SET FOREIGN_KEY_CHECKS=1
+            ->method('exec')
+            ->withConsecutive(
+                [$this->equalTo('SET FOREIGN_KEY_CHECKS = 0;')],
+                [$this->equalTo('DROP VIEW IF EXISTS `view_alpha`;')],
+                [$this->equalTo('DROP VIEW IF EXISTS `view_beta`;')],
+                [$this->equalTo('SET FOREIGN_KEY_CHECKS = 1;')]
+            )
+            ->willReturn(1); // Simulate successful execution
+
+        $helper = $this->getMockBuilder(DatabaseHelper::class)
+            ->onlyMethods(['getViews', 'getConnection'])
+            ->getMock();
+        $helper->expects($this->once())
+            ->method('getViews')
+            ->willReturn($viewsToDrop);
+        $helper->expects($this->once()) // getConnection is called once
+            ->method('getConnection')
+            ->willReturn($pdoMock);
+
+        $helper->dropViews($outputMock);
+
+        $this->assertContains('<info>Dropping views...</info>', $outputMessages);
+        $this->assertContains('<comment>Dropped view:</comment> view_alpha', $outputMessages);
+        $this->assertContains('<comment>Dropped view:</comment> view_beta', $outputMessages);
+        $this->assertContains('<info>Dropped 2 views.</info>', $outputMessages);
+    }
+
+    /**
+     * @test
+     */
+    public function testDropViewsHandlesException()
+    {
+        $viewsToDrop = ['problem_view'];
+
+        $outputMock = $this->getMockBuilder(\Symfony\Component\Console\Output\OutputInterface::class)
+            ->getMock();
+        // We don't care about specific messages here, just that it might write something
+
+        $pdoMock = $this->getMockBuilder(\PDO::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        // First exec (SET FOREIGN_KEY_CHECKS = 0) is fine
+        // Second exec (DROP VIEW) throws exception
+        // Third exec (SET FOREIGN_KEY_CHECKS = 1 in catch) should still be called
+        $pdoMock->expects($this->exactly(3))
+            ->method('exec')
+            ->withConsecutive(
+                [$this->equalTo('SET FOREIGN_KEY_CHECKS = 0;')],
+                [$this->equalTo('DROP VIEW IF EXISTS `problem_view`;')],
+                [$this->equalTo('SET FOREIGN_KEY_CHECKS = 1;')]
+            )
+            ->willReturnOnConsecutiveCalls(
+                $this->returnValue(1),                            // SET FOREIGN_KEY_CHECKS = 0;
+                $this->throwException(new \PDOException('Drop failed')), // DROP VIEW problem_view
+                $this->returnValue(1)                             // SET FOREIGN_KEY_CHECKS = 1;
+            );
+
+
+        $helper = $this->getMockBuilder(DatabaseHelper::class)
+            ->onlyMethods(['getViews', 'getConnection'])
+            ->getMock();
+        $helper->expects($this->once())
+            ->method('getViews')
+            ->willReturn($viewsToDrop);
+        $helper->expects($this->once())
+            ->method('getConnection')
+            ->willReturn($pdoMock);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Error dropping views: Drop failed');
+
+        $helper->dropViews($outputMock);
+    }
 }

--- a/tests/functional_tests_views.md
+++ b/tests/functional_tests_views.md
@@ -1,0 +1,232 @@
+# Functional Tests for View Handling in db:drop and db:dump
+
+This document outlines the manual functional tests for verifying the new view-handling capabilities in `db:drop` and `db:dump` commands.
+
+**Prerequisites:**
+*   A working Magento 2 instance.
+*   `n98-magerun2` installed and configured for the Magento instance.
+*   MySQL client tools available for database inspection and dump import.
+*   Ability to create and drop databases, tables, and views in your MySQL environment.
+
+## Common Setup Steps:
+
+For many tests, you'll need a database with specific tables and views.
+
+**Database Schema Creation SQL:**
+```sql
+-- Create dummy tables
+CREATE TABLE IF NOT EXISTS test_table1 (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    data VARCHAR(255)
+);
+
+CREATE TABLE IF NOT EXISTS test_table2 (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    description TEXT
+);
+
+-- Populate with some data (optional, but good for verifying dumps)
+INSERT INTO test_table1 (data) VALUES ('Sample data 1'), ('Sample data 2');
+INSERT INTO test_table2 (description) VALUES ('Description for T2-1'), ('Description for T2-2');
+
+-- Create dummy views
+-- Note: Adjust view definitions if 'core_config_data' or other tables don't exist or are empty in your test env.
+-- A simple view on a known table is sufficient.
+CREATE OR REPLACE VIEW test_view1 AS SELECT id, data FROM test_table1 WHERE id = 1;
+CREATE OR REPLACE VIEW test_view2 AS SELECT description FROM test_table2 LIMIT 1;
+
+-- Example view for dump tests that might be part of a @stripped group
+CREATE OR REPLACE VIEW test_view_stripped AS SELECT * FROM test_table1 LIMIT 1;
+
+-- Verify creation (optional)
+-- SHOW FULL TABLES;
+-- SELECT * FROM test_view1;
+-- SELECT * FROM test_view2;
+```
+
+**Cleanup SQL (after each test case if needed):**
+```sql
+DROP VIEW IF EXISTS test_view1;
+DROP VIEW IF EXISTS test_view2;
+DROP VIEW IF EXISTS test_view_stripped;
+DROP TABLE IF EXISTS test_table1;
+DROP TABLE IF EXISTS test_table2;
+-- To drop the entire database (if the test case requires it):
+-- DROP DATABASE your_magento_db_name;
+-- CREATE DATABASE your_magento_db_name;
+-- USE your_magento_db_name;
+```
+
+Remember to replace `your_magento_db_name` with the actual name of your Magento test database.
+
+---
+
+## I. `db:drop` Command Tests
+
+### Test Case D1: Drop Views Only
+
+1.  **Setup:**
+    *   Execute the "Database Schema Creation SQL" above in your Magento database.
+    *   Verify that `test_table1`, `test_table2`, `test_view1`, and `test_view2` exist.
+2.  **Command:**
+    ```bash
+    n98-magerun2 db:drop --drop-views --force
+    ```
+3.  **Expected Outcome:**
+    *   `test_view1` and `test_view2` are dropped.
+    *   `test_table1` and `test_table2` still exist.
+4.  **Verification:**
+    *   Connect to the database and check:
+        *   `SHOW TABLES LIKE 'test_view1';` (should return empty set)
+        *   `SHOW TABLES LIKE 'test_view2';` (should return empty set)
+        *   `SELECT COUNT(*) FROM test_table1;` (should return original count)
+        *   `SELECT COUNT(*) FROM test_table2;` (should return original count)
+
+### Test Case D2: Drop Tables and Views
+
+1.  **Setup:**
+    *   Execute the "Database Schema Creation SQL" above.
+    *   Verify tables and views exist.
+2.  **Command:**
+    ```bash
+    n98-magerun2 db:drop --tables --drop-views --force
+    ```
+3.  **Expected Outcome:**
+    *   `test_table1`, `test_table2`, `test_view1`, and `test_view2` are all dropped.
+4.  **Verification:**
+    *   Connect to the database and check:
+        *   `SHOW TABLES LIKE 'test_view1';` (empty)
+        *   `SHOW TABLES LIKE 'test_view2';` (empty)
+        *   `SHOW TABLES LIKE 'test_table1';` (empty)
+        *   `SHOW TABLES LIKE 'test_table2';` (empty)
+
+### Test Case D3: Drop Entire Database (includes views)
+
+1.  **Setup:**
+    *   Execute the "Database Schema Creation SQL" above.
+    *   Verify tables and views exist.
+2.  **Command:**
+    ```bash
+    n98-magerun2 db:drop --force
+    ```
+3.  **Expected Outcome:**
+    *   The entire database is dropped.
+4.  **Verification:**
+    *   Attempting to connect to the database or listing tables should fail or show an empty database (depending on your MySQL client and if `n98-magerun2` recreates it).
+    *   If `n98-magerun2 db:info` is run, it should indicate the database doesn't exist or has no tables.
+
+---
+
+## II. `db:dump` Command Tests (using `mysqldump` path)
+
+**Note:** For these tests, ensure `mydumper` is not installed or not prioritized, so `mysqldump` is used. You might need to temporarily uninstall `mydumper` or use a specific n98-magerun2 configuration if it defaults to `mydumper`.
+
+**Setup for Dump Tests:**
+*   Execute the "Database Schema Creation SQL" in your Magento database.
+*   Create a separate, empty database (e.g., `test_import_db`) for importing and verifying the dumps.
+
+### Test Case P1: Default Dump (should include views)
+
+1.  **Command:**
+    ```bash
+    n98-magerun2 db:dump dump_default.sql.gz --compression="gz"
+    ```
+2.  **Verification:**
+    *   Unzip `dump_default.sql.gz` to `dump_default.sql`.
+    *   Import `dump_default.sql` into `test_import_db`.
+    *   In `test_import_db`:
+        *   Check `test_table1` exists and has data.
+        *   Check `test_view1` exists and can be queried (e.g., `SELECT * FROM test_view1;`).
+        *   Inspect `dump_default.sql` content:
+            *   It should contain `CREATE TABLE test_table1 ...;`
+            *   It should contain `INSERT INTO test_table1 ...;`
+            *   It should contain `CREATE ALGORITHM=UNDEFINED DEFINER=... SQL SECURITY DEFINER VIEW \`test_view1\` AS SELECT ... FROM \`test_table1\` ...;` (or similar view creation syntax).
+
+### Test Case P2: Dump with `--no-views`
+
+1.  **Command:**
+    ```bash
+    n98-magerun2 db:dump --no-views dump_no_views.sql.gz --compression="gz"
+    ```
+2.  **Verification:**
+    *   Unzip and import `dump_no_views.sql` into `test_import_db` (after clearing it).
+    *   In `test_import_db`:
+        *   `test_table1` should exist and have data.
+        *   `test_view1` should NOT exist. Trying `SELECT * FROM test_view1;` should result in an error (table/view not found).
+    *   Inspect `dump_no_views.sql` content:
+        *   It should contain `CREATE TABLE test_table1 ...;`
+        *   It should NOT contain any `CREATE VIEW test_view1 ...;` statement.
+
+### Test Case P3: Dump with `--views` (explicit include)
+
+1.  **Command:**
+    ```bash
+    n98-magerun2 db:dump --views dump_with_views.sql.gz --compression="gz"
+    ```
+2.  **Verification:** (This should behave like the default dump)
+    *   Unzip and import `dump_with_views.sql` into `test_import_db`.
+    *   In `test_import_db`:
+        *   `test_table1` exists and has data.
+        *   `test_view1` exists and can be queried.
+    *   Inspect `dump_with_views.sql`: It should contain the `CREATE VIEW test_view1 ...;` statement.
+
+### Test Case P4: `--no-views` with `--strip="@stripped"` (view in stripped group)
+
+1.  **Setup:**
+    *   Ensure `test_view_stripped` is created from the common setup.
+    *   Configure a table group `@stripped` in your n98-magerun2 config (e.g., `config/commands/db.yaml` or global config) to include `test_view_stripped`. Example:
+        ```yaml
+        commands:
+          N98\Magento\Command\Database\DumpCommand:
+            table-groups:
+              - id: "stripped"
+                description: "Tables to be stripped for development"
+                tables:
+                  - "test_view_stripped" # This is a view
+                  - "another_table_to_strip"
+        ```
+2.  **Command:**
+    ```bash
+    n98-magerun2 db:dump --strip="@stripped" --no-views dump_strip_no_views.sql.gz --compression="gz"
+    ```
+3.  **Verification:**
+    *   Unzip and import `dump_strip_no_views.sql` into `test_import_db`.
+    *   In `test_import_db`:
+        *   `test_view_stripped` should NOT exist.
+    *   Inspect `dump_strip_no_views.sql`:
+        *   It should NOT contain `CREATE VIEW test_view_stripped ...;` (neither structure nor data, as views don't have data in the same way tables do, and `--no-views` should prevent its definition from being dumped).
+        *   If `another_table_to_strip` was an actual table, its structure (`CREATE TABLE`) should be present, but no `INSERT INTO`.
+
+### Test Case P5: `--no-views` with explicit table list that includes a view name
+
+1.  **Setup:** (No special group needed)
+2.  **Command:** (This scenario tests if `--no-views` overrides an explicit mention of a view name in the general tables list for mysqldump if that were possible. However, mysqldump typically takes table names, and views are implicitly included unless ignored. The `--no-views` should add all views to the ignore list.)
+    ```bash
+    n98-magerun2 db:dump --no-views test_table1 test_view1 dump_explicit_list_no_views.sql.gz --compression="gz"
+    ```
+    *(Note: `mysqldump` usually takes table names after options. If `test_view1` is passed as a "table to dump" and `--no-views` is also passed, the view should still be excluded due to `--no-views` adding it to the ignore list.)*
+3.  **Verification:**
+    *   Unzip and import `dump_explicit_list_no_views.sql` into `test_import_db`.
+    *   In `test_import_db`:
+        *   `test_table1` should exist.
+        *   `test_view1` should NOT exist.
+    *   Inspect `dump_explicit_list_no_views.sql`: It should not contain `CREATE VIEW test_view1 ...;`.
+
+### Test Case P6: Default dump with `--strip="test_view1"`
+
+1.  **Command:**
+    ```bash
+    n98-magerun2 db:dump --strip="test_view1" dump_strip_view.sql.gz --compression="gz"
+    ```
+2.  **Verification:**
+    *   Unzip and import `dump_strip_view.sql` into `test_import_db`.
+    *   In `test_import_db`:
+        *   `test_view1` should exist (as its definition should be dumped).
+        *   Querying `test_view1` should work.
+    *   Inspect `dump_strip_view.sql`:
+        *   It SHOULD contain the `CREATE VIEW test_view1 ...;` statement (structure). Since views don't store data themselves, stripping a view means its definition is dumped, which is the default behavior for views anyway when not excluded. The key is that it's not *excluded*.
+
+---
+*(Similar test cases should be designed for the `mydumper` path if it's a critical component, focusing on its specific options like `--ignore-table` for views when `--no-views` is used, and how it handles stripped views (mydumper might not have a direct equivalent of stripping a view's "data" as it's just a definition).)*
+
+```


### PR DESCRIPTION
Adds new options to control the inclusion and exclusion of database views during dump and drop operations, addressing issue #602.

New Functionality:

- `db:dump`:
    - `--views`: Explicitly include views in the dump (this is generally the default behavior).
    - `--no-views`: Exclude all views from the dump. This overrides other flags that might otherwise include a view by name (e.g., if a view is part of an `--include` pattern or not in an `--exclude` or `--strip` pattern).
- `db:drop`:
    - `--drop-views`: Specifically drops all views in the database. Can be used in conjunction with `--tables` to drop both, or independently.

Details:

- `DatabaseHelper` was enhanced with `getViews()` and `dropViews()` methods.
- `DumpCommand` now correctly processes these options for both `mysqldump` and `mydumper` execution paths, ensuring views are ignored or their structure is not dumped if specified.
- `DropCommand` integrates `dropViews()` to allow targeted deletion of views.
- Unit tests were added for the new `DatabaseHelper` methods.
- A functional test plan (`tests/functional_tests_views.md`) was created to guide manual testing of the command functionalities.
- Command documentation for `db:dump` and `db:drop` has been updated to reflect these new options and their usage.

- [x] This pull request targets the `develop` branch (if not, please close and re-open against it)
- [x] Documentation in the `docs/docs` directory reflects any relevant changes *(do not update the README.md for documentation)*
- [ ] All tests pass, including the phar functional test (`tests/phar-test.sh`)
- [ ] I have read and followed the [Contribution Guide](https://netz98.github.io/n98-magerun2/contributing/) (highly recommended for all contributors!)
