### PR TITLE
🧪 Add tests for JsonArrayRenderer

### DIFF
--- a/tests/N98/Util/Console/Helper/Table/Renderer/JsonArrayRendererTest.php
+++ b/tests/N98/Util/Console/Helper/Table/Renderer/JsonArrayRendererTest.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * This file is part of the n98-magerun2 project.
+ *
+ * For the full copyright and license information, please view the MIT-LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+namespace N98\Util\Console\Helper\Table\Renderer;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Output\StreamOutput;
+
+class JsonArrayRendererTest extends TestCase
+{
+    /**
+     * @covers \N98\Util\Console\Helper\Table\Renderer\JsonArrayRenderer::render
+     */
+    public function testRender()
+    {
+        $renderer = new JsonArrayRenderer();
+        $stream = fopen('php://memory', 'r+');
+        $output = new StreamOutput($stream);
+
+        $rows = [
+            ['col1' => 'val1', 'col2' => 'val2'],
+            ['col1' => 'val3', 'col2' => 'val4'],
+        ];
+
+        $renderer->render($output, $rows);
+
+        rewind($stream);
+        $buffer = stream_get_contents($stream);
+        fclose($stream);
+
+        $expectedJson = json_encode($rows, JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT);
+
+        $this->assertEquals($expectedJson . PHP_EOL, $buffer);
+    }
+
+    /**
+     * @covers \N98\Util\Console\Helper\Table\Renderer\JsonArrayRenderer::render
+     */
+    public function testRenderAssociativeRows()
+    {
+        $renderer = new JsonArrayRenderer();
+        $stream = fopen('php://memory', 'r+');
+        $output = new StreamOutput($stream);
+
+        $rows = [
+            'row1' => ['col1' => 'val1'],
+            'row2' => ['col1' => 'val2'],
+        ];
+
+        $renderer->render($output, $rows);
+
+        rewind($stream);
+        $buffer = stream_get_contents($stream);
+        fclose($stream);
+
+        $expectedRows = array_values($rows);
+        $expectedJson = json_encode($expectedRows, JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT);
+
+        $this->assertEquals($expectedJson . PHP_EOL, $buffer);
+    }
+
+    /**
+     * @covers \N98\Util\Console\Helper\Table\Renderer\JsonArrayRenderer::render
+     */
+    public function testRenderEmpty()
+    {
+        $renderer = new JsonArrayRenderer();
+        $stream = fopen('php://memory', 'r+');
+        $output = new StreamOutput($stream);
+
+        $rows = [];
+
+        $renderer->render($output, $rows);
+
+        rewind($stream);
+        $buffer = stream_get_contents($stream);
+        fclose($stream);
+
+        $expectedJson = json_encode([], JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT);
+        $this->assertEquals($expectedJson . PHP_EOL, $buffer);
+    }
+}

--- a/tests/N98/Util/Console/Helper/Table/Renderer/RenderFactoryTest.php
+++ b/tests/N98/Util/Console/Helper/Table/Renderer/RenderFactoryTest.php
@@ -23,6 +23,9 @@ class RenderFactoryTest extends \PHPUnit\Framework\TestCase
         $json = $renderFactory->create('json');
         $this->assertInstanceOf('N98\Util\Console\Helper\Table\Renderer\JsonRenderer', $json);
 
+        $jsonArray = $renderFactory->create('json_array');
+        $this->assertInstanceOf('N98\Util\Console\Helper\Table\Renderer\JsonArrayRenderer', $jsonArray);
+
         $xml = $renderFactory->create('xml');
         $this->assertInstanceOf('N98\Util\Console\Helper\Table\Renderer\XmlRenderer', $xml);
 


### PR DESCRIPTION
🎯 **What:** Added a missing test file for `JsonArrayRenderer` and updated `RenderFactoryTest` to cover the `json_array` format.
📊 **Coverage:**
- `JsonArrayRendererTest::testRender`: Verifies standard rendering of rows.
- `JsonArrayRendererTest::testRenderAssociativeRows`: Verifies that associative keys are removed (as expected by `array_values` usage in the renderer).
- `JsonArrayRendererTest::testRenderEmpty`: Verifies handling of empty rows.
- `RenderFactoryTest::testCreate`: Verified that `create('json_array')` returns a `JsonArrayRenderer` instance.

✨ **Result:** Increased test coverage and ensured correct behavior of the JSON array renderer.

---
*PR created automatically by Jules for task [7442783472462211036](https://jules.google.com/task/7442783472462211036) started by @cmuench*