### PR TITLE
Add documentation for customer add address command

### DIFF
--- a/docs/docs/command-docs/customer/customer-add-address.md
+++ b/docs/docs/command-docs/customer/customer-add-address.md
@@ -1,0 +1,34 @@
+---
+title: customer:add-address
+sidebar_label: customer:add-address
+---
+
+Add a new address to an existing customer.
+
+```sh
+n98-magerun2.phar customer:add-address <email> <website> [--firstname="..."] [--lastname="..."] [--street="..."] [--city="..."] [--country="..."] [--postcode="..."] [--telephone="..."] [--default-billing] [--default-shipping]
+```
+
+**Options:**
+
+| Option              | Description                                        |
+|---------------------|----------------------------------------------------|
+| `--firstname`       | Customer first name                                |
+| `--lastname`        | Customer last name                                 |
+| `--street`          | Street address                                     |
+| `--city`            | City                                               |
+| `--country`         | Country ID (e.g., `US`)                             |
+| `--postcode`        | Postcode                                           |
+| `--telephone`       | Telephone number                                   |
+| `--default-billing` | Set address as default billing address             |
+| `--default-shipping`| Set address as default shipping address            |
+
+Example:
+
+```sh
+n98-magerun2.phar customer:add-address foo@example.com base --firstname="John" --lastname="Doe" --street="Main Street 1" --city="Berlin" --country="DE" --postcode="10117" --telephone="1234567890" --default-billing --default-shipping
+```
+
+:::note
+This command was introduced with version 7.4.0.
+:::

--- a/docs/docs/command-docs/customer/index.md
+++ b/docs/docs/command-docs/customer/index.md
@@ -11,6 +11,7 @@ This section contains documentation for all customer-related commands in n98-mag
 
 - [customer:info](./customer-info.md)
 - [customer:create](./customer-create.md)
+- [customer:add-address](./customer-add-address.md)
 - [customer:list](./customer-list.md)
 - [customer:change-password](./customer-change-password.md)
 - [customer:token:create](./customer-token-create.md)


### PR DESCRIPTION
## Summary
- document `customer:add-address`
- link the new doc in the customer command index

## Testing
- `vendor/bin/php-cs-fixer fix --dry-run`
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_6863fe2dffa8832fbc485b0f611259d7