### PR TITLE
Fix linting issues in deploy.yml

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -60,20 +60,23 @@ jobs:
       - name: Import GPG key
         uses: crazy-max/ghaction-import-gpg@v6
         with:
-          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
-          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+          gpg_private_key: ${{secrets.GPG_PRIVATE_KEY}}
+          passphrase: ${{secrets.GPG_PASSPHRASE}}
           trust_level: 5
 
       - name: GPG sign phar file (detached)
         run: |
-          echo "${{ secrets.GPG_PASSPHRASE }}" | \
-          gpg --batch --yes --pinentry-mode loopback --passphrase-fd 0 --detach-sign -a \
-          -o n98-magerun2.phar.asc n98-magerun2.phar
+          echo "${{secrets.GPG_PASSPHRASE}}" | \
+            gpg --batch --yes --pinentry-mode loopback \
+            --passphrase-fd 0 --detach-sign -a \
+            -o n98-magerun2.phar.asc n98-magerun2.phar
         env:
           GPG_TTY: $(tty)
 
       - name: GPG verify phar file
-        run: gpg --verify n98-magerun2.phar.asc n98-magerun2.phar
+        run: |-
+          gpg --verify n98-magerun2.phar.asc \
+            n98-magerun2.phar
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
@@ -107,7 +110,10 @@ jobs:
         run: |
           # Get tag part of github.ref
           TAG=$(cut -d'/' -f3 <<< "$GITHUB_REF")
