### PR TITLE
Fix MCP server tool names by replacing colons with underscores

### DIFF
--- a/src/N98/Magento/Command/Mcp/Server/StartCommand.php
+++ b/src/N98/Magento/Command/Mcp/Server/StartCommand.php
@@ -66,17 +66,19 @@ class StartCommand extends AbstractMagentoCommand
 
             $description .= ' Arguments: provide CLI arguments as a single string (without the command name).';
 
+            $toolName = str_replace(':', '_', $commandName);
+
             $builder->addTool(
                 handler: function (string $arguments = '') use ($application, $commandName): string {
                     $handler = new CommandToolHandler($application, $commandName);
 
                     return $handler($arguments);
                 },
-                name: $commandName,
+                name: $toolName,
                 description: $description
             );
 
-            $toolNames[] = $commandName;
+            $toolNames[] = $toolName;
         }
 
         $server = $builder->build();


### PR DESCRIPTION
Fixed an issue where commands with colons in their names were not visible as tools in the MCP Server.
MCP tool names must match the regex `^[a-zA-Z0-9_-]+$`.
The fix involves transforming the command name when registering the tool:
- Replaces `:` with `_`.
- Keeps the original command name for the `CommandToolHandler` to ensure the correct command is executed.

Verified that this transformation does not introduce collisions among existing commands.

---
*PR created automatically by Jules for task [10662925463594123410](https://jules.google.com/task/10662925463594123410) started by @cmuench*