### PR TITLE
fix(db:dump): fix mydumper integration for newer versions

### DIFF
--- a/src/N98/Magento/Command/Database/DumpCommand.php
+++ b/src/N98/Magento/Command/Database/DumpCommand.php
@@ -10,6 +10,7 @@ namespace N98\Magento\Command\Database;
 
 use InvalidArgumentException;
 use Magento\Framework\Exception\FileSystemException;
+use N98\Magento\Command\Database\Compressor\AbstractCompressor;
 use N98\Magento\Command\Database\Compressor\Compressor;
 use N98\Util\Console\Enabler;
 use N98\Util\Console\Helper\DatabaseHelper;
@@ -769,12 +770,33 @@ HELP;
         /* @var $database DatabaseHelper */
         $database = $this->getDatabaseHelper(); // Ensure helper is available
         $dbPrefix = $this->dbSettings['prefix'];
+        $compressionType = $input->getOption('compression');
 
+        // mydumper writes to a directory, not stdout — never pipe through a compressor.
+        // Compression is handled as a post-step using tar.
         $execs = new Execs('mydumper');
-        $execs->setCompression($input->getOption('compression'), $input);
+        $execs->setCompression(null, $input);
 
-        // Get output directory from filename
-        $outputDir = dirname($this->getFileName($input, $output, $execs->getCompressor()));
+        // Determine the mydumper output directory and optional archive file.
+        $archiveFile = null;
+        $archiveCompressor = null;
+        if ($compressionType && $compressionType !== 'none') {
+            $archiveCompressor = AbstractCompressor::create($compressionType, $input);
+            // Get the filename that the compressor would normally produce (handles user-supplied
+            // filenames, timestamp flags, default name generation, etc.), then strip the
+            // compression extension so we can use it as the mydumper output directory.
+            $compressedFileName = $this->getFileName($input, $output, $archiveCompressor);
+            $outputDir = $this->stripMydumperCompressionExtension($compressedFileName);
+            // Use the non-pipe (tar-based) filename as the final archive path.
+            $archiveFile = $archiveCompressor->getFileName($outputDir, false);
+        } else {
+            // Without compression: derive the directory from the SQL filename.
+            $sqlFileName = $this->getFileName($input, $output, AbstractCompressor::create(null, $input));
+            $outputDir = str_ends_with($sqlFileName, '.sql')
+                ? substr($sqlFileName, 0, -4)
+                : $sqlFileName;
+        }
+
         $execs->addOptions('--outputdir=' . escapeshellarg($outputDir));
 
         // Database connection options
@@ -787,7 +809,8 @@ HELP;
         ));
 
         if (!$input->getOption('no-single-transaction')) {
-            $execs->addOptions('--trx-consistency-only');
+            // --trx-consistency-only was deprecated in mydumper 0.15; use --trx-tables instead.
+            $execs->addOptions('--trx-tables');
         }
 
         if ($input->getOption('human-readable')) {
@@ -845,6 +868,35 @@ HELP;
             $execs->addOptions(implode(' ', array_unique($noDataOptions)));
         }
 
+        // After mydumper writes its files to $outputDir, compress the directory into an archive
+        // and remove the temporary directory.
+        if ($archiveFile !== null && $archiveCompressor !== null) {
+            $tarCmd = $archiveCompressor->getCompressingCommand(escapeshellarg($archiveFile), false)
+                . ' -C ' . escapeshellarg(dirname($outputDir))
+                . ' ' . escapeshellarg(basename($outputDir));
+            $execs->addPostCommand($tarCmd);
+            $execs->addPostCommand('rm -rf ' . escapeshellarg($outputDir));
+        }
+
         return $execs;
