### PR TITLE
extended sys:store:list format option

### DIFF
--- a/docs/docs/command-docs/system/sys-store-list.md
+++ b/docs/docs/command-docs/system/sys-store-list.md
@@ -11,3 +11,14 @@ List all store views.
 n98-magerun2.phar sys:store:list
 ```
 
+## Options
+- `--format` Output format. One of: `csv`, `json`, `json_array`, `yaml`, `xml`
+
+## Examples
+```sh
+# JSON array output (recommended for scripting)
+n98-magerun2.phar sys:store:list --format json
+
+# CSV output
+n98-magerun2.phar sys:store:list --format csv
+```

--- a/src/N98/Magento/Command/System/Store/ListCommand.php
+++ b/src/N98/Magento/Command/System/Store/ListCommand.php
@@ -56,17 +56,30 @@ class ListCommand extends AbstractMagentoCommand
     {
         $table = [];
 
-        foreach ($this->storeManager->getStores() as $store) {
+        foreach ($this->storeManager->getStores(true, true) as $store) {
+            /** @var \Magento\Store\Model\Store $store */
             $table[$store->getId()] = [
                 $store->getId(),
+                $store->getWebsiteId(),
+                $store->getStoreGroupId(),
+                $store->getName(),
                 $store->getCode(),
+                $store->getData('sort_order'),
+                $store->getIsActive(),
             ];
         }
 
         ksort($table);
+
+        $format = $input->getOption('format');
+        $renderFormat = $format;
+        if ($format === 'json') {
+            $renderFormat = 'json_array';
+        }
+
         $this->getHelper('table')
-            ->setHeaders(['id', 'code'])
-            ->renderByFormat($output, $table, $input->getOption('format'));
+            ->setHeaders(['id', 'website_id', 'group_id', 'name', 'code', 'sort_order', 'is_active'])
+            ->renderByFormat($output, $table, $renderFormat);
 
         return Command::SUCCESS;
     }

--- a/src/N98/Magento/Command/System/Store/ListCommand.php
+++ b/src/N98/Magento/Command/System/Store/ListCommand.php
@@ -72,14 +72,10 @@ class ListCommand extends AbstractMagentoCommand
         ksort($table);
 
         $format = $input->getOption('format');
-        $renderFormat = $format;
-        if ($format === 'json') {
-            $renderFormat = 'json_array';
-        }
 
         $this->getHelper('table')
             ->setHeaders(['id', 'website_id', 'group_id', 'name', 'code', 'sort_order', 'is_active'])
-            ->renderByFormat($output, $table, $renderFormat);
+            ->renderByFormat($output, $table, $format);
 
         return Command::SUCCESS;
     }

--- a/tests/N98/Magento/Command/System/Store/ListCommandTest.php
+++ b/tests/N98/Magento/Command/System/Store/ListCommandTest.php
@@ -17,4 +17,29 @@ class ListCommandTest extends TestCase
         $this->assertDisplayContains('sys:store:list', 'id');
         $this->assertDisplayContains('sys:store:list', 'code');
     }
+
+    public function testExecuteJsonFormat()
+    {
+        $tester = $this->assertExecute([
+            'command' => 'sys:store:list',
+            '--format' => 'json',
+        ]);
+
+        $display = $tester->getDisplay();
+        $this->assertStringStartsWith('{', ltrim($display));
+
+        $data = json_decode($display, true);
+
+        $this->assertIsArray($data);
+        $this->assertNotEmpty($data);
+
+        $first = reset($data);
+        $this->assertArrayHasKey('id', $first);
+        $this->assertArrayHasKey('website_id', $first);
+        $this->assertArrayHasKey('group_id', $first);
+        $this->assertArrayHasKey('name', $first);
+        $this->assertArrayHasKey('code', $first);
+        $this->assertArrayHasKey('sort_order', $first);
+        $this->assertArrayHasKey('is_active', $first);
+    }
 }


### PR DESCRIPTION
Add more fields to `--format` output  of `sys:store:list` command.

## Related Issue(s)

- #1897 
