### PR TITLE
feat(db): prefer mariadb client tools when available

### DIFF
--- a/.github/workflows/mage-os_nightly_test.yml
+++ b/.github/workflows/mage-os_nightly_test.yml
@@ -44,6 +44,17 @@ jobs:
       - name: Check MariaDB version
         run: "mariadb -uroot -proot -e 'SELECT version();'"
 
+      - name: Link MariaDB tools as mysql
+        run: |
+          MARIADB_BIN=$(which mariadb 2>/dev/null || true)
+          MARIADB_DUMP_BIN=$(which mariadb-dump 2>/dev/null || true)
+          if [ -x "$MARIADB_BIN" ]; then
+            sudo ln -sf "$MARIADB_BIN" /usr/bin/mysql
+          fi
+          if [ -x "$MARIADB_DUMP_BIN" ]; then
+            sudo ln -sf "$MARIADB_DUMP_BIN" /usr/bin/mysqldump
+          fi
+
       - name: List installed MySQL/MariaDB tools
         run: |
           mariadb --version || true

--- a/.github/workflows/mage-os_nightly_test.yml
+++ b/.github/workflows/mage-os_nightly_test.yml
@@ -44,17 +44,6 @@ jobs:
       - name: Check MariaDB version
         run: "mariadb -uroot -proot -e 'SELECT version();'"
 
-      - name: Link MariaDB tools as mysql
-        run: |
-          MARIADB_BIN=$(which mariadb 2>/dev/null || true)
-          MARIADB_DUMP_BIN=$(which mariadb-dump 2>/dev/null || true)
-          if [ -x "$MARIADB_BIN" ]; then
-            sudo ln -sf "$MARIADB_BIN" /usr/bin/mysql
-          fi
-          if [ -x "$MARIADB_DUMP_BIN" ]; then
-            sudo ln -sf "$MARIADB_DUMP_BIN" /usr/bin/mysqldump
-          fi
-
       - name: List installed MySQL/MariaDB tools
         run: |
           mariadb --version || true

--- a/.github/workflows/mage-os_nightly_test.yml
+++ b/.github/workflows/mage-os_nightly_test.yml
@@ -36,7 +36,9 @@ jobs:
 
       - uses: shogo82148/actions-setup-mysql@v1
         with:
-          mysql-version: "mariadb-11.6"
+          distribution: "mariadb"
+          mysql-version: "11.4"
+          auto-start: "true"
           root-password: "root"
 
       - name: Check MariaDB version

--- a/.github/workflows/mage-os_nightly_test.yml
+++ b/.github/workflows/mage-os_nightly_test.yml
@@ -36,7 +36,7 @@ jobs:
 
       - uses: shogo82148/actions-setup-mysql@v1
         with:
-          mysql-version: "mariadb-11.4"
+          mysql-version: "mariadb-11.6"
           root-password: "root"
 
       - name: Check MariaDB version

--- a/.github/workflows/mage-os_nightly_test.yml
+++ b/.github/workflows/mage-os_nightly_test.yml
@@ -42,6 +42,13 @@ jobs:
       - name: Check MariaDB version
         run: "mariadb -uroot -proot -e 'SELECT version();'"
 
+      - name: List installed MySQL/MariaDB tools
+        run: |
+          mariadb --version || true
+          mariadb-dump --version || true
+          mysql --version || true
+          mysqldump --version || true
+
       - name: Create Magento database
         run: "mariadb -uroot -proot -e 'CREATE DATABASE magento;'"
 

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,8 @@ super-linter.log
 
 # Act
 /act*
