### PR TITLE
Fixes broken link to system documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ For full installation, usage, development, and contribution guidelines, please v
 | [magerun](https://netz98.github.io/n98-magerun2/command-docs/magerun/)       | Commands for working with n98-magerun2 config and internal tools.         | `magerun:config:info`, `magerun:config:dump`                                                 |
 | [routes](https://netz98.github.io/n98-magerun2/command-docs/routes/)         | Commands for managing and viewing Magento routes.                                  | `routes:list`                                                                               |
 | [script](https://netz98.github.io/n98-magerun2/command-docs/scripting/)      | Command for running sequences of n98-magerun2 commands from a file.       | `script`                                                                                    |
-| [sys](https://netz98.github.io/n98-magerun2/command-docs/sys/)               | Commands for system-level information, checks, and maintenance tasks.     | `sys:info`, `sys:check`, `sys:maintenance`, `sys:cron:list`, `sys:store:list`               |
+| [sys](https://netz98.github.io/n98-magerun2/command-docs/system/)            | Commands for system-level information, checks, and maintenance tasks.     | `sys:info`, `sys:check`, `sys:maintenance`, `sys:cron:list`, `sys:store:list`               |
 
 
 


### PR DESCRIPTION
Thank you for contributing to n98-magerun2! 🚀

Before you submit your pull request, please review the checklist below:

- [x] This pull request targets the `develop` branch (if not, please close and re-open against it)
- [ ] Documentation in the `docs/docs` directory reflects any relevant changes *(do not update the README.md for documentation)*
- [ ] All tests pass, including the phar functional test (`tests/phar-test.sh`)
- [ ] I have read and followed the [Contribution Guide](https://netz98.github.io/n98-magerun2/contributing/) (highly recommended for all contributors!)

💡 _Hint: The [Contribution Guide](https://netz98.github.io/n98-magerun2/contributing/) contains helpful tips and requirements for submitting a successful pull request._

---

## Summary

Changes the link from https://netz98.github.io/n98-magerun2/command-docs/sys/ (which is broken) to https://netz98.github.io/n98-magerun2/command-docs/system/ (which works)
