### PR TITLE
Fix SQL injection in dropTables and dropViews commands

### DIFF
--- a/src/N98/Util/Console/Helper/DatabaseHelper.php
+++ b/src/N98/Util/Console/Helper/DatabaseHelper.php
@@ -106,7 +106,8 @@ class DatabaseHelper extends AbstractHelper implements CommandAware
 
             $droppedCount = 0;
             foreach ($views as $viewName) {
-                $db->exec("DROP VIEW IF EXISTS `{$viewName}`;");
+                $escapedViewName = $this->escapeIdentifier($viewName);
+                $db->exec("DROP VIEW IF EXISTS `{$escapedViewName}`;");
                 $output->writeln("<comment>Dropped view:</comment> {$viewName}");
                 $droppedCount++;
             }
@@ -889,7 +890,7 @@ class DatabaseHelper extends AbstractHelper implements CommandAware
         $query = 'SET FOREIGN_KEY_CHECKS = 0; ';
         $count = 0;
         foreach ($result as $tableName) {
-            $query .= 'DROP TABLE IF EXISTS `' . $tableName . '`; ';
+            $query .= 'DROP TABLE IF EXISTS `' . $this->escapeIdentifier($tableName) . '`; ';
             $count++;
         }
         $query .= 'SET FOREIGN_KEY_CHECKS = 1;';
@@ -992,5 +993,14 @@ class DatabaseHelper extends AbstractHelper implements CommandAware
         }
 
         return $output;
+    }
+
+    /**
+     * @param string $identifier
+     * @return string
+     */
+    private function escapeIdentifier($identifier)
+    {
+        return str_replace('`', '``', $identifier);
     }
 }

--- a/tests/N98/Util/Console/Helper/DatabaseHelperSecurityTest.php
+++ b/tests/N98/Util/Console/Helper/DatabaseHelperSecurityTest.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace N98\Util\Console\Helper;
+
+use N98\Magento\Command\TestCase;
+use PDO;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class DatabaseHelperSecurityTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function dropTablesWithVulnerableName()
+    {
+        $pdoMock = $this->getMockBuilder(PDO::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $pdoMock->expects($this->once())
+            ->method('query')
+            ->with($this->callback(function ($query) {
+                // Check if the query contains ESCAPED backticks
+                // The expected secure query is: DROP TABLE IF EXISTS `table``name`;
+                return strpos($query, "DROP TABLE IF EXISTS `table``name`;") !== false;
+            }));
+
+        $helper = $this->getMockBuilder(DatabaseHelper::class)
+            ->onlyMethods(['getTables', 'getConnection'])
+            ->getMock();
+
+        $helper->expects($this->once())
+            ->method('getTables')
+            ->willReturn(['table`name']);
+
+        $helper->expects($this->any())
+            ->method('getConnection')
+            ->willReturn($pdoMock);
+
+        $outputMock = $this->getMockBuilder(OutputInterface::class)->getMock();
+
+        $helper->dropTables($outputMock);
+    }
+
+    /**
+     * @test
+     */
+    public function dropViewsWithVulnerableName()
+    {
+        $pdoMock = $this->getMockBuilder(PDO::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        // Expect exec to be called with the escaped query string
+        $pdoMock->expects($this->exactly(3))
+            ->method('exec')
+            ->withConsecutive(
+                ['SET FOREIGN_KEY_CHECKS = 0;'],
+                ["DROP VIEW IF EXISTS `view``name`;"],
+                ['SET FOREIGN_KEY_CHECKS = 1;']
+            );
+
+        $helper = $this->getMockBuilder(DatabaseHelper::class)
+            ->onlyMethods(['getViews', 'getConnection'])
+            ->getMock();
+
+        $helper->expects($this->once())
+            ->method('getViews')
+            ->willReturn(['view`name']);
+
+        $helper->expects($this->any())
+            ->method('getConnection')
+            ->willReturn($pdoMock);
+
+        $outputMock = $this->getMockBuilder(OutputInterface::class)->getMock();
+
+        $helper->dropViews($outputMock);
+    }
+}


### PR DESCRIPTION
Fixed a SQL injection vulnerability in `N98\Util\Console\Helper\DatabaseHelper::dropTables` where table names were concatenated into a `DROP TABLE` statement without escaping. Also applied the same fix to `dropViews` method. Added a regression test `tests/N98/Util/Console/Helper/DatabaseHelperSecurityTest.php`.

---
*PR created automatically by Jules for task [7956386492181579966](https://jules.google.com/task/7956386492181579966) started by @cmuench*