### PR TITLE
feat(mcp): add grouped command filtering for MCP server tools

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -200,6 +200,60 @@ commands:
   # The configuration can be changed by magerun modules
   # and on project and user level. See wiki for details.
 
+  N98\Magento\Command\Mcp\Server\StartCommand:
+    command-groups:
+      - id: admin
+        description: Admin users, tokens and notifications
+        commands: "admin:*"
+
+      - id: cron
+        description: Cron related commands
+        commands: "sys:cron:*"
+
+      - id: cache
+        description: Cache related commands
+        commands: "cache:*"
+
+      - id: config
+        description: Environment and store configuration commands
+        commands: "config:* magerun:config:*"
+
+      - id: database
+        description: Database commands
+        commands: "db:*"
+
+      - id: development
+        description: Developer and generation commands
+        commands: "dev:* generation:*"
+
+      - id: index
+        description: Indexer commands
+        commands: "index:*"
+
+      - id: integration
+        description: Integration token and API integration commands
+        commands: "integration:*"
+
+      - id: maintenance
+        description: Core maintenance and setup commands
+        commands: "sys:maintenance sys:setup:*"
+
+      - id: read-only
+        description: Mostly read-only inspection commands
+        commands: "@cron cache:list config:env:show config:store:get customer:info customer:list db:info db:status db:variables dev:log:size dev:module:list dev:module:observer:list dev:report:count dev:theme:list eav:attribute:list eav:attribute:view index:list integration:list integration:show magerun:config:info route:list script:repo:list search:engine:list sys:check sys:info sys:store:list sys:url:list sys:website:list"
+
+      - id: repo
+        description: Script repository commands
+        commands: "script script:repo:*"
+
+      - id: risky
+        description: Commands that can mutate or delete data
+        commands: "admin:* cache:clean cache:disable cache:enable cache:flush cache:remove:id cms:block:toggle config:env:create config:env:delete config:env:set config:store:delete config:store:set customer:add-address customer:change-password customer:create customer:delete db:* dev:* eav:attribute:remove generation:flush index:trigger:recreate integration:create integration:delete install media:dump sales:sequence:* script script:repo:run sys:cron:kill sys:cron:run sys:cron:schedule sys:maintenance sys:setup:* sys:url:regenerate"
+
+      - id: system
+        description: System commands
+        commands: "sys:*"
+
   N98\Magento\Command\Composer\RedeployBasePackagesCommand:
     packages:
       - magento/magento2-base

--- a/docs/docs/command-docs/mcp/index.md
+++ b/docs/docs/command-docs/mcp/index.md
@@ -8,4 +8,4 @@ Commands for the Model Context Protocol (MCP) server integration.
 
 ## Commands
 
-- [mcp:server:start](./mcp-server-start.md) - Start an MCP server exposing all n98-magerun2 commands as tools
+- [mcp:server:start](./mcp-server-start.md) - Start an MCP server exposing a filtered n98-magerun2 command set as tools

--- a/docs/docs/command-docs/mcp/mcp-server-start.md
+++ b/docs/docs/command-docs/mcp/mcp-server-start.md
@@ -5,13 +5,16 @@ title: mcp:server:start
 # mcp:server:start
 
 :::info
