### PR TITLE
docs: add tip admonition to module structure page

### DIFF
--- a/docs/docs/extending/development/modules/index.md
+++ b/docs/docs/extending/development/modules/index.md
@@ -8,4 +8,4 @@ With modules it's also easy to share commands within your developer team.
 - [Module Location](./module-location.md)
 - [Module Structure](./structure.md)
 - [Best Practices](./best-practices.md)
-
+- [Example Module](https://github.com/netz98/n98-magerun2-example-module)

--- a/docs/docs/extending/development/modules/structure.md
+++ b/docs/docs/extending/development/modules/structure.md
@@ -8,6 +8,12 @@ A module is a folder with at least a config file with the name `n98-magerun2.yam
 Inside your config you can define a command by using the same structure as defining a single custom command.
 See [[Add-custom-commands]].
 
+:::tip
+
+You can find a complete example module at [https://github.com/netz98/n98-magerun2-example-module](https://github.com/netz98/n98-magerun2-example-module).
+
+:::
+
 Example n98-magerun2.yaml:
 
 ```yaml


### PR DESCRIPTION
I've added a tip admonition to the module structure page with a link to the n98-magerun2 example module. This provides you with a practical example of a module structure.
