### PR TITLE
fix: remove version check for outdated Magento versions which harm Ma…

### DIFF
--- a/src/N98/Magento/Command/Developer/Console/MakeBlockCommand.php
+++ b/src/N98/Magento/Command/Developer/Console/MakeBlockCommand.php
@@ -51,20 +51,11 @@ class MakeBlockCommand extends AbstractGeneratorCommand
 
         /** @var $classGenerator ClassGenerator */
         $classGenerator->addUse('Magento\Framework\View\Element\Template');
-
-        if (version_compare($this->getMagentoVersion()->getVersion(), '2.2.0', '<')) {
-            $classGenerator->setExtendedClass('Template');
-        } else {
-            $classGenerator->setExtendedClass('Magento\Framework\View\Element\Template');
-        }
-
+        $classGenerator->setExtendedClass('Magento\Framework\View\Element\Template');
         $classGenerator->setName($classNameToGenerate);
 
-        $fileGenerator = FileGenerator::fromArray(
-            [
-                'classes' => [$classGenerator],
-            ]
-        );
+        $fileGenerator = new FileGenerator();
+        $fileGenerator->setClass($classGenerator);
 
         $directoryWriter = $this->getCurrentModuleDirectoryWriter();
         $directoryWriter->writeFile($filePathToGenerate, $fileGenerator->generate());

--- a/src/N98/Magento/Command/Developer/Console/MakeClassCommand.php
+++ b/src/N98/Magento/Command/Developer/Console/MakeClassCommand.php
@@ -45,9 +45,8 @@ class MakeClassCommand extends AbstractGeneratorCommand
         $classGenerator = $this->create(ClassGenerator::class);
         $classGenerator->setName($classNameToGenerate);
 
-        $fileGenerator = FileGenerator::fromArray([
-            'classes' => [$classGenerator],
-        ]);
+        $fileGenerator = new FileGenerator();
+        $fileGenerator->setClass($classGenerator);
 
         $directoryWriter = $this->getCurrentModuleDirectoryWriter();
         $directoryWriter->writeFile($filePathToGenerate, $fileGenerator->generate());

--- a/src/N98/Magento/Command/Developer/Console/MakeCommandCommand.php
+++ b/src/N98/Magento/Command/Developer/Console/MakeCommandCommand.php
@@ -59,12 +59,7 @@ class MakeCommandCommand extends AbstractGeneratorCommand
         $classGenerator->addUse('Symfony\Component\Console\Command\Command');
         $classGenerator->addUse('Symfony\Component\Console\Input\InputInterface');
         $classGenerator->addUse('Symfony\Component\Console\Output\OutputInterface');
-
-        if (version_compare($this->getMagentoVersion()->getVersion(), '2.2.0', '<')) {
-            $classGenerator->setExtendedClass('Command');
-        } else {
-            $classGenerator->setExtendedClass('Symfony\Component\Console\Command\Command');
-        }
+        $classGenerator->setExtendedClass('Symfony\Component\Console\Command\Command');
 
         $commandName = $this->prepareCommandName($input);
 

--- a/src/N98/Magento/Command/Developer/Console/MakeControllerCommand.php
+++ b/src/N98/Magento/Command/Developer/Console/MakeControllerCommand.php
@@ -39,14 +39,9 @@ class MakeControllerCommand extends AbstractGeneratorCommand
             . $this->getNormalizedClassnameByArgument($input->getArgument('classpath'));
         $filePathToGenerate = 'Controller/' . $actionFileName . '.php';
 
-        $classGenerator = $this->create(ClassGenerator::class);
-
         /** @var $classGenerator ClassGenerator */
-        if (version_compare($this->getMagentoVersion()->getVersion(), '2.2.0', '<')) {
-            $classGenerator->setExtendedClass('Action');
-        } else {
-            $classGenerator->setExtendedClass('Magento\Framework\App\Action\Action');
-        }
+        $classGenerator = $this->create(ClassGenerator::class);
+        $classGenerator->setExtendedClass('Magento\Framework\App\Action\Action');
 
         $body = $this->createClassBody($input);
         $executeMethodDefinition = $this->createClassMethodDefinitions($body);

--- a/src/N98/Magento/Command/Developer/Console/MakeHelperCommand.php
+++ b/src/N98/Magento/Command/Developer/Console/MakeHelperCommand.php
@@ -41,12 +41,7 @@ class MakeHelperCommand extends AbstractGeneratorCommand
 
         /** @var $classGenerator ClassGenerator */
         $classGenerator->addUse('Magento\Framework\App\Helper\AbstractHelper');
-
-        if (version_compare($this->getMagentoVersion()->getVersion(), '2.2.0', '<')) {
-            $classGenerator->setExtendedClass('AbstractHelper');
-        } else {
-            $classGenerator->setExtendedClass('Magento\Framework\App\Helper\AbstractHelper');
-        }
+        $classGenerator->setExtendedClass('Magento\Framework\App\Helper\AbstractHelper');
 
         $classGenerator->setName($classNameToGenerate);
 

--- a/src/N98/Magento/Command/Developer/Console/MakeModelCommand.php
+++ b/src/N98/Magento/Command/Developer/Console/MakeModelCommand.php
@@ -40,21 +40,12 @@ class MakeModelCommand extends AbstractGeneratorCommand
         $classGenerator = $this->create(ClassGenerator::class);
 
         /** @var $classGenerator ClassGenerator */
-        $classGenerator->addUse('Magento\Framework\Model\AbstractModel');
-
-        if (version_compare($this->getMagentoVersion()->getVersion(), '2.2.0', '<')) {
-            $classGenerator->setExtendedClass('AbstractModel');
-        } else {
-            $classGenerator->setExtendedClass('Magento\Framework\Model\AbstractModel');
-        }
-
+        $classGenerator->addUse('Magento\\Framework\\Model\\AbstractModel');
+        $classGenerator->setExtendedClass('Magento\\Framework\\Model\\AbstractModel');
         $classGenerator->setName($classNameToGenerate);
 
-        $modelFileGenerator = FileGenerator::fromArray(
-            [
-                'classes' => [$classGenerator],
-            ]
-        );
+        $modelFileGenerator = new FileGenerator();
+        $modelFileGenerator->setClass($classGenerator);
 
         $directoryWriter = $this->getCurrentModuleDirectoryWriter();
         $directoryWriter->writeFile($filePathToGenerate, $modelFileGenerator->generate());


### PR DESCRIPTION
The version check for very old Magento < 2.2 versions break Mage-OS tests, because Mage-OS has a dfiferent versioning.