### PR TITLE
🔒 fix: prevent command injection via stty mode variable

### DIFF
--- a/src/N98/Magento/Command/Database/ImportCommand.php
+++ b/src/N98/Magento/Command/Database/ImportCommand.php
@@ -258,7 +258,7 @@ HELP;
 
         if (!is_null($sttyMode)) {
             // Restore stty mode because 'pv' breaks it in some cases
-            exec(sprintf('stty %s', $sttyMode));
+            exec(sprintf('stty %s', escapeshellarg($sttyMode)));
         }
 
         return $success;


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed is a potential command injection in the `db:import` command. The `$sttyMode` variable, which is captured from the shell via `stty -g`, was being re-inserted into a shell command using `sprintf` without proper escaping.

⚠️ **Risk:** If an attacker can influence the environment such that the `stty -g` command returns a malicious string (e.g., containing semicolons or pipes), they could achieve arbitrary command execution on the system when `n98-magerun2` is run.

🛡️ **Solution:** The fix wraps the `$sttyMode` variable in `escapeshellarg()` before it is interpolated into the `stty` command string. This ensures that the shell treats the entire value of `$sttyMode` as a single argument to the `stty` command, preventing any injected commands from being executed.

---
*PR created automatically by Jules for task [12189464690708202312](https://jules.google.com/task/12189464690708202312) started by @cmuench*