### PR TITLE
Improve dev:module:observer:list output formatting

### DIFF
--- a/src/N98/Magento/Command/Developer/Module/Observer/ListCommand.php
+++ b/src/N98/Magento/Command/Developer/Module/Observer/ListCommand.php
@@ -12,6 +12,7 @@ use Exception;
 use InvalidArgumentException;
 use N98\Magento\Command\AbstractMagentoCommand;
 use N98\Util\Console\Helper\Table\Renderer\RendererFactory;
+use Symfony\Component\Console\Helper\TableSeparator;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -126,32 +127,37 @@ class ListCommand extends AbstractMagentoCommand
         }
 
         $table = [];
+        $isFirstEvent = true;
+        $format = $input->getOption('format');
 
         foreach ($observerConfig as $eventName => $observers) {
-            $firstObserver = true;
-
             if ($eventFilter !== null && $eventName !== $eventFilter) {
                 continue;
             }
+
+            if (!$isFirstEvent && $format === null) {
+                $table[] = new TableSeparator();
+            }
+
+            $isFirstEvent = false;
 
             foreach ($observers as $observerName => $observerData) {
                 if (!isset($observerData['instance'])) {
                     continue;
                 }
-                if ($firstObserver) {
-                    $firstObserver = !$firstObserver;
-                    $table[] = [$eventName, $observerName, $observerData['instance'] . '::' . $observerData['name']];
-                } else {
-                    $table[] = ['', $observerName, $observerData['instance'] . '::' . $observerData['name']];
-                }
+
+                $table[] = [
+                    $eventName,
+                    $observerName,
+                    $observerData['instance'] . '::' . $observerData['name'],
+                ];
             }
         }
 
-        // @todo Output is a bit ugly!?
         $this->getHelper('table')
-                ->setHeaders(['Event', 'Observer name', 'Fires'])
-                ->setRows($table)
-                ->renderByFormat($output, $table, $input->getOption('format'));
+            ->setHeaders(['Event', 'Observer name', 'Fires'])
+            ->setRows($table)
+            ->renderByFormat($output, $table, $format);
 
         return 0;
     }


### PR DESCRIPTION
The output formatting of the `dev:module:observer:list` command has been improved. 

Changes include:
1.  **Repeat Event Names**: The event name is now displayed for every observer row instead of just the first one. This improves clarity when scanning the table and makes the output more "grep-friendly".
2.  **Add Table Separators**: `Symfony\Component\Console\Helper\TableSeparator` is now used to visually separate groups of observers belonging to different events. This is only applied when the output format is the default (text table) to avoid breaking structured formats like JSON or CSV.
3.  **Code Cleanup**: Removed an outdated `@todo` comment.

Verification was performed using a manual reproduction script that simulated the command's output with multiple events and observers, confirming the correct behavior for both default and JSON formats.

---
*PR created automatically by Jules for task [4948479027140157372](https://jules.google.com/task/4948479027140157372) started by @cmuench*