### PR TITLE
🧪 [testing improvement] Add test for execute in CreateReadmeFile.php

### DIFF
--- a/tests/N98/Magento/Command/Developer/Module/Create/SubCommand/CreateReadmeFileTest.php
+++ b/tests/N98/Magento/Command/Developer/Module/Create/SubCommand/CreateReadmeFileTest.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace N98\Magento\Command\Developer\Module\Create\SubCommand;
+
+use N98\Magento\Command\Developer\Module\CreateCommand;
+use N98\Magento\Command\SubCommand\ConfigBag;
+use N98\Util\Console\Helper\TwigHelper;
+use org\bovigo\vfs\vfsStream;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+class CreateReadmeFileTest extends TestCase
+{
+    /**
+     * @var \org\bovigo\vfs\vfsStreamDirectory
+     */
+    private $root;
+
+    protected function setUp(): void
+    {
+        $this->root = vfsStream::setup();
+    }
+
+    public function testExecuteStandardMode()
+    {
+        $moduleDirectory = vfsStream::url('root/app/code/Vendor/Module');
+        mkdir($moduleDirectory, 0777, true);
+
+        $config = new ConfigBag([
+            'isModmanMode' => false,
+            'moduleDirectory' => $moduleDirectory,
+            'twigVars' => ['foo' => 'bar']
+        ]);
+
+        $output = new BufferedOutput();
+        $subCommand = new CreateReadmeFile();
+        $subCommand->setConfig($config);
+        $subCommand->setOutput($output);
+
+        $twigHelper = $this->createMock(TwigHelper::class);
+        $twigHelper->expects($this->once())
+            ->method('render')
+            ->with('dev/module/create/app/code/module/readme.md.twig', ['foo' => 'bar'])
+            ->willReturn('Rendered Content');
+
+        $command = $this->createMock(CreateCommand::class);
+        $command->method('getHelper')
+            ->with('twig')
+            ->willReturn($twigHelper);
+
+        $subCommand->setCommand($command);
+
+        $subCommand->execute();
+
+        $expectedFile = $moduleDirectory . '/readme.md';
+        $this->assertFileExists($expectedFile);
+        $this->assertEquals('Rendered Content', file_get_contents($expectedFile));
+        $this->assertStringContainsString('Created file: ' . $expectedFile, $output->fetch());
+    }
+
+    public function testExecuteModmanMode()
+    {
+        $modmanRootFolder = vfsStream::url('root/Vendor_Module');
+        mkdir($modmanRootFolder, 0777, true);
+
+        $config = new ConfigBag([
+            'isModmanMode' => true,
+            'modmanRootFolder' => $modmanRootFolder,
+            'twigVars' => ['foo' => 'bar']
+        ]);
+
+        $output = new BufferedOutput();
+        $subCommand = new CreateReadmeFile();
+        $subCommand->setConfig($config);
+        $subCommand->setOutput($output);
+
+        $twigHelper = $this->createMock(TwigHelper::class);
+        $twigHelper->expects($this->once())
+            ->method('render')
+            ->with('dev/module/create/app/code/module/readme.md.twig', ['foo' => 'bar'])
+            ->willReturn('Rendered Content Modman');
+
+        $command = $this->createMock(CreateCommand::class);
+        $command->method('getHelper')
+            ->with('twig')
+            ->willReturn($twigHelper);
+
+        $subCommand->setCommand($command);
+
+        $subCommand->execute();
+
+        $expectedFile = $modmanRootFolder . '/readme.md';
+        $this->assertFileExists($expectedFile);
+        $this->assertEquals('Rendered Content Modman', file_get_contents($expectedFile));
+        $this->assertStringContainsString('Created file: ' . $expectedFile, $output->fetch());
+    }
+}


### PR DESCRIPTION
🎯 **What:** Added unit tests for the `CreateReadmeFile` subcommand, which was previously untested.
📊 **Coverage:** Covered both standard and modman modes of the `execute()` method.
✨ **Result:** Improved test coverage for the developer module creation commands, ensuring reliable readme file generation.

---
*PR created automatically by Jules for task [17014734583363280927](https://jules.google.com/task/17014734583363280927) started by @cmuench*