-Start an MCP server exposing all n98-magerun2 commands as tools.
+Start an MCP server exposing selected n98-magerun2 commands as tools.
 :::
 
 ## Description
 
 The `mcp:server:start` command starts a [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server.
-This server exposes all available n98-magerun2 commands as executable tools to MCP clients (like Claude Desktop, or other AI agents).
+This server exposes n98-magerun2 commands as executable tools to MCP clients (like Claude Desktop, or other AI agents).
+
+By default, Symfony internal commands (`help`, `list`, `completion`) and Magento core proxy commands are not exposed.
+You can control the exposed command set with `--include` and `--exclude`.
 
 This allows AI assistants to directly interact with your Magento 2 installation through n98-magerun2 commands.
 
@@ -21,13 +24,71 @@ This allows AI assistants to directly interact with your Magento 2 installation 
 n98-magerun2.phar mcp:server:start
 ```
 
+```bash
+n98-magerun2.phar mcp:server:start --include="sys:cron:* cache:*" --exclude="sys:cron:history"
+```
+
+```bash
+n98-magerun2.phar mcp:server:start --include="@cron"
+```
+
 The server runs using stdio transport, meaning it communicates via standard input/output. This is the standard way to integrate with local MCP clients.
 
 ## Features
 
-- **Tool Exposure**: All standard n98-magerun2 commands (and custom ones) are automatically registered as MCP tools.
+- **Tool Exposure**: Commands are filtered before registration. Aliases and internal Symfony commands are excluded.
 - **Argument Handling**: Arguments for commands are passed as a single string.
 - **Output**: The output of the command is returned to the MCP client.
+
+## Include / Exclude Filters
+
+- `--include`: Registers only commands matching one or more patterns.
+- `--exclude`: Removes matching commands from the result set.
+- Wildcards are supported (`*`, `?`), for example: `sys:cron:*`.
+- Group references are supported with `@group` syntax.
+
+Command groups are configured via command config in `config.yaml`:
+
+```yaml
+commands:
+  N98\Magento\Command\Mcp\Server\StartCommand:
+    command-groups:
+      - id: cron
+        description: Cron related commands
+        commands: "sys:cron:*"
+```
+
+Then you can use `@cron` in `--include` and `--exclude`.
+
+Run the command help to see all configured groups and their patterns:
+
+```bash
+n98-magerun2.phar mcp:server:start --help
+```
+
+## Predefined Command Groups
+
+The project ships with these predefined groups in `config.yaml`:
+
+- `@admin` - Admin users, tokens and notifications (`admin:*`)
+- `@cron` - Cron related commands (`sys:cron:*`)
+- `@cache` - Cache related commands (`cache:*`)
+- `@config` - Environment and store config commands (`config:*`, `magerun:config:*`)
+- `@database` - Database commands (`db:*`)
+- `@development` - Developer and generation commands (`dev:*`, `generation:*`)
+- `@index` - Indexer commands (`index:*`)
+- `@integration` - Integration commands (`integration:*`)
+- `@maintenance` - Core maintenance and setup commands (`sys:maintenance`, `sys:setup:*`)
+- `@read-only` - Mostly read-only inspection command set
+- `@repo` - Script repository commands (`script`, `script:repo:*`)
+- `@risky` - Commands that can mutate or delete data
+- `@system` - System commands (`sys:*`)
+
+Example:
+
+```bash
+n98-magerun2.phar mcp:server:start --include="@read-only" --exclude="@risky"
+```
 
 ## Example Configuration (Claude Desktop)
 

--- a/src/N98/Magento/Command/Mcp/Server/StartCommand.php
+++ b/src/N98/Magento/Command/Mcp/Server/StartCommand.php
@@ -11,9 +11,12 @@ namespace N98\Magento\Command\Mcp\Server;
 use Mcp\Server;
 use Mcp\Server\Transport\StdioTransport;
 use N98\Magento\Command\AbstractMagentoCommand;
+use N98\Magento\Command\MagentoCoreProxyCommand;
+use N98\Magento\Mcp\CommandPatternResolver;
 use N98\Magento\Mcp\CommandToolHandler;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\ConsoleOutputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -26,7 +29,19 @@ class StartCommand extends AbstractMagentoCommand
     {
         $this
             ->setName('mcp:server:start')
-            ->setDescription('Start an MCP server exposing all n98-magerun2 commands as tools');
+            ->setDescription('Start an MCP server exposing selected n98-magerun2 commands as tools')
+            ->addOption(
+                'include',
+                null,
+                InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY,
+                'Command include filter. Supports wildcards and @group references (for example: "sys:cron:* @maintenance").'
+            )
+            ->addOption(
+                'exclude',
+                null,
+                InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY,
+                'Command exclude filter. Supports wildcards and @group references (for example: "dev:* @unsafe").'
+            );
     }
 
     /**
@@ -52,10 +67,44 @@ class StartCommand extends AbstractMagentoCommand
         $commands = $application->all();
         ksort($commands);
 
+        $patternResolver = new CommandPatternResolver();
+        $commandGroups = $patternResolver->getCommandGroupDefinitions($this->getCommandConfig());
+        $includePatterns = $this->resolveFilterPatterns(
+            $input->getOption('include'),
+            $patternResolver,
+            $commandGroups
+        );
+        $excludePatterns = $this->resolveFilterPatterns(
+            $input->getOption('exclude'),
+            $patternResolver,
+            $commandGroups
+        );
+        $internalCommands = ['help', 'list', 'completion'];
+
         $toolNames = [];
 
         foreach ($commands as $commandName => $command) {
             if ($command->isHidden() || $commandName === $this->getName()) {
+                continue;
+            }
+
+            if ($commandName !== $command->getName()) {
+                continue;
+            }
+
+            if (in_array($commandName, $internalCommands, true)) {
+                continue;
+            }
+
+            if ($command instanceof MagentoCoreProxyCommand && !$this->matchesAnyPattern($commandName, $includePatterns)) {
+                continue;
+            }
+
+            if (!empty($includePatterns) && !$this->matchesAnyPattern($commandName, $includePatterns)) {
+                continue;
+            }
+
+            if ($this->matchesAnyPattern($commandName, $excludePatterns)) {
                 continue;
             }
 
@@ -97,5 +146,94 @@ class StartCommand extends AbstractMagentoCommand
         $server->run(new StdioTransport());
 
         return Command::SUCCESS;
+    }
+
+    public function getHelp(): string
+    {
+        return parent::getHelp() . PHP_EOL . $this->getCommandGroupHelp();
+    }
+
+    /**
+     * @param string|string[]|null $rawFilter
+     * @param array<string, array{commands: string[], description: string}> $commandGroups
+     * @return string[]
+     */
+    private function resolveFilterPatterns($rawFilter, CommandPatternResolver $patternResolver, array $commandGroups): array
+    {
+        if ($rawFilter === null || $rawFilter === false) {
+            return [];
+        }
+
+        $entries = [];
+        foreach ((array) $rawFilter as $item) {
+            if (!is_string($item)) {
+                continue;
+            }
+
+            $parts = preg_split('~[\s,]+~', trim($item), -1, PREG_SPLIT_NO_EMPTY);
+            if ($parts === false) {
+                continue;
+            }
+
+            $entries = array_merge($entries, $parts);
+        }
+
+        if (empty($entries)) {
+            return [];
+        }
+
+        return $patternResolver->resolvePatterns($entries, $commandGroups);
+    }
+
+    /**
+     * @param string[] $patterns
+     */
+    private function matchesAnyPattern(string $commandName, array $patterns): bool
+    {
+        foreach ($patterns as $pattern) {
+            if ($pattern === $commandName || fnmatch($pattern, $commandName)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function getCommandGroupHelp(): string
+    {
+        $messages = PHP_EOL;
+        $messages .= "<comment>Available Command Groups</comment>\n\n";
+
+        $patternResolver = new CommandPatternResolver();
+        $groups = $patternResolver->getCommandGroupDefinitions($this->getCommandConfig());
+        if (empty($groups)) {
+            return $messages . " <info>(none configured)</info>\n";
+        }
+
+        $maxNameLen = 0;
+        $list = [];
+        foreach ($groups as $id => $definition) {
+            $name = '@' . $id;
+            $description = $definition['description'] !== '' ? $definition['description'] . '.' : '';
+            $patternPreview = implode(' ', $definition['commands']);
+            if ($patternPreview !== '') {
+                $description .= ($description !== '' ? ' ' : '') . sprintf('Patterns: %s', $patternPreview);
+            }
+
+            $nameLen = strlen($name);
+            if ($nameLen > $maxNameLen) {
+                $maxNameLen = $nameLen;
+            }
+
+            $list[] = [$name, $description];
+        }
+
+        foreach ($list as $entry) {
+            [$name, $description] = $entry;
+            $delta = max(0, $maxNameLen - strlen($name));
+            $messages .= sprintf(" <info>%s</info>%s  %s\n", $name, str_repeat(' ', $delta), $description);
+        }
+
+        return $messages;
     }
 }

--- a/src/N98/Magento/Mcp/CommandPatternResolver.php
+++ b/src/N98/Magento/Mcp/CommandPatternResolver.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * This file is part of the n98-magerun2 project.
+ *
+ * For the full copyright and license information, please view the MIT-LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+namespace N98\Magento\Mcp;
+
+use RuntimeException;
+
+class CommandPatternResolver
+{
+    /**
+     * @param array<string, mixed> $commandConfig
+     * @return array<string, array{commands: string[], description: string}>
+     */
+    public function getCommandGroupDefinitions(array $commandConfig): array
+    {
+        $groupDefinitions = [];
+        if (!isset($commandConfig['command-groups'])) {
+            return $groupDefinitions;
+        }
+
+        $groups = $commandConfig['command-groups'];
+        foreach ($groups as $index => $definition) {
+            if (!isset($definition['id'])) {
+                throw new RuntimeException("Invalid definition of command-groups (id missing) at index: $index");
+            }
+
+            $id = $definition['id'];
+            if (isset($groupDefinitions[$id])) {
+                throw new RuntimeException("Invalid definition of command-groups (duplicate id) id: $id");
+            }
+
+            if (!isset($definition['commands'])) {
+                throw new RuntimeException("Invalid definition of command-groups (commands missing) id: $id");
+            }
+
+            $commands = $definition['commands'];
+            if (is_string($commands)) {
+                $commands = preg_split('~\s+~', $commands, -1, PREG_SPLIT_NO_EMPTY);
+            }
+            if (!is_array($commands)) {
+                throw new RuntimeException("Invalid commands definition of command-groups id: $id");
+            }
+            $commands = array_reduce((array) $commands, [$this, 'resolvePatternsArray'], null);
+
+            $description = $definition['description'] ?? '';
+
+            $groupDefinitions[$id] = [
+                'commands' => $commands,
+                'description' => $description,
+            ];
+        }
+
+        return $groupDefinitions;
+    }
+
+    /**
+     * @param string[] $list
+     * @param array<string, array{commands: string[], description: string}> $definitions
+     * @param array<string, bool> $resolved
+     * @return string[]
+     */
+    public function resolvePatterns(array $list, array $definitions = [], array $resolved = []): array
+    {
+        $resolvedList = [];
+
+        foreach ($list as $entry) {
+            if (strpos($entry, '@') === 0) {
+                $code = substr($entry, 1);
+                if (!isset($definitions[$code])) {
+                    throw new RuntimeException('Command-groups could not be resolved: ' . $entry);
+                }
+
+                if (!isset($resolved[$code])) {
+                    $resolved[$code] = true;
+                    $resolvedList = array_merge(
+                        $resolvedList,
+                        $this->resolvePatterns($definitions[$code]['commands'], $definitions, $resolved)
+                    );
+                }
+
+                continue;
+            }
+
+            $resolvedList[] = $entry;
+        }
+
+        asort($resolvedList);
+
+        return array_values(array_unique($resolvedList));
+    }
+
+    /**
+     * @param string[]|null $carry
+     * @param mixed $item
+     * @return string[]
+     */
+    private function resolvePatternsArray(?array $carry = null, $item = null): array
+    {
+        if (is_string($item)) {
+            $item = preg_split('~\s+~', $item, -1, PREG_SPLIT_NO_EMPTY);
+        }
+
+        if (!is_array($item)) {
+            throw new RuntimeException(sprintf('Unable to handle %s', var_export($item, true)));
+        }
+
+        if (count($item) > 1) {
+            $item = array_reduce($item, [$this, 'resolvePatternsArray'], (array) $carry);
+        }
+
+        return array_merge((array) $carry, $item);
+    }
+}

--- a/tests/N98/Magento/Command/Mcp/Server/StartCommandTest.php
+++ b/tests/N98/Magento/Command/Mcp/Server/StartCommandTest.php
@@ -11,5 +11,7 @@ class StartCommandTest extends TestCase
         $command = new StartCommand();
         $this->assertEquals('mcp:server:start', $command->getName());
         $this->assertStringContainsString('Start an MCP server', $command->getDescription());
+        $this->assertTrue($command->getDefinition()->hasOption('include'));
+        $this->assertTrue($command->getDefinition()->hasOption('exclude'));
     }
 }

--- a/tests/N98/Magento/Mcp/CommandPatternResolverTest.php
+++ b/tests/N98/Magento/Mcp/CommandPatternResolverTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace N98\Magento\Mcp;
+
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+class CommandPatternResolverTest extends TestCase
+{
+    public function testGetCommandGroupDefinitions()
+    {
+        $resolver = new CommandPatternResolver();
+
+        $definitions = $resolver->getCommandGroupDefinitions([
+            'command-groups' => [
+                [
+                    'id' => 'maintenance',
+                    'description' => 'Maintenance commands',
+                    'commands' => 'sys:maintenance sys:check',
+                ],
+                [
+                    'id' => 'cron',
+                    'commands' => ['sys:cron:*', 'index:*'],
+                ],
+            ],
+        ]);
+
+        $this->assertArrayHasKey('maintenance', $definitions);
+        $this->assertArrayHasKey('cron', $definitions);
+        $this->assertSame(['sys:maintenance', 'sys:check'], $definitions['maintenance']['commands']);
+        $this->assertSame(['sys:cron:*', 'index:*'], $definitions['cron']['commands']);
+    }
+
+    public function testResolvePatternsWithGroupsAndNestedGroups()
+    {
+        $resolver = new CommandPatternResolver();
+        $definitions = $resolver->getCommandGroupDefinitions([
+            'command-groups' => [
+                ['id' => 'cron', 'commands' => 'sys:cron:*'],
+                ['id' => 'maintenance', 'commands' => '@cron sys:maintenance'],
+            ],
+        ]);
+
+        $resolved = $resolver->resolvePatterns(['@maintenance', 'cache:*'], $definitions);
+
+        $this->assertSame(['cache:*', 'sys:cron:*', 'sys:maintenance'], $resolved);
+    }
+
+    public function testResolvePatternsThrowsOnUnknownGroup()
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Command-groups could not be resolved: @unknown');
+
+        $resolver = new CommandPatternResolver();
+        $resolver->resolvePatterns(['@unknown'], []);
+    }
+}


### PR DESCRIPTION
## Summary
- reduce MCP tool noise by filtering out aliases, Symfony internal commands (`help`, `list`, `completion`), and Magento core proxy commands by default
- add `--include` and `--exclude` options with wildcard matching and `@group` references for MCP tool selection
- add command-group resolver, predefined command groups in `config.yaml`, and docs/help updates listing all available groups

## Testing
- vendor/bin/phpunit tests/N98/Magento/Command/Mcp/Server/StartCommandTest.php
- vendor/bin/phpunit tests/N98/Magento/Mcp/CommandPatternResolverTest.php
- php bin/n98-magerun2 mcp:server:start --help