### PR TITLE
🔒 Fix insecure Composer installer download

### DIFF
--- a/src/N98/Magento/Command/Installer/SubCommand/InstallComposer.php
+++ b/src/N98/Magento/Command/Installer/SubCommand/InstallComposer.php
@@ -67,13 +67,12 @@ class InstallComposer extends AbstractSubCommand
     {
         $this->output->writeln('<info>Could not find composer. Try to download it.</info>');
 
-        $response = Requests::get('https://getcomposer.org/installer');
+        $composerInstaller = $this->fetchComposerInstaller();
+        $signature = $this->fetchComposerSignature();
 
-        if (!$response->success) {
-            throw new \RuntimeException('Cannot download Composer installer: ' . $response->status_code);
+        if (hash('sha384', $composerInstaller) !== $signature) {
+            throw new \RuntimeException('Composer installer corrupt');
         }
-
-        $composerInstaller = $response->body;
 
         $tempComposerInstaller = $this->config['initialFolder'] . '/_composer_installer.php';
         file_put_contents($tempComposerInstaller, $composerInstaller);
@@ -97,6 +96,34 @@ class InstallComposer extends AbstractSubCommand
         $this->output->writeln('<info>Successfully installed composer to Magento root</info>');
 
         return $this->config['initialFolder'] . '/composer.phar';
+    }
+
+    /**
+     * @return string
+     */
+    protected function fetchComposerInstaller()
+    {
+        $response = Requests::get('https://getcomposer.org/installer');
+
+        if (!$response->success) {
+            throw new \RuntimeException('Cannot download Composer installer: ' . $response->status_code);
+        }
+
+        return $response->body;
+    }
+
+    /**
+     * @return string
+     */
+    protected function fetchComposerSignature()
+    {
+        $response = Requests::get('https://composer.github.io/installer.sig');
+
+        if (!$response->success) {
+            throw new \RuntimeException('Cannot download Composer installer signature: ' . $response->status_code);
+        }
+
+        return trim($response->body);
     }
 
     /**

--- a/tests/N98/Magento/Command/Installer/SubCommand/InstallComposerTest.php
+++ b/tests/N98/Magento/Command/Installer/SubCommand/InstallComposerTest.php
@@ -13,7 +13,7 @@ class InstallComposerTest extends TestCase
         $content = '<?php echo "installer"; ?>';
         $signature = hash('sha384', $content);
 
-        $command = new class extends InstallComposer {
+        $command = new class() extends InstallComposer {
             public $installerContent;
             public $signatureContent;
 
@@ -57,7 +57,7 @@ class InstallComposerTest extends TestCase
         $content = 'some content';
         $signature = 'invalid_hash';
 
-        $command = new class extends InstallComposer {
+        $command = new class() extends InstallComposer {
             public $installerContent;
             public $signatureContent;
 

--- a/tests/N98/Magento/Command/Installer/SubCommand/InstallComposerTest.php
+++ b/tests/N98/Magento/Command/Installer/SubCommand/InstallComposerTest.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace N98\Magento\Command\Installer\SubCommand;
+
+use N98\Magento\Command\SubCommand\ConfigBag;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Output\NullOutput;
+
+class InstallComposerTest extends TestCase
+{
+    public function testDownloadComposerVerifiesHashSuccess()
+    {
+        $content = '<?php echo "installer"; ?>';
+        $signature = hash('sha384', $content);
+
+        $command = new class extends InstallComposer {
+            public $installerContent;
+            public $signatureContent;
+
+            protected function fetchComposerInstaller()
+            {
+                return $this->installerContent;
+            }
+
+            protected function fetchComposerSignature()
+            {
+                return $this->signatureContent;
+            }
+        };
+
+        $command->installerContent = $content;
+        $command->signatureContent = $signature;
+
+        $command->setConfig(new ConfigBag(['initialFolder' => sys_get_temp_dir()]));
+        $command->setOutput(new NullOutput());
+
+        try {
+            $reflection = new \ReflectionClass($command);
+            $method = $reflection->getMethod('downloadComposer');
+            $method->setAccessible(true);
+            $result = $method->invoke($command);
+
+            // If it returns a path, it means it succeeded (execution passed, which might happen if exec works or fails gracefully without throw)
+            // But usually exec failure throws Exception 'Installation failed.'
+            // Let's catch that specific exception as a "success" for hash verification.
+
+        } catch (\Exception $e) {
+            if ($e->getMessage() === 'Composer installer corrupt') {
+                $this->fail('Hash verification failed unexpectedly');
+            }
+            // Other exceptions are acceptable (e.g. installation failed because we didn't provide a real installer)
+        }
+    }
+
+    public function testDownloadComposerVerifiesHashFailure()
+    {
+        $content = 'some content';
+        $signature = 'invalid_hash';
+
+        $command = new class extends InstallComposer {
+            public $installerContent;
+            public $signatureContent;
+
+            protected function fetchComposerInstaller()
+            {
+                return $this->installerContent;
+            }
+
+            protected function fetchComposerSignature()
+            {
+                return $this->signatureContent;
+            }
+        };
+
+        $command->installerContent = $content;
+        $command->signatureContent = $signature;
+
+        $command->setConfig(new ConfigBag(['initialFolder' => sys_get_temp_dir()]));
+        $command->setOutput(new NullOutput());
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Composer installer corrupt');
+
+        $reflection = new \ReflectionClass($command);
+        $method = $reflection->getMethod('downloadComposer');
+        $method->setAccessible(true);
+        $method->invoke($command);
+    }
+}


### PR DESCRIPTION
This PR fixes a security vulnerability where the Composer installer was downloaded and executed without integrity verification.

### Changes
- Modified `src/N98/Magento/Command/Installer/SubCommand/InstallComposer.php` to fetch the installer signature and verify the SHA-384 hash.
- Added `tests/N98/Magento/Command/Installer/SubCommand/InstallComposerTest.php` to test the verification logic.

### Verification
- Ran the new unit test: `vendor/bin/phpunit tests/N98/Magento/Command/Installer/SubCommand/InstallComposerTest.php` (Passed)
- Ran all unit tests: `vendor/bin/phpunit` (Passed, with expected skips/failures for unrelated environment issues)

---
*PR created automatically by Jules for task [14144995659162911477](https://jules.google.com/task/14144995659162911477) started by @cmuench*