### PR TITLE
🔒 [security fix] Fix command injection in OS Utility

### DIFF
--- a/src/N98/Util/OperatingSystem.php
+++ b/src/N98/Util/OperatingSystem.php
@@ -98,7 +98,7 @@ class OperatingSystem
 
         $out = null;
         $return = null;
-        @exec('which ' . $program, $out, $return);
+        @exec('which ' . escapeshellarg($program), $out, $return);
         return ($return === 0 && isset($out[0])) ? $out[0] : '';
     }
 

--- a/tests/N98/Util/OperatingSystemSecurityTest.php
+++ b/tests/N98/Util/OperatingSystemSecurityTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace N98\Util;
+
+use PHPUnit\Framework\TestCase;
+
+class OperatingSystemSecurityTest extends TestCase
+{
+    /**
+     * @requires OS Linux|Darwin
+     */
+    public function testLocateProgramCommandInjection()
+    {
+        if (OperatingSystem::isWindows()) {
+            $this->markTestSkipped('Test only for POSIX systems');
+        }
+
+        // We try to inject a command that creates a file in the temporary directory
+        $tmpFile = tempnam(sys_get_temp_dir(), 'injection_test');
+        if (file_exists($tmpFile)) {
+            unlink($tmpFile);
+        }
+
+        $injectedCommand = 'ls; touch ' . escapeshellarg($tmpFile);
+
+        // This should not create the file if properly escaped
+        OperatingSystem::locateProgram($injectedCommand);
+
+        $exists = file_exists($tmpFile);
+        if ($exists) {
+            unlink($tmpFile);
+        }
+
+        $this->assertFalse($exists, 'Vulnerability: Command injection possible in locateProgram');
+    }
+}


### PR DESCRIPTION
### 🎯 What: The vulnerability fixed
Command injection in `N98\Util\OperatingSystem::locateProgram`.

### ⚠️ Risk: The potential impact if left unfixed
An attacker who can control the input to `locateProgram` (e.g., via a configuration setting or a command-line argument that eventually reaches this method) could execute arbitrary shell commands on the system where the application is running.

### 🛡️ Solution: How the fix addresses the vulnerability
The fix uses `escapeshellarg()` to properly escape the program name before it is passed to the `exec()` function. This ensures the shell interprets the entire string as a single argument to the `which` command, rather than potentially executing multiple commands.

---
*PR created automatically by Jules for task [5324663423659352109](https://jules.google.com/task/5324663423659352109) started by @cmuench*