### PR TITLE
Update default store scope constant in AbstractMagentoStoreConfigCommand

### DIFF
--- a/src/N98/Magento/Command/AbstractMagentoStoreConfigCommand.php
+++ b/src/N98/Magento/Command/AbstractMagentoStoreConfigCommand.php
@@ -156,7 +156,7 @@ abstract class AbstractMagentoStoreConfigCommand extends AbstractMagentoCommand
         $this->beforeSave($store, $isFalse);
 
         if ($store->getId() == \Magento\Store\Model\Store::DEFAULT_STORE_ID) {
-            $scope = 'default'; // @TODO Constant was removed in Magento2 ?
+            $scope = \Magento\Framework\App\ScopeInterface::SCOPE_DEFAULT;
         } else {
             $scope = \Magento\Store\Model\ScopeInterface::SCOPE_STORES;
         }


### PR DESCRIPTION
Replaces the hardcoded 'default' string with the Magento 2 constant \Magento\Framework\App\ScopeInterface::SCOPE_DEFAULT in the AbstractMagentoStoreConfigCommand class. This resolves a long-standing @TODO and follows Magento 2 best practices.

---
*PR created automatically by Jules for task [11537466355630638534](https://jules.google.com/task/11537466355630638534) started by @cmuench*