### PR TITLE
docs: add dev console to commands list

### DIFF
--- a/docs/docs/command-docs/development/index.md
+++ b/docs/docs/command-docs/development/index.md
@@ -27,6 +27,7 @@ Commands tailored for Magento developers, including code generation and debuggin
 - [dev:translate:export](./dev-translate-export.md) - Export inline translations
 
 ### Development Utilities
+- [dev:console](./dev-console.md) - Run the interactive PHP console
 - [dev:report:count](./dev-report-count.md) - Get count of report files
 - [dev:symlinks](./dev-symlinks.md) - Toggle allow symlinks setting
 - [dev:template-hints](./dev-template-hints.md) - Toggle template hints


### PR DESCRIPTION
## Summary
- list `dev:console` on the development commands index

------
https://chatgpt.com/codex/tasks/task_e_6855a74971bc832fabf243f8bd33dc5e