### PR TITLE
feat: Add --add-module-dir command-line option (#1677)

### DIFF
--- a/docs/docs/usage-and-general-commands.md
+++ b/docs/docs/usage-and-general-commands.md
@@ -50,3 +50,38 @@ php n98-magerun2.phar cache:clean
 ```
 
 See the command reference for more details on each command.
+
+## Loading External Modules via Command Line
+
+n98-magerun2 allows you to load custom modules from directories specified directly on the command line. This is useful for testing modules, or when you want to temporarily load a module without modifying global or project configuration files.
+
+### `--add-module-dir=<path>`
+
+You can use the `--add-module-dir` option to specify a path to a directory containing a n98-magerun2 module. The specified directory should contain a valid `n98-magerun2.yaml` file at its root, which defines the commands and autoloaders for that module.
+
+**Usage:**
+
+```bash
+n98-magerun2 --add-module-dir=/path/to/your/module some:command
+```
+
+Or, using a relative path:
+
+```bash
+n98-magerun2 --add-module-dir=../relative/path/to/your/module some:command
+```
+
+**Multiple Directories:**
+
+This option can be used multiple times to load modules from several different directories:
+
+```bash
+n98-magerun2 --add-module-dir=/path/to/module1 --add-module-dir=/path/to/module2 admin:user:list
+```
+
+**Details:**
+
+- The path provided can be absolute or relative to the current working directory from where n98-magerun2 is executed.
+- n98-magerun2 will look for a `n98-magerun2.yaml` file in the root of the specified directory.
+- The configurations (commands, autoloaders, etc.) from this YAML file will be merged with the existing configurations.
+- If the path is invalid, does not exist, or does not contain a readable `n98-magerun2.yaml`, it will be skipped. Verbose mode (`-v`) may show warnings for such cases.

--- a/tests/N98/Magento/Application/AddModuleDirArgumentTest.php
+++ b/tests/N98/Magento/Application/AddModuleDirArgumentTest.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace N98\Magento\Application;
+
+use N98\Magento\TestApplication;
+use Symfony\Component\Console\Tester\ApplicationTester;
+
+class AddModuleDirArgumentTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @var TestApplication
+     */
+    private $application;
+
+    /**
+     * @var ApplicationTester
+     */
+    private $tester;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->application = new TestApplication();
+        $this->application->setAutoExit(false);
+        // It's important to use a real autoloader instance for this test
+        // The TestApplication might mock or simplify this, ensure it's suitable.
+        // If TestApplication::getAutoloader() doesn't provide a real one, we might need to adjust.
+        // For now, assume TestApplication handles autoloader setup sufficiently for plugins.
+
+        $this->tester = new ApplicationTester($this->application);
+    }
+
+    public function testCommandAndAutoloadingFromAddedModuleDir()
+    {
+        // Path to the test module created in the previous step
+        // Adjust if path is different, ensure it's relative to project root
+        $modulePath = 'tests/_files/custom_module_test_add_dir';
+
+        // First, check if the command is listed
+        $this->tester->run(
+            [
+                '--add-module-dir' => $modulePath,
+                'command' => 'list',
+                //'--skip-magento-compatibility-check' => true, // May be needed if Magento isn't fully bootstrapped
+                //'--skip-config' => true, // Avoid loading other configs that might interfere
+            ],
+            ['decorated' => false] // No decoration for easier string matching
+        );
+
+        $listOutput = $this->tester->getDisplay();
+        $this->assertStringContainsString('mytest:hello', $listOutput, 'The command mytest:hello should be listed.');
+
+        // Now, execute the command itself
+        $this->tester->run(
+            [
+                '--add-module-dir' => $modulePath,
+                'command' => 'mytest:hello',
+                //'--skip-magento-compatibility-check' => true,
+                //'--skip-config' => true,
+            ],
+            ['decorated' => false]
+        );
+
+        $commandOutput = $this->tester->getDisplay();
+        $this->assertStringContainsString(
+            'Hello from MyTestHelloCommand! Autoloaded: AutoloadTestClass says hi!',
+            $commandOutput,
+            'The output from mytest:hello command is not as expected.'
+        );
+        $this->assertSame(0, $this->tester->getStatusCode(), 'Command execution should be successful.');
+    }
+
+    public function testCommandFromMultipleAddedModuleDirs()
+    {
+        // For this test, we'd ideally have a second minimal test module.
+        // For now, we can reuse the same one twice, though it doesn't prove distinct module loading fully.
+        // A more robust test would involve creating another module, e.g., custom_module_test_add_dir_2
+        // with a different command.
+        // For simplicity in this step, we'll just pass the option multiple times with the same path.
+        // The underlying code supports multiple paths, so this at least tests the option parsing.
+
+        $modulePath1 = 'tests/_files/custom_module_test_add_dir';
+        // $modulePath2 = 'tests/_files/custom_module_test_add_dir_2'; // if we had a second one
+
+        $this->tester->run(
+            [
+                '--add-module-dir' => [$modulePath1, $modulePath1], // Pass as an array for multiple options
+                'command' => 'mytest:hello',
+            ],
+            ['decorated' => false]
+        );
+
+        $commandOutput = $this->tester->getDisplay();
+        $this->assertStringContainsString(
+            'Hello from MyTestHelloCommand! Autoloaded: AutoloadTestClass says hi!',
+            $commandOutput,
+            'The output from mytest:hello command with multiple --add-module-dir options is not as expected.'
+        );
+        $this->assertSame(0, $this->tester->getStatusCode(), 'Command execution should be successful with multiple --add-module-dir options.');
+    }
+
+    public function testNonExistentModuleDir()
+    {
+        $nonExistentPath = 'tests/_files/non_existent_module_dir_for_test';
+
+        // We expect the application to run without error, but our command should not be available.
+        // The ConfigurationLoader should log a warning (if verbose) but not crash.
+        $this->tester->run(
+            [
+                '--add-module-dir' => $nonExistentPath,
+                'command' => 'list',
+                '-v' => true, // Enable verbosity to check for warnings (optional for this assertion)
+            ],
+            ['decorated' => false]
+        );
+
+        $listOutput = $this->tester->getDisplay();
+        // Check that the command is NOT listed
+        $this->assertStringNotContainsString('mytest:hello', $listOutput, 'The command mytest:hello should NOT be listed when path is invalid.');
+
+        // Check for the warning message (optional, depends on exact logging implementation)
+        // This assertion might be fragile if the warning message changes.
+        // $this->assertStringContainsString("Warning: --add-module-dir: Could not resolve path", $listOutput);
+        // Or, check the warning from ConfigurationLoader:
+        // $this->assertStringContainsString("Provided additional module path is not a valid directory: ".realpath($nonExistentPath), $listOutput);
+        // For now, just ensuring the command isn't loaded is the primary goal.
+
+        $this->assertSame(0, $this->tester->getStatusCode(), 'Listing commands should be successful even with an invalid module path.');
+    }
+}

--- a/tests/_files/custom_module_test_add_dir/n98-magerun2.yaml
+++ b/tests/_files/custom_module_test_add_dir/n98-magerun2.yaml
@@ -1,0 +1,6 @@
+commands:
+  customCommands:
+    - MyCompany\TestModule\Command\MyTestHelloCommand
+
+autoloaders_psr4:
+  MyCompany\TestModule\: src/

--- a/tests/_files/custom_module_test_add_dir/src/Command/MyTestHelloCommand.php
+++ b/tests/_files/custom_module_test_add_dir/src/Command/MyTestHelloCommand.php
@@ -1,0 +1,24 @@
+<?php
+namespace MyCompany\TestModule\Command;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use MyCompany\TestModule\Dummy\AutoloadTestClass;
+
+class MyTestHelloCommand extends Command
+{
+    protected static $defaultName = 'mytest:hello';
+
+    protected function configure()
+    {
+        $this->setDescription('A simple test command from an added module directory.');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $autoloaderTest = new AutoloadTestClass();
+        $output->writeln('Hello from MyTestHelloCommand! Autoloaded: ' . $autoloaderTest->greet());
+        return Command::SUCCESS;
+    }
+}

--- a/tests/_files/custom_module_test_add_dir/src/Dummy/AutoloadTestClass.php
+++ b/tests/_files/custom_module_test_add_dir/src/Dummy/AutoloadTestClass.php
@@ -1,0 +1,10 @@
+<?php
+namespace MyCompany\TestModule\Dummy;
+
+class AutoloadTestClass
+{
+    public function greet()
+    {
+        return 'AutoloadTestClass says hi!';
+    }
+}


### PR DESCRIPTION
This commit introduces a new command-line option `--add-module-dir` to n98-magerun2. This option allows you to specify one or more additional directory paths from which to load n98-magerun2 modules.

Each specified directory is expected to contain a `n98-magerun2.yaml` file at its root. The commands and autoloader configurations from these YAML files will be merged into the main application configuration, enabling the loading of custom or temporary modules without modifying global or project-level configuration files.

Key changes include:
- Definition of the `--add-module-dir` option in `Application.php`.
- Modification of `ConfigurationLoader.php` to accept and process these additional module paths, looking for `n98-magerun2.yaml` files within them.
- Integration in `Application::init()` to retrieve the option value(s) and pass them to the `ConfigurationLoader`.
- Addition of tests to verify command loading, PSR-4 autoloading, handling of multiple directories, and behavior with invalid paths.
- Updated documentation in `usage-and-general-commands.md` to explain the new option and its usage.

This feature addresses issue #1677 by providing a flexible way to extend n98-magerun2 with modules from arbitrary locations via the command line.

---

## Related Issue(s)

#1677 

<!-- 
If this PR fixes an issue, please reference it here (e.g., Relates to #123).
Please use the hashtag format to link issues, e.g., `#123` for issue #123.
-->
