### PR TITLE
Add Magento 2.4.9-beta1 and PHP 8.5 compatibility

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -1,7 +1,7 @@
 name: n98-magerun2
 type: php
 docroot: ""
-php_version: "8.3"
+php_version: "8.5"
 webserver_type: nginx-fpm
 xdebug_enabled: false
 additional_hostnames: []
@@ -32,13 +32,13 @@ xhgui_http_port: "8143"
 # If the name is omitted, the project will take the name of the enclosing directory,
 # which is useful if you want to have a copy of the project side by side with this one.
 
-# type: <projecttype>  # backdrop, cakephp, craftcms, drupal, drupal6, drupal7, drupal8, drupal9, drupal10, drupal11, generic, laravel, magento, magento2, php, shopware6, silverstripe, symfony, typo3, wordpress
+# type: <projecttype>  # backdrop, cakephp, codeigniter, craftcms, drupal, drupal6, drupal7, drupal8, drupal9, drupal10, drupal11, drupal12, generic, laravel, magento, magento2, php, shopware6, silverstripe, symfony, typo3, wordpress
 # See https://docs.ddev.com/en/stable/users/quickstart/ for more
 # information on the different project types
 
 # docroot: <relative_path> # Relative path to the directory containing index.php.
 
-# php_version: "8.3"  # PHP version to use, "5.6" through "8.5"
+# php_version: "8.4"  # PHP version to use, "5.6" through "8.5"
 
 # You can explicitly specify the webimage but this
 # is not recommended, as the images are often closely tied to DDEV's' behavior,
@@ -74,8 +74,7 @@ xhgui_http_port: "8143"
 # bind_all_ports is used (normally with router disabled)
 
 # xhprof_mode: [prepend|xhgui|global]
-# Set to "xhgui" to enable XHGui features
-# "xhgui" will become default in a future major release
+# Default is "xhgui"
 
 # webserver_type: nginx-fpm, apache-fpm, generic
 
@@ -93,7 +92,7 @@ xhgui_http_port: "8143"
 # commands are executed.
 
 # composer_version: "2"
-# You can set it to "" or "2" (default) for Composer v2 or "1" for Composer v1
+# You can set it to "" or "2" (default) for Composer v2
 # to use the latest major version available at the time your container is built.
 # It is also possible to use each other Composer version channel. This includes:
 #   - 2.2 (latest Composer LTS version)
@@ -101,14 +100,12 @@ xhgui_http_port: "8143"
 #   - preview
 #   - snapshot
 # Alternatively, an explicit Composer version may be specified, for example "2.2.18".
-# To reinstall Composer after the image was built, run "ddev debug rebuild".
+# To reinstall Composer after the image was built, run "ddev utility rebuild".
 
-# nodejs_version: "22"
+# nodejs_version: "24"
 # change from the default system Node.js version to any other version.
 # See https://docs.ddev.com/en/stable/users/configuration/config/#nodejs_version for more information
-# and https://www.npmjs.com/package/n#specifying-nodejs-versions for the full documentation,
-# Note that using of 'ddev nvm' is discouraged because "nodejs_version" is much easier to use,
-# can specify any version, and is more robust than using 'nvm'.
+# and https://www.npmjs.com/package/n#specifying-nodejs-versions for the full documentation.
 
 # corepack_enable: false
 # Change to 'true' to 'corepack enable' and gain access to latest versions of yarn/pnpm
@@ -168,9 +165,7 @@ xhgui_http_port: "8143"
 #   - "global":  uses the value from the global config.
 #   - "none":    disables performance optimization for this project.
 #   - "mutagen": enables Mutagen for this project.
-#   - "nfs":     enables NFS for this project.
 #
-# See https://docs.ddev.com/en/stable/users/install/performance/#nfs
 # See https://docs.ddev.com/en/stable/users/install/performance/#mutagen
 
 # fail_on_hook_fail: False
@@ -200,10 +195,10 @@ xhgui_http_port: "8143"
 # The mailpit port is not normally bound on the host at all, instead being routed
 # through ddev-router, but it can be bound directly to localhost if specified here.
 
-# webimage_extra_packages: [php7.4-tidy, php-bcmath]
+# webimage_extra_packages: ['php${DDEV_PHP_VERSION}-tidy', 'php${DDEV_PHP_VERSION}-yac']
 # Extra Debian packages that are needed in the webimage can be added here
 
-# dbimage_extra_packages: [telnet,netcat]
+# dbimage_extra_packages: [netcat, telnet, sudo]
 # Extra Debian packages that are needed in the dbimage can be added here
 
 # use_dns_when_possible: true
@@ -215,12 +210,15 @@ xhgui_http_port: "8143"
 # project_tld: ddev.site
 # The top-level domain used for project URLs
 # The default "ddev.site" allows DNS lookup via a wildcard
-# If you prefer you can change this to "ddev.local" to preserve
-# pre-v1.9 behavior.
 
