### PR TITLE
Add unit test for YamlRenderer

### DIFF
--- a/tests/N98/Util/Console/Helper/Table/Renderer/YamlRendererTest.php
+++ b/tests/N98/Util/Console/Helper/Table/Renderer/YamlRendererTest.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * This file is part of the n98-magerun2 project.
+ *
+ * For the full copyright and license information, please view the MIT-LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+namespace N98\Util\Console\Helper\Table\Renderer;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Output\StreamOutput;
+use Symfony\Component\Yaml\Yaml;
+
+class YamlRendererTest extends TestCase
+{
+    public function testRender()
+    {
+        $renderer = new YamlRenderer();
+        $stream = fopen('php://memory', 'r+');
+        $output = new StreamOutput($stream);
+
+        $rows = [
+            ['col1' => 'val1', 'col2' => 'val2'],
+        ];
+
+        $renderer->render($output, $rows);
+
+        rewind($stream);
+        $yamlOutput = stream_get_contents($stream);
+        fclose($stream);
+
+        $expectedOutput = Yaml::dump($rows) . "\n";
+        $this->assertEquals($expectedOutput, $yamlOutput);
+    }
+
+    public function testRenderEmptyRows()
+    {
+        $renderer = new YamlRenderer();
+        $stream = fopen('php://memory', 'r+');
+        $output = new StreamOutput($stream);
+
+        $rows = [];
+
+        $renderer->render($output, $rows);
+
+        rewind($stream);
+        $yamlOutput = stream_get_contents($stream);
+        fclose($stream);
+
+        $expectedOutput = Yaml::dump($rows) . "\n";
+        $this->assertEquals($expectedOutput, $yamlOutput);
+    }
+
+    public function testRenderNestedArray()
+    {
+        $renderer = new YamlRenderer();
+        $stream = fopen('php://memory', 'r+');
+        $output = new StreamOutput($stream);
+
+        $rows = [
+            'row1' => ['col1' => 'val1', 'col2' => 'val2'],
+            'row2' => ['nested' => ['a' => 1, 'b' => 2]],
+        ];
+
+        $renderer->render($output, $rows);
+
+        rewind($stream);
+        $yamlOutput = stream_get_contents($stream);
+        fclose($stream);
+
+        $expectedOutput = Yaml::dump($rows) . "\n";
+        $this->assertEquals($expectedOutput, $yamlOutput);
+    }
+}


### PR DESCRIPTION
Added unit test for `YamlRenderer` to verify correct delegation to Symfony Yaml component.
The test covers:
- Basic array rendering
- Empty array rendering
- Nested array rendering

Tests verified with `phpunit`.

---
*PR created automatically by Jules for task [15099694528382936689](https://jules.google.com/task/15099694528382936689) started by @cmuench*