### PR TITLE
Add test for RendererFactory::getFormats and fix test class name

### DIFF
--- a/tests/N98/Util/Console/Helper/Table/Renderer/RendererFactoryTest.php
+++ b/tests/N98/Util/Console/Helper/Table/Renderer/RendererFactoryTest.php
@@ -8,10 +8,10 @@
 
 namespace N98\Util\Console\Helper\Table\Renderer;
 
-class RenderFactoryTest extends \PHPUnit\Framework\TestCase
+class RendererFactoryTest extends \PHPUnit\Framework\TestCase
 {
     /**
-     * @covers \N98\Util\Console\Helper\Table\Renderer\RendererFactory::getFormats
+     * @covers \N98\Util\Console\Helper\Table\Renderer\RendererFactory::create
      */
     public function testCreate()
     {
@@ -31,5 +31,20 @@ class RenderFactoryTest extends \PHPUnit\Framework\TestCase
 
         $invalidFormat = $renderFactory->create('invalid_format');
         $this->assertFalse($invalidFormat);
+    }
+
+    /**
+     * @covers \N98\Util\Console\Helper\Table\Renderer\RendererFactory::getFormats
+     */
+    public function testGetFormats()
+    {
+        $formats = RendererFactory::getFormats();
+        $this->assertIsArray($formats);
+        $this->assertContains('csv', $formats);
+        $this->assertContains('json', $formats);
+        $this->assertContains('json_array', $formats);
+        $this->assertContains('yaml', $formats);
+        $this->assertContains('xml', $formats);
+        $this->assertCount(5, $formats);
     }
 }


### PR DESCRIPTION
This PR adds a unit test for the `RendererFactory::getFormats` method, which was previously untested.

It also includes some cleanups for the test file:
- Renamed `tests/N98/Util/Console/Helper/Table/Renderer/RenderFactoryTest.php` to `tests/N98/Util/Console/Helper/Table/Renderer/RendererFactoryTest.php` to correct a typo.
- Updated the test class name from `RenderFactoryTest` to `RendererFactoryTest`.
- Corrected the `@covers` annotation on `testCreate`.

The new test `testGetFormats` verifies that `getFormats` returns an array containing the keys 'csv', 'json', 'json_array', 'yaml', and 'xml'.

---
*PR created automatically by Jules for task [4745411758771696721](https://jules.google.com/task/4745411758771696721) started by @cmuench*