### PR TITLE
🧹 refactor: add getConfiguration getter to Application class

### DIFF
--- a/src/N98/Magento/Application.php
+++ b/src/N98/Magento/Application.php
@@ -251,8 +251,15 @@ class Application extends BaseApplication
      */
     public function getConfig()
     {
-        // TODO(TK) getter for config / getter for config array
         return $this->config->getConfig();
+    }
+
+    /**
+     * @return Config
+     */
+    public function getConfiguration()
+    {
+        return $this->config;
     }
 
     /**


### PR DESCRIPTION
This PR adds a `getConfiguration()` getter to the `N98\Magento\Application` class to provide access to the `Config` object. It also cleans up a `TODO` comment in the `getConfig()` method, which was previously used for both the array and the object getter. This improvement enhances encapsulation and maintainability.

---
*PR created automatically by Jules for task [1671198646481314828](https://jules.google.com/task/1671198646481314828) started by @cmuench*