### PR TITLE
Use build cmd to support all Hyva versions

### DIFF
--- a/docs/docs/command-docs/development/dev-theme-build-hyva.md
+++ b/docs/docs/command-docs/development/dev-theme-build-hyva.md
@@ -50,7 +50,7 @@ Use this option to force a fresh `npm install` before building the theme CSS. Th
 **Timeouts**
 
 - The `npm install` process has a timeout of 1 hour (3600 seconds) to prevent hanging on long installs.
-- The build process (`npm run watch` or `npm run build-prod`) has no timeout in watch mode, so it will run until you stop it (Ctrl+C). In production mode, it will run until the build completes.
+- The build process (`npm run watch` or `npm run build`) has no timeout in watch mode, so it will run until you stop it (Ctrl+C). In production mode, it will run until the build completes.
 :::
 
 ---

--- a/src/N98/Magento/Command/Developer/Theme/BuildHyvaThemeCommand.php
+++ b/src/N98/Magento/Command/Developer/Theme/BuildHyvaThemeCommand.php
@@ -272,7 +272,7 @@ class BuildHyvaThemeCommand extends AbstractMagentoCommand
 
         $buildNpmCommand = 'watch'; // Default is watch mode
         if ($isProduction) {
-            $buildNpmCommand = 'build-prod';
+            $buildNpmCommand = 'build';
         }
 
         $process = new Process(['npm', 'run', $buildNpmCommand]);


### PR DESCRIPTION
Closes #1980 

## Summary

Now uses `build` npm command to support all Hyvä versions including v1.4+ that dropped the older npm command `build-prod`