-          LATEST_VERSION=$(curl -s https://raw.githubusercontent.com/netz98/n98-magerun2/master/version.txt | tr -d '[:space:]')
+          LATEST_VERSION=$( \
+            curl -s https://raw.githubusercontent.com/netz98/n98-magerun2/master/version.txt | \
+            tr -d '[:space:]' \
+          )
 
           # Check if curl was successful
           if [[ -z "$LATEST_VERSION" ]]; then
@@ -116,16 +122,22 @@ jobs:
           fi
 
           # Rename files - always create version-specific files
-          cp "n98-magerun2.phar" "n98-magerun2-${TAG}.phar"
-          cp "n98-magerun2.phar.asc" "n98-magerun2-${TAG}.phar.asc"
-          cp "n98-magerun2.phar.sig" "n98-magerun2-${TAG}.phar.sig"
+          cp "n98-magerun2.phar" \
+            "n98-magerun2-${TAG}.phar"
+          cp "n98-magerun2.phar.asc" \
+            "n98-magerun2-${TAG}.phar.asc"
+          cp "n98-magerun2.phar.sig" \
+            "n98-magerun2-${TAG}.phar.sig"
 
           # Only mark as latest if it's a stable version
           if [[ "$TAG" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "This is a stable release. Marking as latest."
-            mv "n98-magerun2.phar" "n98-magerun2-latest.phar"
-            mv "n98-magerun2.phar.asc" "n98-magerun2-latest.phar.asc"
-            mv "n98-magerun2.phar.sig" "n98-magerun2-latest.phar.sig"
+            mv "n98-magerun2.phar" \
+              "n98-magerun2-latest.phar"
+            mv "n98-magerun2.phar.asc" \
+              "n98-magerun2-latest.phar.asc"
+            mv "n98-magerun2.phar.sig" \
+              "n98-magerun2-latest.phar.sig"
           else
             echo "This is an alpha/beta release. Not marking as latest."
             # Remove only the original phar file since we don't need it anymore
@@ -141,32 +153,37 @@ jobs:
       - name: Upload phar file to files.magerun.net
         uses: appleboy/scp-action@master
         with:
-          host: ${{ secrets.SSH_DEPLOY_HOST }}
-          username: ${{ secrets.SSH_DEPLOY_USERNAME }}
-          key: ${{ secrets.SSH_DEPLOY_PRIVATE_KEY }}
-          passphrase: ${{ secrets.SSH_DEPLOY_PASSPHRASE }}
-          source: '*.phar,*.phar.asc,*.phar.sig'
-          target: ${{ secrets.SSH_DEPLOY_TARGET }}
+          host: ${{secrets.SSH_DEPLOY_HOST}}
+          username: ${{secrets.SSH_DEPLOY_USERNAME}}
+          key: ${{secrets.SSH_DEPLOY_PRIVATE_KEY}}
+          passphrase: >-
+            ${{secrets.SSH_DEPLOY_PASSPHRASE}}
+          source: >-
+            *.phar,*.phar.asc,*.phar.sig
+          target: ${{secrets.SSH_DEPLOY_TARGET}}
           rm: false
           overwrite: true
 
       - name: Run update tasks on files.magerun.net
         uses: appleboy/ssh-action@v1.2.2
         with:
-          host: ${{ secrets.SSH_DEPLOY_HOST }}
-          username: ${{ secrets.SSH_DEPLOY_USERNAME }}
-          key: ${{ secrets.SSH_DEPLOY_PRIVATE_KEY }}
-          passphrase: ${{ secrets.SSH_DEPLOY_PASSPHRASE }}
+          host: ${{secrets.SSH_DEPLOY_HOST}}
+          username: ${{secrets.SSH_DEPLOY_USERNAME}}
+          key: ${{secrets.SSH_DEPLOY_PRIVATE_KEY}}
+          passphrase: >-
+            ${{secrets.SSH_DEPLOY_PASSPHRASE}}
           script: |
             ./site/build/build_phive.sh
-            curl -s https://files.magerun.net/list.php > ./site/public/index.html
+            curl -s https://files.magerun.net/list.php > \
+              ./site/public/index.html
 
       - name: Invalidate cloudflare
         run: |
-          curl -X POST 'https://api.cloudflare.com/client/v4/zones/${{ secrets.CLOUDFLARE_ZONE }}/purge_cache' \
-              -H 'Content-Type:application/json' \
-              -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_TOKEN }}" \
-              --data-raw '{"purge_everything":true}'
+          curl -X POST \
+            'https://api.cloudflare.com/client/v4/zones/${{secrets.CLOUDFLARE_ZONE}}/purge_cache' \
+            -H 'Content-Type:application/json' \
+            -H "Authorization: Bearer ${{secrets.CLOUDFLARE_TOKEN}}" \
+            --data-raw '{"purge_everything":true}'
 
   update-dist-repo:
     runs-on: ubuntu-latest
@@ -176,15 +193,15 @@ jobs:
         uses: actions/checkout@v4.2.2
       - uses: webfactory/ssh-agent@v0.9.1
         with:
-          ssh-private-key: ${{ secrets.DIST_REPO_DEPLOY_KEY }}
+          ssh-private-key: ${{secrets.DIST_REPO_DEPLOY_KEY}}
       - name: Download artifacts
         uses: actions/download-artifact@v4
         with:
           name: n98-magerun2.phar
       - name: Update dist repo
         env:
-          GIT_USER_EMAIL: ${{ secrets.GIT_USER_EMAIL }}
-          GIT_USER_NAME: ${{ secrets.GIT_USER_NAME }}
+          GIT_USER_EMAIL: ${{secrets.GIT_USER_EMAIL}}
+          GIT_USER_NAME: ${{secrets.GIT_USER_NAME}}
         run: bash .github/workflows/update-dist-repo.sh
 
   create-github-release:
@@ -205,8 +222,8 @@ jobs:
           repo: "n98-magerun2"
         id: build_changelog
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - run: echo "${{ steps.build_changelog.outputs.changelog }}"
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+      - run: echo "${{steps.build_changelog.outputs.changelog}}"
       - name: Set release type
         id: release_type
         run: |
@@ -216,21 +233,24 @@ jobs:
           # Check if it's a stable version (x.y.z format without alpha/beta)
           if [[ "$TAG" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "This is a stable release."
-            echo "make_latest=true" >> $GITHUB_OUTPUT
-            echo "prerelease=false" >> $GITHUB_OUTPUT
+            echo "make_latest=true" >> "$GITHUB_OUTPUT"
+            echo "prerelease=false" >> "$GITHUB_OUTPUT"
           else
             echo "This is a pre-release (alpha/beta)."
-            echo "make_latest=false" >> $GITHUB_OUTPUT
-            echo "prerelease=true" >> $GITHUB_OUTPUT
+            echo "make_latest=false" >> "$GITHUB_OUTPUT"
+            echo "prerelease=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Release
         uses: softprops/action-gh-release@v2
         if: startsWith(github.ref, 'refs/tags/')
         with:
-          body: ${{steps.build_changelog.outputs.changelog}}
-          make_latest: ${{ steps.release_type.outputs.make_latest }}
-          prerelease: ${{ steps.release_type.outputs.prerelease }}
+          body: |
+            ${{steps.build_changelog.outputs.changelog}}
+          make_latest: >-
+            ${{steps.release_type.outputs.make_latest}}
+          prerelease: >-
+            ${{steps.release_type.outputs.prerelease}}
           files: |
             n98-magerun2.phar
             n98-magerun2.phar.asc


### PR DESCRIPTION
This commit addresses several linting issues identified in the .github/workflows/deploy.yml file:

- **Shellcheck SC2086:** Variables ($GITHUB_OUTPUT) in the 'Set release type' step of the 'create-github-release' job are now double-quoted to prevent globbing and word splitting issues.
- **Yamllint line length:** Long lines were reformatted to be under the 80-character limit. This involved breaking down long commands and strings using YAML block scalars.
- **Yamllint bracket spacing:** Extra spaces within ${{ ... }} expressions were removed for consistency and to adhere to linting best practices.