### PR TITLE
⚡ Optimize eav:attribute:list command to fix N+1 query issue

### DIFF
--- a/src/N98/Magento/Command/Eav/Attribute/ListCommand.php
+++ b/src/N98/Magento/Command/Eav/Attribute/ListCommand.php
@@ -11,6 +11,7 @@ namespace N98\Magento\Command\Eav\Attribute;
 use Magento\Eav\Model\Attribute;
 use Magento\Eav\Model\Entity\Type as EntityType;
 use Magento\Eav\Model\ResourceModel\Entity\Attribute\Collection as AttributeCollection;
+use Magento\Eav\Model\ResourceModel\Entity\Type\CollectionFactory as EntityTypeCollectionFactory;
 use N98\Magento\Command\AbstractMagentoCommand;
 use N98\Util\Console\Helper\Table\Renderer\RendererFactory;
 use Symfony\Component\Console\Command\Command;
@@ -30,13 +31,21 @@ class ListCommand extends AbstractMagentoCommand
     private $attributeCollection;
 
     /**
+     * @var EntityTypeCollectionFactory
+     */
+    private $entityTypeCollectionFactory;
+
+    /**
      * @param AttributeCollection $attributeCollection
+     * @param EntityTypeCollectionFactory $entityTypeCollectionFactory
      * @return void
      */
     public function inject(
-        AttributeCollection $attributeCollection
+        AttributeCollection $attributeCollection,
+        EntityTypeCollectionFactory $entityTypeCollectionFactory
     ) {
         $this->attributeCollection = $attributeCollection;
+        $this->entityTypeCollectionFactory = $entityTypeCollectionFactory;
     }
 
     /**
@@ -92,10 +101,32 @@ class ListCommand extends AbstractMagentoCommand
         $filterType = $input->getOption('filter-type');
         $this->attributeCollection->setOrder('attribute_code', 'asc');
 
+        $entityTypeCollection = $this->entityTypeCollectionFactory->create();
+        $entityTypesById = [];
+        $entityTypesByCode = [];
+
+        foreach ($entityTypeCollection as $entityType) {
+            $entityTypesById[$entityType->getId()] = $entityType;
+            $entityTypesByCode[$entityType->getEntityTypeCode()] = $entityType->getId();
+        }
+
+        if ($filterType) {
+            if (isset($entityTypesByCode[$filterType])) {
+                $this->attributeCollection->addFieldToFilter('entity_type_id', $entityTypesByCode[$filterType]);
+            } else {
+                $this->attributeCollection->addFieldToFilter('entity_type_id', 0);
+            }
+        }
+
         /** @var Attribute $attribute */
         foreach ($this->attributeCollection as $attribute) {
             /** @var EntityType $entityType */
-            $entityType = $attribute->getEntityType();
+            if (isset($entityTypesById[$attribute->getEntityTypeId()])) {
+                $entityType = $entityTypesById[$attribute->getEntityTypeId()];
+            } else {
+                $entityType = $attribute->getEntityType();
+            }
+
             if ($filterType &&
                 $entityType->getEntityTypeCode() !== $filterType) {
                 continue;


### PR DESCRIPTION
This PR optimizes the `eav:attribute:list` command by resolving an N+1 query issue where `getEntityType()` was called for each attribute.

Changes:
- Injected `Magento\Eav\Model\ResourceModel\Entity\Type\CollectionFactory`.
- Pre-loaded all entity types into an array keyed by ID.
- Replaced the `$attribute->getEntityType()` call inside the loop with a lookup in the pre-loaded array.
- Optimized the `filter-type` logic to filter the collection by `entity_type_id` at the database level instead of filtering in PHP after fetching all attributes.

Performance Impact:
- Reduces the number of database queries from N+1 (where N is the number of attributes) to 2 (1 for attributes, 1 for entity types).
- Reduces memory usage and processing time when filtering by entity type by avoiding the instantiation of irrelevant attribute objects.

---
*PR created automatically by Jules for task [11756476820337043046](https://jules.google.com/task/11756476820337043046) started by @cmuench*