-# ngrok_args: --basic-auth username:pass1234
-# Provide extra flags to the "ngrok http" command, see
-# https://ngrok.com/docs/agent/config/v3/#agent-configuration or run "ngrok http -h"
+# share_default_provider: ngrok
+# The default share provider to use for "ddev share"
+# Defaults to global configuration, usually "ngrok"
+# Can be "ngrok" or "cloudflared" or the name of a custom provider from .ddev/share-providers/
+
+# share_provider_args: --basic-auth username:pass1234
+# Provide extra flags to the share provider script
+# See https://docs.ddev.com/en/stable/users/configuration/config/#share_provider_args
 
 # disable_settings_management: false
 # If true, DDEV will not create CMS-specific settings files like

--- a/.github/workflows/magento_platform_tests.yml
+++ b/.github/workflows/magento_platform_tests.yml
@@ -123,6 +123,17 @@ jobs:
             git-repository: ""
 
           # Magento versions
+          - magento-version: 2.4.9-beta1
+            composer-repository-url: "https://repo.magento.com/"
+            operating-system: ubuntu-22.04
+            php-version: '8.5'
+            mariadb-version: '10.6'
+            opensearch-version: '2'
+            composer-version: '2.8.8'
+            use-git-repository: false
+            git-repository: ""
+            git-branch: ""
+
           - magento-version: 2.4.8
             composer-repository-url: "https://repo.magento.com/"
             operating-system: ubuntu-22.04

--- a/docs/docs/compatibility.md
+++ b/docs/docs/compatibility.md
@@ -10,6 +10,7 @@ We recommend using the **latest version** of n98-magerun2 for the best support a
 
 | Platform & Version                        | Recommended n98-magerun2 Version |
 | ----------------------------------------- |----------------------------------|
+| Adobe Commerce / Magento OS 2.4.9-beta1+  | `v9.0.0` or later                |
 | Adobe Commerce / Magento OS 2.4.8+        | `v9.0.0` or later                |
 | Mage-OS 1.2.x+                            | `v9.0.0` or later                |
 | Adobe Commerce / Magento OS 2.4.5 - 2.4.7 | `v8.0.0` or later                |
@@ -24,6 +25,7 @@ We recommend using the **latest version** of n98-magerun2 for the best support a
 
 | PHP Version | Required n98-magerun2 Version |
 | ----------- |-------------------------------|
+| PHP 8.5     | `v9.0.0` or later             |
 | PHP 8.4     | `v9.0.0` or later             |
 | PHP 8.3     | `v8.0.0` or later             |
 | PHP 8.2     | `v8.0.0` or later             |

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,6 +10,7 @@
         convertErrorsToExceptions="true"
         convertNoticesToExceptions="true"
         convertWarningsToExceptions="true"
+        convertDeprecationsToExceptions="false"
         forceCoversAnnotation="false"
         processIsolation="true"
         stopOnError="false"

--- a/src/N98/Magento/Application/AutoloaderDecorator.php
+++ b/src/N98/Magento/Application/AutoloaderDecorator.php
@@ -175,7 +175,9 @@ class AutoloaderDecorator implements AutoloaderInterface
         try {
             $autoloaderReflection = new \ReflectionObject($this->magentoAutoloader);
             $autoloaderProperty = $autoloaderReflection->getProperty('autoloader');
-            $autoloaderProperty->setAccessible(true);
+            if (\PHP_VERSION_ID < 80100) {
+                $autoloaderProperty->setAccessible(true);
+            }
 
             /** @var ClassLoader $magentoComposerAutoloader */
             $magentoComposerAutoloader = $autoloaderProperty->getValue($this->magentoAutoloader);

--- a/src/N98/Magento/Application/Console/EventSubscriber/DevUrnCatalogAutoPath.php
+++ b/src/N98/Magento/Application/Console/EventSubscriber/DevUrnCatalogAutoPath.php
@@ -139,7 +139,9 @@ class DevUrnCatalogAutoPath implements EventSubscriberInterface
     {
         $refl = new ReflectionObject($arg);
         $prop = $refl->getProperty('tokens');
-        $prop->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $prop->setAccessible(true);
+        }
         $tokens = $prop->getValue($arg);
         $tokens[] = $file;
         $prop->setValue($arg, $tokens);

--- a/src/N98/Util/Console/Helper/DatabaseHelper.php
+++ b/src/N98/Util/Console/Helper/DatabaseHelper.php
@@ -259,7 +259,11 @@ class DatabaseHelper extends AbstractHelper implements CommandAware
         $this->_connection->query('SET NAMES utf8');
 
         $this->_connection->setAttribute(PDO::ATTR_EMULATE_PREPARES, true);
-        $this->_connection->setAttribute(PDO::MYSQL_ATTR_USE_BUFFERED_QUERY, true);
+
+        $bufferedQueryAttr = defined('\Pdo\Mysql::ATTR_USE_BUFFERED_QUERY')
+            ? \Pdo\Mysql::ATTR_USE_BUFFERED_QUERY
+            : \PDO::MYSQL_ATTR_USE_BUFFERED_QUERY;
+        $this->_connection->setAttribute($bufferedQueryAttr, true);
 
         return $this->_connection;
     }

