### PR TITLE
chore(ci): add mage-os 2.3.0 to platform test matrix

### DIFF
--- a/.github/workflows/magento_platform_tests.yml
+++ b/.github/workflows/magento_platform_tests.yml
@@ -122,6 +122,16 @@ jobs:
             use-git-repository: false
             git-repository: ""
 
+          - magento-version: 2.3.0
+            composer-repository-url: "https://repo.mage-os.org/"
+            operating-system: ubuntu-22.04
+            php-version: '8.5'
+            mariadb-version: '10.6'
+            opensearch-version: '2'
+            composer-version: '2.8.8'
+            use-git-repository: false
+            git-repository: ""
+
           # Magento versions
           - magento-version: 2.4.9
             composer-repository-url: "https://repo.magento.com/"


### PR DESCRIPTION
## Summary
- add Mage-OS 2.3.0 to the GitHub Actions platform test matrix
- use the same dependency versions as the existing Magento 2.4.9 matrix entry
- keep the change scoped to the CI workflow matrix only