### PR TITLE
chore: update Mage-OS version to 1.3.1 in configuration files

### DIFF
--- a/.github/workflows/magento_platform_tests.yml
+++ b/.github/workflows/magento_platform_tests.yml
@@ -92,7 +92,7 @@ jobs:
             use-git-repository: false
             git-repository: ""
 
-          - magento-version: 1.3.0
+          - magento-version: 1.3.1
             composer-repository-url: "https://repo.mage-os.org/"
             operating-system: ubuntu-22.04
             php-version: '8.4'

--- a/config.yaml
+++ b/config.yaml
@@ -367,6 +367,11 @@ commands:
 
   N98\Magento\Command\Installer\InstallCommand:
     magento-packages:
+      - name: mage-os-1.3.1
+        package: mage-os/project-community-edition
+        version: 1.3.1
+        options:
+          repository-url: https://repo.mage-os.org
       - name: mage-os-1.3.0
         package: mage-os/project-community-edition
         version: 1.3.0


### PR DESCRIPTION
- Add Mage-OS 1.3.1 to list of installable versions
- Test Mage-OS 1.3.1 instead of 1.3.0 in the platform tests