### PR TITLE
Improve readability of dev:module:observer:list command output

### DIFF
--- a/src/N98/Magento/Command/Developer/Module/Observer/ListCommand.php
+++ b/src/N98/Magento/Command/Developer/Module/Observer/ListCommand.php
@@ -14,6 +14,7 @@ use N98\Magento\Command\AbstractMagentoCommand;
 use N98\Util\Console\Helper\Table\Renderer\RendererFactory;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Helper\TableSeparator;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ChoiceQuestion;
@@ -126,28 +127,39 @@ class ListCommand extends AbstractMagentoCommand
         }
 
         $table = [];
+        $hasRows = false;
 
         foreach ($observerConfig as $eventName => $observers) {
-            $firstObserver = true;
-
             if ($eventFilter !== null && $eventName !== $eventFilter) {
                 continue;
             }
+
+            $currentEventRows = [];
+            $firstObserver = true;
 
             foreach ($observers as $observerName => $observerData) {
                 if (!isset($observerData['instance'])) {
                     continue;
                 }
                 if ($firstObserver) {
-                    $firstObserver = !$firstObserver;
-                    $table[] = [$eventName, $observerName, $observerData['instance'] . '::' . $observerData['name']];
+                    $firstObserver = false;
+                    $currentEventRows[] = [$eventName, $observerName, $observerData['instance'] . '::' . $observerData['name']];
                 } else {
-                    $table[] = ['', $observerName, $observerData['instance'] . '::' . $observerData['name']];
+                    $currentEventRows[] = ['', $observerName, $observerData['instance'] . '::' . $observerData['name']];
                 }
+            }
+
+            if (count($currentEventRows) > 0) {
+                if ($hasRows && $input->getOption('format') === null) {
+                    $table[] = new TableSeparator();
+                }
+                foreach ($currentEventRows as $row) {
+                    $table[] = $row;
+                }
+                $hasRows = true;
             }
         }
 
-        // @todo Output is a bit ugly!?
         $this->getHelper('table')
                 ->setHeaders(['Event', 'Observer name', 'Fires'])
                 ->setRows($table)