+
+# SQL dumps
+/*.sql
+/*.sql.gz
+

--- a/docs/docs/command-docs/db/db-dump.md
+++ b/docs/docs/command-docs/db/db-dump.md
@@ -7,12 +7,12 @@ title: db:dump
 Dump database
 
 :::info
-Requires MySQL CLI tools (`mysqldump` or `mydumper`). Use the `--force` option with caution, as it will skip confirmation prompts. The `--strip` option can remove important data from the dump; review your table groups before using it.
+Requires MySQL or MariaDB CLI tools (`mysqldump`/`mariadb-dump` or `mydumper`). Use the `--force` option with caution, as it will skip confirmation prompts. The `--strip` option can remove important data from the dump; review your table groups before using it.
 :::
 
-Dumps configured Magento database with `mysqldump` or `mydumper`.
+Dumps configured Magento database with `mysqldump`, `mariadb-dump`, or `mydumper`.
 
-- Requires MySQL CLI tools (either `mysqldump` or `mydumper`)
+- Requires MySQL or MariaDB CLI tools (either `mysqldump`/`mariadb-dump` or `mydumper`)
 
 ```sh
 n98-magerun2.phar db:dump [options] [--] [<filename>]
@@ -43,7 +43,7 @@ n98-magerun2.phar db:dump [options] [--] [<filename>]
 | `--mydumper`                        | Use mydumper instead of mysqldump for potentially faster dumps.                                                                      |
 | `--no-single-transaction`           | Do not use single-transaction (not recommended, this is blocking).                                                                   |
 | `--no-tablespaces`                  | Use this option if you want to create a dump without having the PROCESS privilege.                                                   |
-| `--only-command`                    | Print only mysqldump/mydumper command. Does not execute.                                                                             |
+| `--only-command`                    | Print only mysqldump/mariadb-dump/mydumper command. Does not execute.                                                                             |
 | `--print-only-filename`             | Execute and prints no output except the dump filename.                                                                               |
 | `--set-gtid-purged-off`             | Adds --set-gtid-purged=OFF to mysqldump.                                                                                             |
 | `--stdout`                          | Dump to stdout.                                                                                                                      |

--- a/docs/docs/command-docs/db/db-import.md
+++ b/docs/docs/command-docs/db/db-import.md
@@ -10,7 +10,7 @@ Import database
 Using the `--drop` or `--drop-tables` options will remove existing data before import. Make sure you have backups and understand the consequences before using these options.
 :::
 
-- Requires MySQL CLI tools
+- Requires MySQL or MariaDB CLI tools
 
 ```sh
 n98-magerun2.phar db:import [options] [<filename>]
@@ -31,7 +31,7 @@ n98-magerun2.phar db:import [options] [<filename>]
 | `--drop`                              | Drop and recreate database before import                                           |
 | `--drop-tables`                       | Drop tables before import                                                          |
 | `--force`                             | Continue even if an SQL error occurs                                               |
-| `--only-command`                      | Print only mysql command. Do not execute                                           |
+| `--only-command`                      | Print only mysql/mariadb command. Do not execute                                   |
 | `--only-if-empty`                     | Imports only if database is empty                                                  |
 | `--optimize`                          | Convert verbose INSERTs to short ones before import (not working with compression) |
 | `--skip-authorization-entry-creation` | Do not create authorization rule/role entries if they are missing.                 |

--- a/src/N98/Magento/Command/Database/DumpCommand.php
+++ b/src/N98/Magento/Command/Database/DumpCommand.php
@@ -350,7 +350,8 @@ HELP;
             }
         }
 
-        $execs = new Execs('mysqldump');
+        $database = $this->getDatabaseHelper();
+        $execs = new Execs($database->getMysqlDumpBinary());
         $execs->setCompression($input->getOption('compression'), $input);
         $execs->setFileName($this->getFileName($input, $output, $execs->getCompressor()));
 

--- a/src/N98/Magento/Command/Database/ImportCommand.php
+++ b/src/N98/Magento/Command/Database/ImportCommand.php
@@ -145,9 +145,10 @@ HELP;
 
         $compressor = AbstractCompressor::create($compression, $input);
 
-        $exec = 'mysql ';
+        $mysqlBinary = $dbHelper->getMysqlBinary();
+        $exec = $mysqlBinary . ' ';
         if ($input->getOption('force')) {
-            $exec = 'mysql --force ';
+            $exec = $mysqlBinary . ' --force ';
         }
 
         // create import command

--- a/src/N98/Util/Console/Helper/DatabaseHelper.php
+++ b/src/N98/Util/Console/Helper/DatabaseHelper.php
@@ -342,6 +342,43 @@ class DatabaseHelper extends AbstractHelper implements CommandAware
     }
 
     /**
+     * Check if the connected database server is MariaDB
+     */
+    public function isMariaDbServer(): bool
+    {
+        try {
+            $version = $this->getMysqlVariable('version');
+            return stripos((string) $version, 'mariadb') !== false;
+        } catch (\Throwable $e) {
+            return false;
+        }
+    }
+
+    private function commandExists(string $command): bool
+    {
+        exec('command -v ' . escapeshellarg($command) . ' >/dev/null 2>&1', $o, $r);
+        return $r === 0;
+    }
+
+    public function getMysqlDumpBinary(): string
+    {
+        if ($this->isMariaDbServer() && $this->commandExists('mariadb-dump')) {
+            return 'mariadb-dump';
+        }
+
+        return 'mysqldump';
+    }
+
+    public function getMysqlBinary(): string
+    {
+        if ($this->isMariaDbServer() && $this->commandExists('mariadb')) {
+            return 'mariadb';
+        }
+
+        return 'mysql';
+    }
+
+    /**
      * @return string
      * @throws FileSystemException
      */

--- a/tests/bats/functional_magerun_commands.bats
+++ b/tests/bats/functional_magerun_commands.bats
@@ -482,8 +482,10 @@ function cleanup_files_in_magento() {
 }
 
 @test "Command: db:dump with --keep-definer" {
-  run $BIN "db:dump" --keep-definer db.sql
-  assert_output --partial "Finished"
+  run $BIN "db:dump" --keep-definer --only-command db.sql
+
+  # check if the sed to replace the definer is not in the command pipe
+  refute_output --partial "DEFINER"
 }
 
 @test "Command: db:dump --stdout with --strip" {


### PR DESCRIPTION
## Summary
- add helper methods to detect MariaDB servers
- select `mariadb-dump`/`mariadb` when dumping/importing
- mention MariaDB tools in documentation

## Testing
- `vendor/bin/phpunit`
- `bats tests/bats/functional_magerun_commands.bats` *(fails: `N98_MAGERUN2_TEST_MAGENTO_ROOT` is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68578716f540832fbe8cb1c383da51f3