--- a/tests/N98/Magento/Command/Database/DumpCommandUnitTest.php
+++ b/tests/N98/Magento/Command/Database/DumpCommandUnitTest.php
@@ -168,7 +168,9 @@ class DumpCommandUnitTest extends TestCase
 
         $reflection = new ReflectionClass($command);
         $method = $reflection->getMethod('getFileName');
-        $method->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $method->setAccessible(true);
+        }
 
         $compressor = $this->createMock(Compressor::class);
         $compressor->method('getFileName')->will($this->returnArgument(0));

--- a/tests/N98/Magento/Command/Installer/SubCommand/CreateDatabaseTest.php
+++ b/tests/N98/Magento/Command/Installer/SubCommand/CreateDatabaseTest.php
@@ -67,7 +67,9 @@ class CreateDatabaseTest extends TestCase
 
         $reflection = new \ReflectionClass(CreateDatabase::class);
         $method = $reflection->getMethod('validateDatabaseSettings');
-        $method->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $method->setAccessible(true);
+        }
 
         $result = $method->invoke($subCommand, $inputMock, $outputMock);
 

--- a/tests/N98/Magento/Command/Installer/SubCommand/InstallComposerTest.php
+++ b/tests/N98/Magento/Command/Installer/SubCommand/InstallComposerTest.php
@@ -37,7 +37,9 @@ class InstallComposerTest extends TestCase
         try {
             $reflection = new \ReflectionClass($command);
             $method = $reflection->getMethod('downloadComposer');
-            $method->setAccessible(true);
+            if (\PHP_VERSION_ID < 80100) {
+                $method->setAccessible(true);
+            }
             $result = $method->invoke($command);
 
             // If it returns a path, it means it succeeded (execution passed, which might happen if exec works or fails gracefully without throw)
@@ -83,7 +85,9 @@ class InstallComposerTest extends TestCase
 
         $reflection = new \ReflectionClass($command);
         $method = $reflection->getMethod('downloadComposer');
-        $method->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $method->setAccessible(true);
+        }
         $method->invoke($command);
     }
 }

--- a/tests/N98/Util/Console/Helper/DatabaseHelperSecurityTest.php
+++ b/tests/N98/Util/Console/Helper/DatabaseHelperSecurityTest.php
@@ -103,7 +103,9 @@ class DatabaseHelperSecurityTest extends TestCase
         // Set dbSettings directly as it is protected
         $reflection = new \ReflectionClass(DatabaseHelper::class);
         $property = $reflection->getProperty('dbSettings');
-        $property->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $property->setAccessible(true);
+        }
         $property->setValue($helper, ['dbname' => 'db`name']);
 
         $outputMock = $this->getMockBuilder(OutputInterface::class)->getMock();
@@ -137,7 +139,9 @@ class DatabaseHelperSecurityTest extends TestCase
         // Set dbSettings directly as it is protected
         $reflection = new \ReflectionClass(DatabaseHelper::class);
         $property = $reflection->getProperty('dbSettings');
-        $property->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $property->setAccessible(true);
+        }
         $property->setValue($helper, ['dbname' => 'db`name']);
 
         $outputMock = $this->getMockBuilder(OutputInterface::class)->getMock();

--- a/tests/N98/Util/Console/Helper/DatabaseHelperTest.php
+++ b/tests/N98/Util/Console/Helper/DatabaseHelperTest.php
@@ -215,7 +215,9 @@ class DatabaseHelperTest extends TestCase
 
         // Manually set dbSettings as it's used directly
         $reflection = new ReflectionProperty(DatabaseHelper::class, 'dbSettings');
-        $reflection->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $reflection->setAccessible(true);
+        }
         $reflection->setValue($helper, ['dbname' => 'test_db']);
 
         $this->assertEquals([], $helper->getViews());
@@ -250,7 +252,9 @@ class DatabaseHelperTest extends TestCase
             ->method('getConnection')
             ->willReturn($pdoMock);
         $reflection = new ReflectionProperty(DatabaseHelper::class, 'dbSettings');
-        $reflection->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $reflection->setAccessible(true);
+        }
         $reflection->setValue($helper, ['dbname' => 'test_db']);
         $this->assertEquals($expectedViews, $helper->getViews());
     }
@@ -284,7 +288,9 @@ class DatabaseHelperTest extends TestCase
             ->method('getConnection')
             ->willReturn($pdoMock);
         $reflection = new ReflectionProperty(DatabaseHelper::class, 'dbSettings');
-        $reflection->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $reflection->setAccessible(true);
+        }
         $reflection->setValue($helper, ['dbname' => 'test_db']);
         $this->assertEquals($expectedViews, $helper->getViews());
     }


### PR DESCRIPTION
## Summary
- add Magento 2.4.9-beta1 and PHP 8.5 coverage to the CI matrix and compatibility docs
- update reflection and PDO attribute handling so the codebase and tests run cleanly on PHP 8.5
- disable PHPUnit deprecations-as-exceptions for the current test suite and align local DDEV config with PHP 8.5