--- a/tests/N98/Magento/Command/Developer/Module/Observer/ListCommandUnitTest.php
+++ b/tests/N98/Magento/Command/Developer/Module/Observer/ListCommandUnitTest.php
@@ -1,0 +1,175 @@
+<?php
+/**
+ * This file is part of the n98-magerun2 project.
+ *
+ * For the full copyright and license information, please view the MIT-LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+namespace N98\Magento\Command\Developer\Module\Observer;
+
+use N98\Magento\Command\TestCase;
+use PHPUnit\Framework\MockObject\MockObject;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\Console\Helper\TableSeparator;
+
+// Define dummy interfaces/classes if they don't exist
+if (!interface_exists('Magento\Framework\ObjectManagerInterface')) {
+    eval('namespace Magento\Framework; interface ObjectManagerInterface {
+        public function get($type);
+        public function create($type, array $arguments = []);
+        public function configure(array $configuration);
+    }');
+}
+
+if (!class_exists('Magento\Framework\Event\Config\Reader')) {
+    eval('namespace Magento\Framework\Event\Config; class Reader {
+        public function read($scope) {}
+    }');
+}
+
+class ListCommandUnitTest extends TestCase
+{
+    /**
+     * @var ListCommand
+     */
+    private $command;
+
+    /**
+     * @var MockObject
+     */
+    private $objectManagerMock;
+
+    protected function setUp(): void
+    {
+        // Skip parent setup which tries to init real application
+        $this->command = new ListCommand();
+
+        // Setup Helpers
+        $helperSet = new \Symfony\Component\Console\Helper\HelperSet([
+            new \N98\Util\Console\Helper\TableHelper(),
+            new \Symfony\Component\Console\Helper\FormatterHelper(),
+            new \Symfony\Component\Console\Helper\QuestionHelper(),
+        ]);
+        $this->command->setHelperSet($helperSet);
+
+        // AbstractMagentoCommand expects 'command' argument to be present
+        $this->command->getDefinition()->addArgument(
+            new \Symfony\Component\Console\Input\InputArgument('command', \Symfony\Component\Console\Input\InputArgument::OPTIONAL)
+        );
+    }
+
+    public function testExecuteWithSeparators()
+    {
+        // Mock Application
+        $applicationMock = $this->getMockBuilder(\N98\Magento\Application::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        // Ensure Application mock returns our HelperSet
+        $applicationMock->method('getHelperSet')->willReturn($this->command->getHelperSet());
+
+        $applicationMock->method('initMagento')->willReturn(true);
+        $applicationMock->method('detectMagento')->willReturn(true);
+        $applicationMock->method('getMagentoRootFolder')->willReturn('/tmp');
+        $applicationMock->method('isMagentoEnterprise')->willReturn(false);
+        $applicationMock->method('getMagentoMajorVersion')->willReturn(2);
+
+        // Mock ObjectManager
+        $this->objectManagerMock = $this->getMockBuilder('Magento\Framework\ObjectManagerInterface')
+            ->getMock();
+
+        $applicationMock->method('getObjectManager')->willReturn($this->objectManagerMock);
+
+        $this->command->setApplication($applicationMock);
+
+        // Mock Config Reader
+        $configReaderMock = $this->getMockBuilder('Magento\Framework\Event\Config\Reader')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $configReaderMock->method('read')->willReturn([
+            'event_one' => [
+                'observer_a' => ['instance' => 'ClassA', 'name' => 'methodA'],
+            ],
+            'event_two' => [
+                'observer_b' => ['instance' => 'ClassB', 'name' => 'methodB'],
+            ],
+            'event_three' => [
+                'observer_c' => ['instance' => 'ClassC', 'name' => 'methodC'],
+            ]
+        ]);
+
+        $this->objectManagerMock->method('get')
+            ->with('\Magento\Framework\Event\Config\Reader')
+            ->willReturn($configReaderMock);
+
+        $commandTester = new CommandTester($this->command);
+
+        $commandTester->execute(['area' => 'global']);
+
+        $output = $commandTester->getDisplay();
+
+        // Count occurrences of the separator line pattern "+---"
+        // It should appear 2 (borders) + 1 (header sep) + 2 (inner separators) = 5 times
+
+        $separatorCount = substr_count($output, '+---');
+        $this->assertGreaterThanOrEqual(5, $separatorCount, 'Output should contain separators between events');
+    }
+
+    public function testExecuteWithoutSeparatorsWhenFormatIsSet()
+    {
+        // Mock Application
+        $applicationMock = $this->getMockBuilder(\N98\Magento\Application::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        // Ensure Application mock returns our HelperSet
+        $applicationMock->method('getHelperSet')->willReturn($this->command->getHelperSet());
+
+        $applicationMock->method('initMagento')->willReturn(true);
+        $applicationMock->method('detectMagento')->willReturn(true);
+        $applicationMock->method('getMagentoRootFolder')->willReturn('/tmp');
+        $applicationMock->method('isMagentoEnterprise')->willReturn(false);
+        $applicationMock->method('getMagentoMajorVersion')->willReturn(2);
+
+        // Mock ObjectManager
+        $this->objectManagerMock = $this->getMockBuilder('Magento\Framework\ObjectManagerInterface')
+            ->getMock();
+
+        $applicationMock->method('getObjectManager')->willReturn($this->objectManagerMock);
+
+        $this->command->setApplication($applicationMock);
+
+        // Mock Config Reader
+        $configReaderMock = $this->getMockBuilder('Magento\Framework\Event\Config\Reader')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $configReaderMock->method('read')->willReturn([
+            'event_one' => [
+                'observer_a' => ['instance' => 'ClassA', 'name' => 'methodA'],
+            ],
+            'event_two' => [
+                'observer_b' => ['instance' => 'ClassB', 'name' => 'methodB'],
+            ]
+        ]);
+
+        $this->objectManagerMock->method('get')
+            ->with('\Magento\Framework\Event\Config\Reader')
+            ->willReturn($configReaderMock);
+
+        $commandTester = new CommandTester($this->command);
+        $commandTester->execute(['area' => 'global', '--format' => 'csv']);
+
+        $output = $commandTester->getDisplay();
+
+        // CSV should not contain table borders
+        $this->assertStringNotContainsString('+---', $output, 'CSV output should not contain table separators');
+
+        // Should contain raw data
+        $this->assertStringContainsString('event_one,observer_a,ClassA::methodA', $output);
+        $this->assertStringContainsString('event_two,observer_b,ClassB::methodB', $output);
+    }
+}


### PR DESCRIPTION
This PR improves the readability of the `dev:module:observer:list` command output by adding horizontal separators between groups of observers for different events. This makes it easier to distinguish between different events in the table output.

The change includes logic to ensure that separators are NOT added when a machine-readable format (like JSON or CSV) is requested via the `--format` option, preventing any potential issues with those formats.

Verification:
- Manually verified using a reproduction script that mocks the Magento environment.
- Confirmed that default table output includes separators.
- Confirmed that JSON and CSV output remain unchanged (no separators).


---
*PR created automatically by Jules for task [9418994327581628498](https://jules.google.com/task/9418994327581628498) started by @cmuench*