### PR TITLE
🧪 Add test for malformed composer.lock in ProjectComposer

### DIFF
--- a/tests/N98/Util/ProjectComposerTest.php
+++ b/tests/N98/Util/ProjectComposerTest.php
@@ -50,4 +50,16 @@ class ProjectComposerTest extends TestCase
 
         $this->assertCount(44, $returnedPackages);
     }
+
+    /**
+     * @test
+     */
+    public function itShouldReturnEmptyArrayIfLockFileIsMalformed()
+    {
+        $projectComposer = new ProjectComposer(__DIR__ . '/_files/malformed-project');
+        $returnedPackages = $projectComposer->getComposerLockPackages();
+
+        $this->assertIsArray($returnedPackages);
+        $this->assertEmpty($returnedPackages);
+    }
 }

--- a/tests/N98/Util/_files/malformed-project/composer.lock
+++ b/tests/N98/Util/_files/malformed-project/composer.lock
@@ -1,0 +1,1 @@
+{ invalid-json }


### PR DESCRIPTION
This PR improves the test coverage for `N98\Util\ProjectComposer` by adding a test case that verifies the behavior when `composer.lock` contains invalid JSON.

**Changes:**
- Created a new test fixture directory `tests/N98/Util/_files/malformed-project` with a malformed `composer.lock` file.
- Added `itShouldReturnEmptyArrayIfLockFileIsMalformed` test method to `tests/N98/Util/ProjectComposerTest.php`.
- Verified that the method returns an empty array instead of throwing an exception.

**Coverage:**
- Covers the `catch (\JsonException $e)` block in `getComposerLockPackages`.

**Result:**
- Improved test coverage and reliability for `ProjectComposer`.

---
*PR created automatically by Jules for task [9382162337307953355](https://jules.google.com/task/9382162337307953355) started by @cmuench*