### PR TITLE
docs: correct --skip-root-check description

### DIFF
--- a/docs/docs/command-docs/development/dev-console.md
+++ b/docs/docs/command-docs/development/dev-console.md
@@ -127,3 +127,28 @@ This video showcases many of the features discussed, including live examples of 
 
 We also work on support for switching the app area. Currently only the "global" area is loaded.
 In some cases (errors) we loose the context of the module.
+
+## dev:console Deep Dive
+The dev:console command provides an interactive PHP shell with full Magento integration, making it an invaluable tool for rapid debugging, one-off code execution, and complex data manipulation directly from the command line.
+Key Capabilities:
+Interactive PHP Shell: Drop directly into a PHP environment with Magento's bootstrap loaded, allowing immediate execution of PHP code within the Magento context.
+Full Magento Integration: Commands are carried out extremely fast due to local integration with Magento.
+Direct Object Manager Access: The special $di (or $dh for Development Helper) variable provides direct access to Magento's Object Manager, enabling easy creation and manipulation of objects with dependency injection.
+Example:
+
+```
+$product = $di->create(\Magento\Catalog\Model\Product::class)->load(123);
+```
+
+Debugging Functions with `$dh`: The $dh (Development Helper) variable offers convenient debugging functions for common tasks, useful even in production environments.
+One-off Commands & Code Testing: Ideal for running quick, one-time commands or testing code snippets without needing to create controllers or temporary files.
+Data Inspection & Manipulation: Quickly retrieve specific records, inspect full product details, attributes, media gallery images, quantities, and more.
+Area Initialization: The dev:console can be initialized in different Magento application areas using the --area option.
+
+Example: Inspecting Product Data
+
+```
+# In dev:console
+$product = $dh->loadProductBySku('joust-duffel-bag'); # Using a helper function
+$dh->dump($product->getData()); # Inspect all product data
+```

--- a/docs/docs/usage-and-general-commands.md
+++ b/docs/docs/usage-and-general-commands.md
@@ -40,6 +40,8 @@ php n98-magerun2.phar <command> --help
 ## Common Options
 
 - `--root-dir`: Specify Magento root directory
+- `--skip-config`: Skip loading of custom config files
+- `--skip-root-check`: Suppress warning if n98-magerun2 is run as root user
 - `--help`: Show help for a command
 - `--version`: Show version information
 


### PR DESCRIPTION
Updates the description for the global parameter --skip-root-check to accurately reflect its purpose.

The --skip-root-check parameter is used to suppress the warning message that appears when n98-magerun2 is run as the root user.
