### PR TITLE
chore: change MariaDB version in ddev

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -8,7 +8,7 @@ additional_hostnames: []
 additional_fqdns: []
 database:
     type: mariadb
-    version: "10.3"
+    version: "11,4"
 hooks:
     post-start:
         - composer: install
@@ -47,7 +47,7 @@ corepack_enable: false
 # database:
 #   type: <dbtype> # mysql, mariadb, postgres
 #   version: <version> # database version, like "10.11" or "8.0"
-#   MariaDB versions can be 5.5-10.8, 10.11, and 11.4.
+#   MariaDB versions can be 5.5-10.8, 10.11, 11.4, and 11.8.
 #   MySQL versions can be 5.5-8.0.
 #   PostgreSQL versions can be 9-17.
 


### PR DESCRIPTION
Thank you for contributing to n98-magerun2! 🚀

Before you submit your pull request, please review the checklist below:

- [X] This pull request targets the `develop` branch (if not, please close and re-open against it)
- [N/A] Documentation in the `docs/docs` directory reflects any relevant changes *(do not update the README.md for documentation)*
- [Hoping CI works] All tests pass, including the phar functional test (`tests/phar-test.sh`)
- [X] I have read and followed the [Contribution Guide](https://netz98.github.io/n98-magerun2/contributing/) (highly recommended for all contributors!)

💡 _Hint: The [Contribution Guide](https://netz98.github.io/n98-magerun2/contributing/) contains helpful tips and requirements for submitting a successful pull request._

---

## Related Issue(s)

<!-- 
If this PR fixes an issue, please reference it here (e.g., Relates to #123).
Please use the hashtag format to link issues, e.g., `#123` for issue #123.
-->

## Summary

Change from MariaDB 10.3, out of upstream maintenance, to 11.4.

Append the 11.8 LTS version to allowed versions.

## Additional Notes


found via: https://stackoverflow.com/questions/79861019/how-to-extract-the-correct-server-version-from-a-mysqldump?noredirect=1#comment140933555_79861019

Thanks for using/supporting MariaDB.