### PR TITLE
🔒 Fix Command Argument Injection in OpenBrowserCommand

### DIFF
--- a/src/N98/Magento/Command/OpenBrowserCommand.php
+++ b/src/N98/Magento/Command/OpenBrowserCommand.php
@@ -62,7 +62,7 @@ class OpenBrowserCommand extends AbstractMagentoCommand
         $output->writeln('Opening URL <comment>' . $url . '</comment> in browser');
 
         $opener = $this->resolveOpenerCommand($output);
-        Exec::run(escapeshellcmd($opener . ' ' . $url));
+        Exec::run(escapeshellcmd($opener) . ' ' . escapeshellarg($url));
 
         return Command::SUCCESS;
     }


### PR DESCRIPTION
This PR fixes a security vulnerability in `OpenBrowserCommand` where user-controlled input (store URL) was not properly escaped when constructing the shell command to open the browser. By switching to `escapeshellarg` for the URL argument, we prevent argument injection attacks.


---
*PR created automatically by Jules for task [13574665052326009524](https://jules.google.com/task/13574665052326009524) started by @cmuench*