### PR TITLE
🔒 [security] Fix SQL Injection in Database Creation

### DIFF
--- a/src/N98/Magento/Command/Installer/SubCommand/CreateDatabase.php
+++ b/src/N98/Magento/Command/Installer/SubCommand/CreateDatabase.php
@@ -186,6 +186,20 @@ class CreateDatabase extends AbstractSubCommand
     }
 
     /**
+     * @param string $host
+     * @param int $port
+     * @param string $user
+     * @param string $pass
+     * @return PDO
+     * @codeCoverageIgnore
+     */
+    protected function createPdoConnection($host, $port, $user, $pass)
+    {
+        $dsn = sprintf('mysql:host=%s;port=%s', $host, $port);
+        return new \PDO($dsn, $user, $pass);
+    }
+
+    /**
      * @param InputInterface $input
      * @param OutputInterface $output
      * @return bool|\PDO
@@ -193,19 +207,19 @@ class CreateDatabase extends AbstractSubCommand
     protected function validateDatabaseSettings(InputInterface $input, OutputInterface $output)
     {
         try {
-            $dsn = sprintf(
-                'mysql:host=%s;port=%s',
+            $db = $this->createPdoConnection(
                 $this->config->getString('db_host'),
-                $this->config->getString('db_port')
+                $this->config->getInt('db_port'),
+                $this->config->getString('db_user'),
+                $this->config->getString('db_pass')
             );
 
-            $db = new \PDO($dsn, $this->config->getString('db_user'), $this->config->getString('db_pass'));
-
             $dbName = $this->config->getString('db_name');
-            if (!$db->query('USE `' . $dbName . '`')) {
-                $db->query('CREATE DATABASE `' . $dbName . '`');
+            $escapedDbName = str_replace('`', '``', $dbName);
+            if (!$db->query('USE `' . $escapedDbName . '`')) {
+                $db->query('CREATE DATABASE `' . $escapedDbName . '`');
                 $output->writeln('<info>Created database ' . $dbName . '</info>');
-                $db->query('USE `' . $dbName . '`');
+                $db->query('USE `' . $escapedDbName . '`');
 
                 // Check DB version
                 $statement = $db->query('SELECT VERSION()');

--- a/src/N98/Util/Console/Helper/DatabaseHelper.php
+++ b/src/N98/Util/Console/Helper/DatabaseHelper.php
@@ -245,7 +245,7 @@ class DatabaseHelper extends AbstractHelper implements CommandAware
         $this->_connection->query("SET SQL_MODE=''");
 
         try {
-            $this->_connection->query('USE `' . $this->dbSettings['dbname'] . '`');
+            $this->_connection->query('USE `' . $this->escapeIdentifier($this->dbSettings['dbname']) . '`');
         } catch (PDOException $e) {
             if ($output && OutputInterface::VERBOSITY_VERY_VERBOSE <= $output->getVerbosity()) {
                 $output->writeln(sprintf(
@@ -876,7 +876,7 @@ class DatabaseHelper extends AbstractHelper implements CommandAware
     {
         $this->detectDbSettings($output);
         $db = $this->getConnection();
-        $db->query('DROP DATABASE IF EXISTS `' . $this->dbSettings['dbname'] . '`');
+        $db->query('DROP DATABASE IF EXISTS `' . $this->escapeIdentifier($this->dbSettings['dbname']) . '`');
         $output->writeln('<info>Dropped database</info> <comment>' . $this->dbSettings['dbname'] . '</comment>');
     }
 
@@ -906,7 +906,7 @@ class DatabaseHelper extends AbstractHelper implements CommandAware
     {
         $this->detectDbSettings($output);
         $db = $this->getConnection();
-        $db->query('CREATE DATABASE IF NOT EXISTS `' . $this->dbSettings['dbname'] . '`');
+        $db->query('CREATE DATABASE IF NOT EXISTS `' . $this->escapeIdentifier($this->dbSettings['dbname']) . '`');
         $output->writeln('<info>Created database</info> <comment>' . $this->dbSettings['dbname'] . '</comment>');
     }
 
@@ -999,7 +999,7 @@ class DatabaseHelper extends AbstractHelper implements CommandAware
      * @param string $identifier
      * @return string
      */
-    private function escapeIdentifier($identifier)
+    public function escapeIdentifier($identifier)
     {
         return str_replace('`', '``', $identifier);
     }

