### PR TITLE
🔒 [security] Fix Path Traversal in Module and Theme Generators (Updated)

### DIFF
--- a/src/N98/Magento/Command/Developer/Console/Structure/ModuleNameStructure.php
+++ b/src/N98/Magento/Command/Developer/Console/Structure/ModuleNameStructure.php
@@ -35,6 +35,10 @@ class ModuleNameStructure
             throw new \InvalidArgumentException('Please specify a correct module name like Acme_Foo');
         }
 
+        if (!preg_match('/^[a-z0-9]+$/i', $parts[0]) || !preg_match('/^[a-z0-9]+$/i', $parts[1])) {
+            throw new \InvalidArgumentException('Module name parts must be alphanumeric');
+        }
+
         $this->vendorName = ucfirst($parts[0]);
         $this->shortModuleName = ucfirst($parts[1]);
     }

--- a/src/N98/Magento/Command/Developer/Console/Structure/ThemeNameStructure.php
+++ b/src/N98/Magento/Command/Developer/Console/Structure/ThemeNameStructure.php
@@ -36,6 +36,13 @@ class ThemeNameStructure
      */
     public function __construct($area, $package, $name)
     {
+        if (!preg_match('/^[a-z0-9_-]+$/i', $area) ||
+            !preg_match('/^[a-z0-9_-]+$/i', $package) ||
+            !preg_match('/^[a-z0-9_-]+$/i', $name)
+        ) {
+            throw new \InvalidArgumentException('Theme name parts must be alphanumeric (including underscore and hyphen)');
+        }
+
         $this->area = $area;
         $this->package = ucfirst($package);
         $this->name = strtolower($name);

--- a/tests/N98/Magento/Command/Developer/Console/Structure/ModuleNameStructureTest.php
+++ b/tests/N98/Magento/Command/Developer/Console/Structure/ModuleNameStructureTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace N98\Magento\Command\Developer\Console\Structure;
+
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+
+class ModuleNameStructureTest extends TestCase
+{
+    /**
+     * @dataProvider validModuleNameProvider
+     */
+    public function testValidModuleName($fullModuleName, $expectedVendor, $expectedModule)
+    {
+        $structure = new ModuleNameStructure($fullModuleName);
+        $this->assertEquals($expectedVendor, $structure->getVendorName());
+        $this->assertEquals($expectedModule, $structure->getShortModuleName());
+    }
+
+    public function validModuleNameProvider()
+    {
+        return [
+            ['Acme_Foo', 'Acme', 'Foo'],
+            ['acme_foo', 'Acme', 'Foo'],
+            ['Vendor123_Module456', 'Vendor123', 'Module456'],
+        ];
+    }
+
+    /**
+     * @dataProvider invalidModuleNameProvider
+     */
+    public function testInvalidModuleName($fullModuleName)
+    {
+        $this->expectException(InvalidArgumentException::class);
+        new ModuleNameStructure($fullModuleName);
+    }
+
+    public function invalidModuleNameProvider()
+    {
+        return [
+            ['Acme'],
+            ['Acme_Foo_Bar'],
+            ['../../_Foo'],
+            ['Acme_../../Foo'],
+            ['Vendor/../_Module'],
+            ['Vendor_Module/..'],
+            ['Vendor!_Module'],
+            ['Vendor_Module!'],
+            ['Vendor_Mod.ule'],
+        ];
+    }
+}

--- a/tests/N98/Magento/Command/Developer/Console/Structure/ThemeNameStructureTest.php
+++ b/tests/N98/Magento/Command/Developer/Console/Structure/ThemeNameStructureTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace N98\Magento\Command\Developer\Console\Structure;
+
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+
+class ThemeNameStructureTest extends TestCase
+{
+    /**
+     * @dataProvider validThemeNameProvider
+     */
+    public function testValidThemeName($area, $package, $name, $expectedArea, $expectedPackage, $expectedName)
+    {
+        $structure = new ThemeNameStructure($area, $package, $name);
+        $this->assertEquals($expectedArea, $structure->getArea());
+        $this->assertEquals($expectedPackage, $structure->getPackage());
+        $this->assertEquals($expectedName, $structure->getName());
+    }
+
+    public function validThemeNameProvider()
+    {
+        return [
+            ['frontend', 'Acme', 'default', 'frontend', 'Acme', 'default'],
+            ['adminhtml', 'acme', 'BLUE', 'adminhtml', 'Acme', 'blue'],
+            ['base', 'My-Vendor', 'my_theme', 'base', 'My-Vendor', 'my_theme'],
+        ];
+    }
+
+    /**
+     * @dataProvider invalidThemeNameProvider
+     */
+    public function testInvalidThemeName($area, $package, $name)
+    {
+        $this->expectException(InvalidArgumentException::class);
+        new ThemeNameStructure($area, $package, $name);
+    }
+
+    public function invalidThemeNameProvider()
+    {
+        return [
+            ['../', 'Package', 'Name'],
+            ['Area', '../', 'Name'],
+            ['Area', 'Package', '../'],
+            ['Area!', 'Package', 'Name'],
+        ];
+    }
+}


### PR DESCRIPTION
I have addressed the feedback regarding `php-cs-fixer` violations by running the fixer on the codebase. The violations were limited to the newly added test files and involved the ordering of `use` statements.

---
*PR created automatically by Jules for task [12545921793006369415](https://jules.google.com/task/12545921793006369415) started by @cmuench*