### PR TITLE
⚡ Optimize Customer DeleteCommand: Fix N+1 Query

### DIFF
--- a/src/N98/Magento/Command/Customer/DeleteCommand.php
+++ b/src/N98/Magento/Command/Customer/DeleteCommand.php
@@ -312,8 +312,7 @@ class DeleteCommand extends AbstractCustomerCommand
         $this->registry->register('isSecureArea', true);
         $isSecure = $this->registry->registry('isSecureArea');
         foreach ($customerCollection as $customerToDelete) {
-            $customer = $this->customerRepository->getById($customerToDelete->getId());
-            if ($this->customerRepository->delete($customer)) {
+            if ($this->customerRepository->deleteById($customerToDelete->getId())) {
                 $count++;
             }
         }


### PR DESCRIPTION
Optimized `src/N98/Magento/Command/Customer/DeleteCommand.php` to fix an N+1 query issue in the `batchDelete` method.

Previously, the code iterated over a customer collection, loaded each customer by ID using `getById`, and then called `delete($customer)`. This resulted in a separate query to load each customer before deletion.

The optimized code now directly calls `deleteById($customerToDelete->getId())`, eliminating the need to load the full customer object. This reduces database load and improves execution time for bulk customer deletions.

Verified the fix by creating a temporary unit test that mocked the `CustomerRepositoryInterface` and asserted that `deleteById` is called instead of `getById`. The existing test suite was also run to ensure no regressions (unrelated failures in `DumpCommandUnitTest` due to missing `mysqldump` were observed but are expected in this environment).

---
*PR created automatically by Jules for task [5238200759946763461](https://jules.google.com/task/5238200759946763461) started by @cmuench*