### PR TITLE
Add single-process flag to dev:console

### DIFF
--- a/docs/docs/command-docs/development/dev-console.md
+++ b/docs/docs/command-docs/development/dev-console.md
@@ -19,8 +19,13 @@ n98-magerun2.phar dev:console [options] [--] [<cmd>]
 |------------------|----------------------------|
 | `-a, --area=AREA`| Area to initialize         |
 | `-e, --auto-exit`| Automatic exit after cmd   |
+| `-s, --single-process`| Run without forking (single process) |
 
 Optional an area code can be defined. If provided, the configuration (di.xml, translations) of the area are loaded.
+
+:::warning
+The `--single-process` flag disables process forking and should only be used for database transaction edge cases. It is not recommended for daily work.
+:::
 
 :::tip
 Use area codes like `adminhtml` or `crontab` to load specific Magento configurations for your session.

--- a/res/autocompletion/bash/n98-magerun2.phar.bash
+++ b/res/autocompletion/bash/n98-magerun2.phar.bash
@@ -174,7 +174,7 @@ _n98-magerun2()
             opts="${opts} --theme"
             ;;
             dev:console)
-            opts="${opts} "
+            opts="${opts} --area --auto-exit --single-process"
             ;;
             dev:module:create)
             opts="${opts} --minimal --add-blocks --add-helpers --add-models --add-setup --add-all --enable --modman --add-readme --add-composer --add-strict-types --author-name --author-email --description"

--- a/src/N98/Magento/Command/Developer/ConsoleCommand.php
+++ b/src/N98/Magento/Command/Developer/ConsoleCommand.php
@@ -53,6 +53,7 @@ class ConsoleCommand extends AbstractMagentoCommand
             ->setName('dev:console')
             ->addOption('area', 'a', InputOption::VALUE_REQUIRED, 'Area to initialize')
             ->addOption('auto-exit', 'e', InputOption::VALUE_NONE, 'Automatic exit after cmd')
+            ->addOption('single-process', 's', InputOption::VALUE_NONE, 'Run without forking (single process)')
             ->addArgument('cmd', InputArgument::OPTIONAL, 'Direct code to run', '')
             ->setDescription(
                 'Opens PHP interactive shell with a initialized Magento application</comment>'
@@ -96,6 +97,13 @@ class ConsoleCommand extends AbstractMagentoCommand
 
         error_reporting(E_ERROR | E_WARNING | E_PARSE);
         $config = new Configuration();
+
+        if ($input->getOption('single-process')) {
+            $output->writeln(
+                '<comment>Warning: Running console in single process mode disables process forking. Use only for DB transaction edge cases and not for daily work.</comment>'
+            );
+            $config->setUsePcntl(false);
+        }
 
         $php8Parser = new Parser\Php8(new Lexer\Emulative());
 


### PR DESCRIPTION
## Summary
- add `--single-process` option to `dev:console` command
- warn when running in single-process mode
- document new flag and update autocompletion

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_686402a61a18832f8a33906412381377