### PR TITLE
Add URL rewrite regeneration command

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -169,6 +169,7 @@ commands:
     - N98\Magento\Command\System\Setup\DowngradeVersionsCommand
     - N98\Magento\Command\System\Store\ListCommand
     - N98\Magento\Command\System\Url\ListCommand
+    - N98\Magento\Command\System\Url\RegenerateCommand
     - N98\Magento\Command\System\Store\Config\BaseUrlListCommand
     - N98\Magento\Command\System\Website\ListCommand
     - N98\Magento\Command\Indexer\ListCommand

--- a/docs/docs/command-docs/system/sys-url-regenerate.md
+++ b/docs/docs/command-docs/system/sys-url-regenerate.md
@@ -1,0 +1,16 @@
+---
+title: sys:url:regenerate
+---
+
+# sys:url:regenerate
+
+Regenerate product and category URL rewrites.
+
+## Usage
+```sh
+n98-magerun2.phar sys:url:regenerate --products 1,2 --categories 3 --store 1
+```
+
+- `--products`   Comma separated product IDs. Leave empty to process all products.
+- `--categories` Comma separated category IDs. Leave empty to process all categories.
+- `--store`      Store ID. Default processes all stores.

--- a/src/N98/Magento/Command/System/Url/RegenerateCommand.php
+++ b/src/N98/Magento/Command/System/Url/RegenerateCommand.php
@@ -1,0 +1,162 @@
+<?php
+
+namespace N98\Magento\Command\System\Url;
+
+use Magento\Catalog\Model\ResourceModel\Category\CollectionFactory as CategoryCollectionFactory;
+use Magento\Catalog\Model\ResourceModel\Product\CollectionFactory as ProductCollectionFactory;
+use Magento\CatalogUrlRewrite\Model\CategoryUrlRewriteGenerator;
+use Magento\CatalogUrlRewrite\Model\ProductUrlRewriteGenerator;
+use Magento\Store\Model\StoreManagerInterface;
+use Magento\UrlRewrite\Model\UrlPersistInterface;
+use Magento\UrlRewrite\Service\V1\Data\UrlRewrite;
+use N98\Magento\Command\AbstractMagentoCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class RegenerateCommand extends AbstractMagentoCommand
+{
+    /**
+     * @var UrlPersistInterface
+     */
+    protected $urlPersist;
+
+    /**
+     * @var ProductUrlRewriteGenerator
+     */
+    protected $productGenerator;
+
+    /**
+     * @var CategoryUrlRewriteGenerator
+     */
+    protected $categoryGenerator;
+
+    /**
+     * @var ProductCollectionFactory
+     */
+    protected $productCollectionFactory;
+
+    /**
+     * @var CategoryCollectionFactory
+     */
+    protected $categoryCollectionFactory;
+
+    /**
+     * @var StoreManagerInterface
+     */
+    protected $storeManager;
+
+    protected function configure()
+    {
+        $this
+            ->setName('sys:url:regenerate')
+            ->setDescription('Regenerate product and category url rewrites')
+            ->addOption('products', null, InputOption::VALUE_OPTIONAL, 'Comma separated product ids', '')
+            ->addOption('categories', null, InputOption::VALUE_OPTIONAL, 'Comma separated category ids', '')
+            ->addOption('store', null, InputOption::VALUE_OPTIONAL, 'Store id', 0);
+    }
+
+    public function inject(
+        UrlPersistInterface $urlPersist,
+        ProductUrlRewriteGenerator $productGenerator,
+        CategoryUrlRewriteGenerator $categoryGenerator,
+        ProductCollectionFactory $productCollectionFactory,
+        CategoryCollectionFactory $categoryCollectionFactory,
+        StoreManagerInterface $storeManager
+    ) {
+        $this->urlPersist = $urlPersist;
+        $this->productGenerator = $productGenerator;
+        $this->categoryGenerator = $categoryGenerator;
+        $this->productCollectionFactory = $productCollectionFactory;
+        $this->categoryCollectionFactory = $categoryCollectionFactory;
+        $this->storeManager = $storeManager;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $this->detectMagento($output, true);
+        if (!$this->initMagento()) {
+            return Command::FAILURE;
+        }
+
+        $storeId = (int) $input->getOption('store');
+        $stores = $storeId ? [$storeId] : array_keys($this->storeManager->getStores());
+
+        $productIds = array_filter(array_map('intval', explode(',', (string) $input->getOption('products'))));
+        $categoryIds = array_filter(array_map('intval', explode(',', (string) $input->getOption('categories'))));
+
+        $count = 0;
+        foreach ($stores as $id) {
+            if ($input->getOption('categories') !== '') {
+                $count += $this->regenerateCategories($categoryIds, $id, $output);
+            }
+            if ($input->getOption('products') !== '') {
+                $count += $this->regenerateProducts($productIds, $id, $output);
+            }
+        }
+
+        $output->writeln(sprintf('<info>Generated %d url rewrites</info>', $count));
+
+        return Command::SUCCESS;
+    }
+
+    private function regenerateCategories(array $categoryIds, $storeId, OutputInterface $output)
+    {
+        $collection = $this->categoryCollectionFactory->create();
+        $collection->setStoreId($storeId);
+        $collection->addAttributeToSelect(['name', 'url_path', 'url_key', 'path']);
+        if ($categoryIds) {
+            $collection->addAttributeToFilter('entity_id', ['in' => $categoryIds]);
+        }
+
+        $counter = 0;
+        foreach ($collection as $category) {
+            $output->writeln(sprintf('Regenerating category %s (%s)', $category->getName(), $category->getId()));
+            $this->urlPersist->deleteByData([
+                UrlRewrite::ENTITY_ID => $category->getId(),
+                UrlRewrite::ENTITY_TYPE => CategoryUrlRewriteGenerator::ENTITY_TYPE,
+                UrlRewrite::REDIRECT_TYPE => 0,
+                UrlRewrite::STORE_ID => $storeId,
+            ]);
+            $urls = $this->categoryGenerator->generate($category);
+            $urls = array_filter($urls, function ($url) {
+                return !empty($url->getRequestPath());
+            });
+            $this->urlPersist->replace($urls);
+            $counter += count($urls);
+        }
+
+        return $counter;
+    }
+
+    private function regenerateProducts(array $productIds, $storeId, OutputInterface $output)
+    {
+        $collection = $this->productCollectionFactory->create();
+        $collection->setStoreId($storeId);
+        $collection->addStoreFilter($storeId);
+        $collection->addAttributeToSelect('name');
+        if ($productIds) {
+            $collection->addIdFilter($productIds);
+        }
+
+        $counter = 0;
+        foreach ($collection as $product) {
+            $output->writeln(sprintf('Regenerating product %s (%s)', $product->getSku(), $product->getId()));
+            $this->urlPersist->deleteByData([
+                UrlRewrite::ENTITY_ID => $product->getId(),
+                UrlRewrite::ENTITY_TYPE => ProductUrlRewriteGenerator::ENTITY_TYPE,
+                UrlRewrite::REDIRECT_TYPE => 0,
+                UrlRewrite::STORE_ID => $storeId,
+            ]);
+            $urls = $this->productGenerator->generate($product);
+            $urls = array_filter($urls, function ($url) {
+                return !empty($url->getRequestPath());
+            });
+            $this->urlPersist->replace($urls);
+            $counter += count($urls);
+        }
+
+        return $counter;
+    }
+}

--- a/tests/bats/functional_magerun_commands.bats
+++ b/tests/bats/functional_magerun_commands.bats
@@ -1019,6 +1019,12 @@ function cleanup_files_in_magento() {
   assert_output --partial "/"
 }
 
+@test "Command: sys:url:regenerate" {
+  run $BIN sys:url:regenerate --products 1 --categories 2 --store 1
+  assert_output --partial "Generated"
+  assert [ "$status" -eq 0 ]
+}
+
 @test "Command: sys:website:list" {
   run $BIN "sys:website:list"
   assert_output --partial "base"


### PR DESCRIPTION
## Summary
- add `sys:url:regenerate` command to regenerate product and category URL rewrites
- document the new command
- register command in config
- cover command with BATS functional test

## Related Issues

#549 

## Testing
- `vendor/bin/phpunit --stop-on-failure`
- `bats tests/bats/functional_magerun_commands.bats` 
------
https://chatgpt.com/codex/tasks/task_e_685a3a08aa64832fbf31951ffc3a91d6