### PR TITLE
Deprecate _connection magic property in AbstractDatabaseCommand

### DIFF
--- a/src/N98/Magento/Command/Database/AbstractDatabaseCommand.php
+++ b/src/N98/Magento/Command/Database/AbstractDatabaseCommand.php
@@ -76,11 +76,15 @@ abstract class AbstractDatabaseCommand extends AbstractMagentoCommand
      *
      * @return mixed
      * @throws \Magento\Framework\Exception\FileSystemException
+     * @deprecated
      */
     public function __get($name)
     {
         if ($name == '_connection') {
-            // TODO(tk): deprecate
+            trigger_error(
+                'Accessing the magic property "_connection" is deprecated. Use getDatabaseHelper()->getConnection() instead.',
+                E_USER_DEPRECATED
+            );
             return $this->getDatabaseHelper()->getConnection();
         }
     }

--- a/tests/N98/Magento/Command/Database/ConnectionPropertyDeprecationTest.php
+++ b/tests/N98/Magento/Command/Database/ConnectionPropertyDeprecationTest.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * This file is part of the n98-magerun2 project.
+ *
+ * For the full copyright and license information, please view the MIT-LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+namespace N98\Magento\Command\Database;
+
+use N98\Util\Console\Helper\DatabaseHelper;
+use PHPUnit\Framework\TestCase;
+
+class ConnectionPropertyDeprecationTest extends TestCase
+{
+    public function testConnectionPropertyAccessTriggersDeprecation()
+    {
+        $dbHelperMock = $this->getMockBuilder(DatabaseHelper::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['getConnection'])
+            ->getMock();
+
+        $dbHelperMock->expects($this->once())
+            ->method('getConnection')
+            ->willReturn(new \stdClass()); // Return dummy connection
+
+        $command = $this->getMockBuilder(AbstractDatabaseCommand::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['getDatabaseHelper'])
+            ->getMock();
+
+        $command->expects($this->any())
+            ->method('getDatabaseHelper')
+            ->willReturn($dbHelperMock);
+
+        $triggered = false;
+        set_error_handler(function ($errno, $errstr) use (&$triggered) {
+            if ($errno === E_USER_DEPRECATED) {
+                if (strpos($errstr, 'Accessing the magic property "_connection" is deprecated') !== false) {
+                    $triggered = true;
+                    // Return true to suppress standard error handling (preventing PHPUnit from failing the test due to error)
+                    return true;
+                }
+            }
+            // Delegate to previous handler
+            return false;
+        });
+
+        try {
+            $connection = $command->_connection;
+        } finally {
+            restore_error_handler();
+        }
+
+        $this->assertTrue($triggered, 'Expected deprecation error was not triggered.');
+        $this->assertInstanceOf(\stdClass::class, $connection);
+    }
+}


### PR DESCRIPTION
Implemented deprecation for `_connection` magic property access in `AbstractDatabaseCommand`.
- Added `trigger_error(..., E_USER_DEPRECATED)` in `__get` method.
- Added `@deprecated` annotation to `__get` method docblock.
- Added a new test `tests/N98/Magento/Command/Database/ConnectionPropertyDeprecationTest.php` to verify the deprecation.

---
*PR created automatically by Jules for task [8023965906705840432](https://jules.google.com/task/8023965906705840432) started by @cmuench*