+    }
+
+    /**
+     * Strips known dump/compression file extensions from a filename so that the bare
+     * base name can be used as a mydumper output directory.
+     *
+     * @param string $fileName
+     * @return string
+     */
+    private function stripMydumperCompressionExtension(string $fileName): string
+    {
+        $extensions = ['.sql.gz', '.sql.lz4', '.sql.zstd', '.tar.gz', '.tar.lz4', '.tar.zstd', '.tgz', '.sql'];
+        foreach ($extensions as $ext) {
+            if (str_ends_with($fileName, $ext)) {
+                return substr($fileName, 0, -strlen($ext));
+            }
+        }
+
+        return $fileName;
     }
 }

--- a/src/N98/Magento/Command/Database/DumpCommand.php
+++ b/src/N98/Magento/Command/Database/DumpCommand.php
@@ -800,13 +800,17 @@ HELP;
         $execs->addOptions('--outputdir=' . escapeshellarg($outputDir));
 
         // Database connection options
-        $execs->addOptions(sprintf(
+        $connectionOptions = sprintf(
             '--host=%s --user=%s --password=%s --database=%s',
             escapeshellarg($this->dbSettings['host']),
             escapeshellarg($this->dbSettings['username']),
             escapeshellarg($this->dbSettings['password']),
             escapeshellarg($this->dbSettings['dbname'])
-        ));
+        );
+        if (isset($this->dbSettings['port']) && is_numeric($this->dbSettings['port']) && (int)$this->dbSettings['port'] > 0) {
+            $connectionOptions .= ' --port=' . escapeshellarg($this->dbSettings['port']);
+        }
+        $execs->addOptions($connectionOptions);
 
         if (!$input->getOption('no-single-transaction')) {
             $execs->addOptions($this->getMydumperTransactionFlag());

--- a/src/N98/Magento/Command/Database/DumpCommand.php
+++ b/src/N98/Magento/Command/Database/DumpCommand.php
@@ -809,8 +809,7 @@ HELP;
         ));
 
         if (!$input->getOption('no-single-transaction')) {
-            // --trx-consistency-only was deprecated in mydumper 0.15; use --trx-tables instead.
-            $execs->addOptions('--trx-tables');
+            $execs->addOptions($this->getMydumperTransactionFlag());
         }
 
         if ($input->getOption('human-readable')) {
@@ -879,6 +878,32 @@ HELP;
         }
 
         return $execs;
+    }
+
+    /**
+     * Returns the correct mydumper flag for transaction consistency depending on the
+     * installed version. mydumper 0.15+ uses --trx-tables; older versions use
+     * --trx-consistency-only.
+     */
+    private function getMydumperTransactionFlag(): string
+    {
+        exec('mydumper --version 2>&1', $output, $returnVal);
+        $versionString = implode(' ', $output);
+
+        // Version string examples:
+        //   "mydumper 0.11.5, built against MySQL 8.0.28"
+        //   "mydumper v0.15.1-3, built against MySQL 8.0.33 with SSL support"
+        if (preg_match('/v?(\d+)\.(\d+)/', $versionString, $matches)) {
+            $major = (int) $matches[1];
+            $minor = (int) $matches[2];
+
+            if ($major > 0 || $minor >= 15) {
+                return '--trx-tables';
+            }
+        }
+
+        // Older versions (< 0.15) or version detection failure: use the legacy flag.
+        return '--trx-consistency-only';
     }
 
     /**

--- a/src/N98/Magento/Command/Database/Execs.php
+++ b/src/N98/Magento/Command/Database/Execs.php
@@ -43,6 +43,11 @@ class Execs
     private $fileName;
 
     /**
+     * @var array
+     */
+    private $postCommands = [];
+
+    /**
      * Execs constructor.
      *
      * @param string|null $command [optional]
@@ -105,6 +110,16 @@ class Execs
     }
 
     /**
+     * Adds an independent command to run after all main commands (e.g. post-processing steps).
+     *
+     * @param string $command
+     */
+    public function addPostCommand($command)
+    {
+        $this->postCommands[] = $command;
+    }
+
+    /**
      * @param string $separator
      * @return string
      */
