### PR TITLE
test(bats): skip varnish vcl generation on mage-os

### DIFF
--- a/tests/bats/functional_core_commands.bats
+++ b/tests/bats/functional_core_commands.bats
@@ -3,6 +3,7 @@
 setup() {
     load 'test_helper/bats-support/load'
     load 'test_helper/bats-assert/load'
+    load 'test_helper/distribution'
 
     declare PHP_BIN
     if ! PHP_BIN=$(which php); then
@@ -290,7 +291,10 @@ setup() {
 }
 
 @test "Command: varnish:vcl:generate" {
+  if is_mage_os_distribution; then
+    skip "varnish:vcl:generate is not supported on Mage-OS"
+  fi
+
   run $BIN "varnish:vcl:generate"
   assert_output --partial "vcl 4.0"
 }
-

--- a/tests/bats/functional_magerun_commands.bats
+++ b/tests/bats/functional_magerun_commands.bats
@@ -3,6 +3,7 @@
 setup() {
     load 'test_helper/bats-support/load'
     load 'test_helper/bats-assert/load'
+    load 'test_helper/distribution'
 
     declare PHP_BIN
     if ! PHP_BIN=$(which php); then

--- a/tests/bats/test_helper/distribution.bash
+++ b/tests/bats/test_helper/distribution.bash
@@ -1,0 +1,6 @@
+is_mage_os_distribution() {
+  local composer_lock
+  composer_lock="$N98_MAGERUN2_TEST_MAGENTO_ROOT/composer.lock"
+
+  [ -f "$composer_lock" ] && grep -q '"name": "mage-os/' "$composer_lock"
+}


### PR DESCRIPTION
## Summary
- skip the `varnish:vcl:generate` functional BATS test on Mage-OS
- extract Mage-OS distribution detection into a reusable BATS helper
- load the helper in the BATS suites for future distribution-specific checks