### PR TITLE
⚡ Optimize EAV attribute list filtering

### DIFF
--- a/src/N98/Magento/Command/Eav/Attribute/ListCommand.php
+++ b/src/N98/Magento/Command/Eav/Attribute/ListCommand.php
@@ -9,6 +9,7 @@
 namespace N98\Magento\Command\Eav\Attribute;
 
 use Magento\Eav\Model\Attribute;
+use Magento\Eav\Model\Config as EavConfig;
 use Magento\Eav\Model\Entity\Type as EntityType;
 use Magento\Eav\Model\ResourceModel\Entity\Attribute\Collection as AttributeCollection;
 use N98\Magento\Command\AbstractMagentoCommand;
@@ -30,13 +31,21 @@ class ListCommand extends AbstractMagentoCommand
     private $attributeCollection;
 
     /**
+     * @var EavConfig
+     */
+    private $eavConfig;
+
+    /**
      * @param AttributeCollection $attributeCollection
+     * @param EavConfig $eavConfig
      * @return void
      */
     public function inject(
-        AttributeCollection $attributeCollection
+        AttributeCollection $attributeCollection,
+        EavConfig $eavConfig
     ) {
         $this->attributeCollection = $attributeCollection;
+        $this->eavConfig = $eavConfig;
     }
 
     /**
@@ -90,16 +99,20 @@ class ListCommand extends AbstractMagentoCommand
         $addSource = $input->getOption('add-source');
         $addBackend = $input->getOption('add-backend');
         $filterType = $input->getOption('filter-type');
+        if ($filterType) {
+            try {
+                $entityType = $this->eavConfig->getEntityType($filterType);
+                $this->attributeCollection->setEntityTypeFilter($entityType->getEntityTypeId());
+            } catch (\Exception $e) {
+                $this->attributeCollection->addFieldToFilter('entity_type_id', -1);
+            }
+        }
         $this->attributeCollection->setOrder('attribute_code', 'asc');
 
         /** @var Attribute $attribute */
         foreach ($this->attributeCollection as $attribute) {
             /** @var EntityType $entityType */
             $entityType = $attribute->getEntityType();
-            if ($filterType &&
-                $entityType->getEntityTypeCode() !== $filterType) {
-                continue;
-            }
 
             $row = [
                 $attribute->getAttributeCode(),


### PR DESCRIPTION
### 💡 What: The optimization implemented
Moved the entity type filtering in `eav:attribute:list` from a PHP `foreach` loop to the Magento collection level (`setEntityTypeFilter`).

### 🎯 Why: The performance problem it solves
The original implementation fetched and hydrated all EAV attributes from the database even when a specific entity type was requested. This caused unnecessary memory allocation and CPU overhead in PHP, especially in Magento installations with hundreds or thousands of attributes.

### 📊 Measured Improvement:
While a full benchmark in a production-like Magento environment was not possible due to environment constraints, the optimization follows standard best practices for Magento development:
- **Database level filtering**: Reduces the result set returned by the SQL query.
- **Reduced memory footprint**: Fewer objects are hydrated into memory.
- **Lower CPU usage**: Removes redundant iterations and object method calls in PHP.

Functional parity is maintained, including graceful handling of invalid entity type codes.

---
*PR created automatically by Jules for task [8556375463438319915](https://jules.google.com/task/8556375463438319915) started by @cmuench*