### PR TITLE
Add Mage-OS 1.2.0 test coverage

### DIFF
--- a/.github/workflows/magento_platform_tests.yml
+++ b/.github/workflows/magento_platform_tests.yml
@@ -72,6 +72,26 @@ jobs:
             use-git-repository: false
             git-repository: ""
 
+          - magento-version: 1.2.0
+            composer-repository-url: "https://repo.mage-os.org/"
+            operating-system: ubuntu-22.04
+            php-version: '8.4'
+            mariadb-version: '10.6'
+            opensearch-version: '2'
+            composer-version: '2.8.8'
+            use-git-repository: false
+            git-repository: ""
+
+          - magento-version: 1.2.0
+            composer-repository-url: "https://repo.mage-os.org/"
+            operating-system: ubuntu-22.04
+            php-version: '8.3'
+            mariadb-version: '10.6'
+            opensearch-version: '2'
+            composer-version: '2.8.8'
+            use-git-repository: false
+            git-repository: ""
+
           # Magento versions
           - magento-version: 2.4.8
             composer-repository-url: "https://repo.magento.com/"

--- a/docs/docs/compatibility.md
+++ b/docs/docs/compatibility.md
@@ -9,6 +9,8 @@ or `install` are excluded).
 
 We support the following Magento Versions:
 
+- Mage-OS 1.2.x
+- Mage-OS 1.1.x
 - Mage-OS 1.0.x
 - 2.4.7 Open Source/Commerce
 - 2.4.6 Open Source/Commerce


### PR DESCRIPTION
## Summary
- test(ci): add Mage-OS 1.2.0
- update supported version docs

## Testing
- `composer install --no-interaction`
- `vendor/bin/phpunit --testsuite "unit"`
- `npx bats tests/bats` *(fails: `ENV variable N98_MAGERUN2_TEST_MAGENTO_ROOT is missing`)*

------
https://chatgpt.com/codex/tasks/task_e_685522e1ca6c832f9dc2b416784662e4