### PR TITLE
🔒 fix command injection in database compressor classes

### DIFF
--- a/src/N98/Magento/Command/Database/Compressor/Gzip.php
+++ b/src/N98/Magento/Command/Database/Compressor/Gzip.php
@@ -51,7 +51,7 @@ class Gzip extends AbstractCompressor
                 return 'pv -cN tar -zxf ' . escapeshellarg($fileName) . ' && pv -cN mysql | ' . $command;
             }
 
-            return 'tar -zxf ' . escapeshellarg($fileName) . ' -C ' . dirname($fileName) . ' && ' . $command . ' < '
+            return 'tar -zxf ' . escapeshellarg($fileName) . ' -C ' . escapeshellarg(dirname($fileName)) . ' && ' . $command . ' < '
                 . escapeshellarg(substr($fileName, 0, -4));
         }
     }

--- a/src/N98/Magento/Command/Database/Compressor/LZ4.php
+++ b/src/N98/Magento/Command/Database/Compressor/LZ4.php
@@ -54,7 +54,7 @@ class LZ4 extends AbstractCompressor
                 return 'pv -cN tar -zxf ' . escapeshellarg($fileName) . ' && pv -cN mysql | ' . $command;
             }
 
-            return 'tar -zxf ' . escapeshellarg($fileName) . ' -C ' . dirname($fileName) . ' && ' . $command . ' < '
+            return 'tar -zxf ' . escapeshellarg($fileName) . ' -C ' . escapeshellarg(dirname($fileName)) . ' && ' . $command . ' < '
                 . escapeshellarg(substr($fileName, 0, -4));
         }
     }

--- a/src/N98/Magento/Command/Database/Compressor/Uncompressed.php
+++ b/src/N98/Magento/Command/Database/Compressor/Uncompressed.php
@@ -37,10 +37,10 @@ class Uncompressed extends AbstractCompressor
     public function getDecompressingCommand($command, $fileName, $pipe = true)
     {
         if ($this->hasPipeViewer()) {
-            return 'pv ' . $fileName . ' | ' . $command;
+            return 'pv ' . escapeshellarg($fileName) . ' | ' . $command;
         }
 
-        return $command . ' < ' . $fileName;
+        return $command . ' < ' . escapeshellarg($fileName);
     }
 
     /**

--- a/src/N98/Magento/Command/Database/Compressor/Zstandard.php
+++ b/src/N98/Magento/Command/Database/Compressor/Zstandard.php
@@ -78,7 +78,7 @@ class Zstandard extends AbstractCompressor
                 return 'pv -cN tar -zxf ' . escapeshellarg($fileName) . ' && pv -cN mysql | ' . $command;
             }
 
-            return 'tar -zxf ' . escapeshellarg($fileName) . ' -C ' . dirname($fileName) . ' && ' . $command . ' < '
+            return 'tar -zxf ' . escapeshellarg($fileName) . ' -C ' . escapeshellarg(dirname($fileName)) . ' && ' . $command . ' < '
                 . escapeshellarg(substr($fileName, 0, -4));
         }
     }

--- a/tests/N98/Magento/Command/Database/Compressor/CompressorTest.php
+++ b/tests/N98/Magento/Command/Database/Compressor/CompressorTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace N98\Magento\Command\Database\Compressor;
+
+use PHPUnit\Framework\TestCase;
+
+class CompressorTest extends TestCase
+{
+    public function testUncompressedDecompressingCommandEscaping()
+    {
+        $compressor = new Uncompressed();
+        $fileName = 'file;inject.sql';
+        $command = 'mysql';
+
+        $result = $compressor->getDecompressingCommand($command, $fileName);
+        $this->assertStringContainsString("'file;inject.sql'", $result);
+    }
+
+    public function testGzipDecompressingCommandEscaping()
+    {
+        $compressor = new Gzip();
+        $fileName = 'dir;inject/file.sql.gz';
+        $command = 'mysql';
+
+        // Test pipe = false case where dirname is used
+        $result = $compressor->getDecompressingCommand($command, $fileName, false);
+        $this->assertStringContainsString("'dir;inject'", $result);
+    }
+
+    public function testLZ4DecompressingCommandEscaping()
+    {
+        $compressor = new LZ4();
+        $fileName = 'dir;inject/file.sql.lz4';
+        $command = 'mysql';
+
+        // Test pipe = false case where dirname is used
+        $result = $compressor->getDecompressingCommand($command, $fileName, false);
+        $this->assertStringContainsString("'dir;inject'", $result);
+    }
+
+    public function testZstandardDecompressingCommandEscaping()
+    {
+        $compressor = new Zstandard();
+        $fileName = 'dir;inject/file.sql.zstd';
+        $command = 'mysql';
+
+        // Test pipe = false case where dirname is used
+        $result = $compressor->getDecompressingCommand($command, $fileName, false);
+        $this->assertStringContainsString("'dir;inject'", $result);
+    }
+}


### PR DESCRIPTION
🎯 **What:** Fixed command injection vulnerabilities in database compressor classes.
⚠️ **Risk:** Potential for arbitrary command execution if a user imports a database dump with a specially crafted filename.
🛡️ **Solution:** Sanitize all shell command arguments (filenames and directory names) using `escapeshellarg()` before they are concatenated into the command string. Added unit tests to verify proper escaping.

---
*PR created automatically by Jules for task [5335632606920958351](https://jules.google.com/task/5335632606920958351) started by @cmuench*