### PR TITLE
chore(ci): add mage-os 3.0.0 to platform test matrix

### DIFF
--- a/.github/workflows/magento_platform_tests.yml
+++ b/.github/workflows/magento_platform_tests.yml
@@ -122,13 +122,23 @@ jobs:
             use-git-repository: false
             git-repository: ""
 
-          - magento-version: 2.3.0
+          - magento-version: 3.0.0
             composer-repository-url: "https://repo.mage-os.org/"
             operating-system: ubuntu-22.04
             php-version: '8.5'
-            mariadb-version: '10.6'
-            opensearch-version: '2'
-            composer-version: '2.8.8'
+            mariadb-version: '11.4'
+            opensearch-version: '3'
+            composer-version: '2.9.8'
+            use-git-repository: false
+            git-repository: ""
+
+          - magento-version: 3.0.0
+            composer-repository-url: "https://repo.mage-os.org/"
+            operating-system: ubuntu-22.04
+            php-version: '8.4'
+            mariadb-version: '11.4'
+            opensearch-version: '3'
+            composer-version: '2.9.8'
             use-git-repository: false
             git-repository: ""
 


### PR DESCRIPTION
## Summary
- add Mage-OS 3.0.0 to the GitHub Actions platform test matrix
- cover the supported PHP variants 8.4 and 8.5
- align the matrix values with the provided supported platform dependencies for Composer, MariaDB, and OpenSearch

## Notes
- this PR supersedes #2017, which used the wrong Mage-OS version