### PR TITLE
Fix: Correct sidebar label for Route Commands in documentation

### DIFF
--- a/docs/docs/command-docs/routes/index.md
+++ b/docs/docs/command-docs/routes/index.md
@@ -1,6 +1,6 @@
 ---
 title: Routes Commands
-sidebar_label: Routes
+sidebar_label: Route Commands
 ---
 
 # Routes Commands


### PR DESCRIPTION
The sidebar label for the Route command group in the static documentation was 'Routes'. This commit changes it to 'Route Commands' to be consistent with other command group labels.