--- a/tests/N98/Magento/Command/Installer/SubCommand/CreateDatabaseTest.php
+++ b/tests/N98/Magento/Command/Installer/SubCommand/CreateDatabaseTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace N98\Magento\Command\Installer\SubCommand;
+
+use N98\Magento\Command\SubCommand\ConfigBag;
+use PHPUnit\Framework\TestCase;
+use PDO;
+use PDOStatement;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class CreateDatabaseTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function validateDatabaseSettingsEscapesDatabaseName()
+    {
+        $inputMock = $this->createMock(InputInterface::class);
+        $outputMock = $this->createMock(OutputInterface::class);
+
+        $pdoMock = $this->createMock(PDO::class);
+        $pdoStatementMock = $this->createMock(PDOStatement::class);
+
+        // Mock query calls
+        // 1. USE `db``name` -> returns false (triggering creation)
+        // 2. CREATE DATABASE `db``name`
+        // 3. USE `db``name`
+        // 4. SELECT VERSION()
+
+        $pdoMock->expects($this->exactly(4))
+            ->method('query')
+            ->withConsecutive(
+                ['USE `db``name`'],
+                ['CREATE DATABASE `db``name`'],
+                ['USE `db``name`'],
+                ['SELECT VERSION()']
+            )
+            ->willReturnOnConsecutiveCalls(
+                false,
+                $pdoStatementMock,
+                $pdoStatementMock,
+                $pdoStatementMock
+            );
+
+        $pdoStatementMock->expects($this->once())
+            ->method('fetchColumn')
+            ->willReturn('5.7.0');
+
+        $configBag = new ConfigBag();
+        $configBag->setString('db_host', 'localhost');
+        $configBag->setInt('db_port', 3306);
+        $configBag->setString('db_user', 'user');
+        $configBag->setString('db_pass', 'pass');
+        $configBag->setString('db_name', 'db`name');
+
+        /** @var CreateDatabase|\PHPUnit\Framework\MockObject\MockObject $subCommand */
+        $subCommand = $this->getMockBuilder(CreateDatabase::class)
+            ->onlyMethods(['createPdoConnection'])
+            ->getMock();
+
+        $subCommand->expects($this->once())
+            ->method('createPdoConnection')
+            ->willReturn($pdoMock);
+
+        $subCommand->setConfig($configBag);
+
+        $reflection = new \ReflectionClass(CreateDatabase::class);
+        $method = $reflection->getMethod('validateDatabaseSettings');
+        $method->setAccessible(true);
+
+        $result = $method->invoke($subCommand, $inputMock, $outputMock);
+
+        $this->assertSame($pdoMock, $result);
+    }
+}

--- a/tests/N98/Util/Console/Helper/DatabaseHelperSecurityTest.php
+++ b/tests/N98/Util/Console/Helper/DatabaseHelperSecurityTest.php
@@ -76,4 +76,72 @@ class DatabaseHelperSecurityTest extends TestCase
 
         $helper->dropViews($outputMock);
     }
+
+    /**
+     * @test
+     */
+    public function dropDatabaseWithVulnerableName()
+    {
+        $pdoMock = $this->getMockBuilder(PDO::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $pdoMock->expects($this->once())
+            ->method('query')
+            ->with($this->callback(function ($query) {
+                return strpos($query, "DROP DATABASE IF EXISTS `db``name`") !== false;
+            }));
+
+        $helper = $this->getMockBuilder(DatabaseHelper::class)
+            ->onlyMethods(['getConnection', 'detectDbSettings'])
+            ->getMock();
+
+        $helper->expects($this->any())
+            ->method('getConnection')
+            ->willReturn($pdoMock);
+
+        // Set dbSettings directly as it is protected
+        $reflection = new \ReflectionClass(DatabaseHelper::class);
+        $property = $reflection->getProperty('dbSettings');
+        $property->setAccessible(true);
+        $property->setValue($helper, ['dbname' => 'db`name']);
+
+        $outputMock = $this->getMockBuilder(OutputInterface::class)->getMock();
+
+        $helper->dropDatabase($outputMock);
+    }
+
+    /**
+     * @test
+     */
+    public function createDatabaseWithVulnerableName()
+    {
+        $pdoMock = $this->getMockBuilder(PDO::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $pdoMock->expects($this->once())
+            ->method('query')
+            ->with($this->callback(function ($query) {
+                return strpos($query, "CREATE DATABASE IF NOT EXISTS `db``name`") !== false;
+            }));
+
+        $helper = $this->getMockBuilder(DatabaseHelper::class)
+            ->onlyMethods(['getConnection', 'detectDbSettings'])
+            ->getMock();
+
+        $helper->expects($this->any())
+            ->method('getConnection')
+            ->willReturn($pdoMock);
+
+        // Set dbSettings directly as it is protected
+        $reflection = new \ReflectionClass(DatabaseHelper::class);
+        $property = $reflection->getProperty('dbSettings');
+        $property->setAccessible(true);
+        $property->setValue($helper, ['dbname' => 'db`name']);
+
+        $outputMock = $this->getMockBuilder(OutputInterface::class)->getMock();
+
+        $helper->createDatabase($outputMock);
+    }
 }


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed is a potential SQL Injection in database creation and connection logic.
⚠️ **Risk:** If the database name comes from an untrusted source, an attacker could inject arbitrary SQL by craftig a database name that escapes the backticks (e.g., `db`; DROP TABLE users; --`).
🛡️ **Solution:** The fix implements proper MySQL identifier escaping by doubling any backticks within the database name and wrapping it in backticks. I've also refactored `DatabaseHelper::escapeIdentifier` to be public for reuse and secured several other locations where database names were used in raw SQL queries.

---
*PR created automatically by Jules for task [8453824771195163996](https://jules.google.com/task/8453824771195163996) started by @cmuench*