### PR TITLE
🧹 Refactor deprecated getTableDefinitions in DumpCommand

### DIFF
--- a/src/N98/Magento/Command/Database/DumpCommand.php
+++ b/src/N98/Magento/Command/Database/DumpCommand.php
@@ -30,16 +30,6 @@ use Symfony\Component\Console\Question\Question;
  */
 class DumpCommand extends AbstractDatabaseCommand
 {
-    /**
-     * @var array
-     */
-    protected $tableDefinitions = null;
-
-    /**
-     * @var array
-     */
-    protected $commandConfig = null;
-
     protected function configure()
     {
         parent::configure();
@@ -223,25 +213,6 @@ HELP;
     }
 
     /**
-     * @return array
-     *
-     * @deprecated Use database helper
-     */
-    private function getTableDefinitions()
-    {
-        $this->commandConfig = $this->getCommandConfig();
-
-        if ($this->tableDefinitions === null) {
-            /* @var $dbHelper DatabaseHelper */
-            $dbHelper = $this->getHelper('database');
-
-            $this->tableDefinitions = $dbHelper->getTableDefinitions($this->commandConfig);
-        }
-
-        return $this->tableDefinitions;
-    }
-
-    /**
      * Generate help for table definitions
      *
      * @return string
@@ -249,7 +220,6 @@ HELP;
     public function getTableDefinitionHelp()
     {
         $messages = PHP_EOL;
-        $this->commandConfig = $this->getCommandConfig();
         $messages .= <<<HELP
 <comment>Strip option</comment>
  If you like to skip data of some tables you can use the --strip option.
@@ -269,7 +239,7 @@ HELP;
 
 HELP;
 
-        $definitions = $this->getTableDefinitions();
+        $definitions = $this->getDatabaseHelper()->getTableDefinitions($this->getCommandConfig());
         $list = [];
         $maxNameLen = 0;
         foreach ($definitions as $id => $definition) {


### PR DESCRIPTION
🎯 **What:** The code health issue addressed was a deprecated method `getTableDefinitions` in `DumpCommand.php`. I replaced its internal usage with the recommended database helper call and removed the deprecated method and its associated properties (`$tableDefinitions` and `$commandConfig`).

💡 **Why:** This improves maintainability and readability by removing dead code and following the established pattern of using specialized helpers for database-related information. It also removes redundant property declarations that shadow base class properties.

✅ **Verification:** I verified the changes by:
- Inspecting the code using `read_file` and `grep` to ensure no orphaned usages remained.
- Running existing unit tests in `tests/N98/Magento/Command/Database/DumpCommandUnitTest.php`.
- Adding a temporary unit test to specifically verify that `getTableDefinitionHelp()` still correctly retrieves and formats table definitions via the helper.

✨ **Result:** The `DumpCommand` class is now cleaner, uses the correct helper pattern, and no longer contains deprecated code.

---
*PR created automatically by Jules for task [355992109590970957](https://jules.google.com/task/355992109590970957) started by @cmuench*