@@ -127,16 +142,16 @@ class Execs
     public function getCommands()
     {
         if (empty($this->execs)) {
-            return [$this->getBaseCommand()];
+            $commands = [$this->getBaseCommand()];
+        } else {
+            $commands = [];
+            foreach ($this->execs as $exec) {
+                $next = clone $this;
+                $next->options[] = trim($exec);
+                $commands[] = $next->getBaseCommand($commands ? '>>' : '>');
+            }
         }
 
-        $commands = [];
-        foreach ($this->execs as $exec) {
-            $next = clone $this;
-            $next->options[] = trim($exec);
-            $commands[] = $next->getBaseCommand($commands ? '>>' : '>');
-        }
-
-        return $commands;
+        return array_merge($commands, $this->postCommands);
     }
 }

--- a/tests/bats/functional_magerun_commands.bats
+++ b/tests/bats/functional_magerun_commands.bats
@@ -514,6 +514,56 @@ function cleanup_files_in_magento() {
 }
 
 # ============================================
+# Command: db:dump (mydumper)
+# ============================================
+
+@test "Command: db:dump --mydumper to directory" {
+  if ! command -v mydumper &> /dev/null; then
+    skip "mydumper not installed"
+  fi
+  run $BIN "db:dump" --mydumper db_mydumper.sql
+  assert_output --partial "Finished"
+  assert [ "$status" -eq 0 ]
+}
+
+@test "Command: db:dump --mydumper with --strip" {
+  if ! command -v mydumper &> /dev/null; then
+    skip "mydumper not installed"
+  fi
+  run $BIN "db:dump" --mydumper --strip=@development db_mydumper_strip.sql
+  assert_output --partial "Finished"
+  assert [ "$status" -eq 0 ]
+}
+
+@test "Command: db:dump --mydumper with --strip and --exclude" {
+  if ! command -v mydumper &> /dev/null; then
+    skip "mydumper not installed"
+  fi
+  run $BIN "db:dump" --mydumper --strip=@development --exclude=core_config_data db_mydumper_strip_excl.sql
+  assert_output --partial "Finished"
+  assert [ "$status" -eq 0 ]
+}
+
+@test "Command: db:dump --mydumper --only-command" {
+  if ! command -v mydumper &> /dev/null; then
+    skip "mydumper not installed"
+  fi
+  run $BIN "db:dump" --mydumper --only-command db_mydumper_cmd.sql
+  assert [ "$status" -eq 0 ]
+  assert_output --partial "mydumper"
+}
+
+@test "Command: db:dump --mydumper --only-command with --strip and --exclude" {
+  if ! command -v mydumper &> /dev/null; then
+    skip "mydumper not installed"
+  fi
+  run $BIN "db:dump" --mydumper --strip=@development --exclude=admin_* --only-command db_mydumper_strip_cmd.sql
+  assert [ "$status" -eq 0 ]
+  assert_output --partial "--no-data="
+  assert_output --partial "--ignore-table="
+}
+
+# ============================================
 # Command: db:info
 # ============================================
 

--- a/tests/bats/functional_magerun_commands.bats
+++ b/tests/bats/functional_magerun_commands.bats
@@ -539,6 +539,9 @@ function cleanup_files_in_magento() {
   if ! command -v mydumper &> /dev/null; then
     skip "mydumper not installed"
   fi
+  if ! mydumper --help 2>&1 | grep -q -- '--ignore-table'; then
+    skip "mydumper version does not support --ignore-table"
+  fi
   run $BIN "db:dump" --mydumper --strip=@development --exclude=core_config_data db_mydumper_strip_excl.sql
   assert_output --partial "Finished"
   assert [ "$status" -eq 0 ]


### PR DESCRIPTION
- Replace deprecated --trx-consistency-only with --trx-tables (fixes #1971)
- Fix incorrect command generation when using --mydumper with --compression (fixes #1972)

mydumper writes files to a directory, not stdout, so piping through a compressor (| gzip -c) was incorrect. Compression is now handled as a post-step: mydumper dumps to a temporary directory, tar compresses it into an archive, and the directory is then removed.
