### PR TITLE
fix(db): support dash shell by wrapping piped commands in bash with pipefail

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -281,8 +281,8 @@ commands:
         tables: session persistent_session
 
       - id: stripped
-        description: Standard definition for a stripped dump (logs, sessions, dotmailer)
-        tables: "@log @sessions @dotmailer @newrelic_reporting @temp system_config_snapshot"
+        description: Standard definition for a stripped dump (logs, sessions, dotmailer, indexer noise)
+        tables: "@log @sessions @dotmailer @newrelic_reporting @temp @ee_changelog @indexer_batches system_config_snapshot"
 
       - id: sales
         description: Sales data (orders, invoices, creditmemos etc)
@@ -356,6 +356,10 @@ commands:
       - id: ee_changelog
         description: Changelog tables of new indexer since EE 1.13
         tables: "*_cl"
+
+      - id: indexer_batches
+        description: Indexer batch tables (data exporter, etc.) — regenerated on demand
+        tables: "*_index_batches"
 
       - id: search
         description: Search related tables

--- a/src/N98/Magento/Command/Database/DumpCommand.php
+++ b/src/N98/Magento/Command/Database/DumpCommand.php
@@ -482,7 +482,12 @@ HELP;
         if ($input->getOption('stdout')) {
             passthru(Exec::wrapWithBashPipefail($command), $returnCode);
         } else {
-            Exec::run($command, $commandOutput, $returnCode);
+            try {
+                Exec::run($command, $commandOutput, $returnCode);
+            } catch (\RuntimeException $e) {
+                $output->writeln('<error>' . $e->getMessage() . '</error>');
+                return false;
+            }
         }
 
         if ($returnCode > 0) {

--- a/src/N98/Magento/Command/Database/DumpCommand.php
+++ b/src/N98/Magento/Command/Database/DumpCommand.php
@@ -480,7 +480,7 @@ HELP;
         $commandOutput = '';
 
         if ($input->getOption('stdout')) {
-            passthru($command, $returnCode);
+            passthru(Exec::wrapWithBashPipefail($command), $returnCode);
         } else {
             Exec::run($command, $commandOutput, $returnCode);
         }

--- a/src/N98/Magento/Command/Database/ImportCommand.php
+++ b/src/N98/Magento/Command/Database/ImportCommand.php
@@ -11,6 +11,7 @@ namespace N98\Magento\Command\Database;
 use Exception;
 use InvalidArgumentException;
 use N98\Magento\Command\Database\Compressor\AbstractCompressor;
+use N98\Util\Exec;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -249,7 +250,7 @@ HELP;
             '<comment>Importing SQL dump <info>' . $fileName . '</info> to database <info>'
             . $this->dbSettings['dbname'] . '</info>'
         );
-        exec($exec, $commandOutput, $returnValue);
+        exec(Exec::wrapWithBashPipefail($exec), $commandOutput, $returnValue);
         if ($returnValue != 0) {
             $output->writeln('<error>' . implode(PHP_EOL, $commandOutput) . '</error>');
             $success = false;

--- a/src/N98/Util/Exec.php
+++ b/src/N98/Util/Exec.php
@@ -33,6 +33,11 @@ class Exec
     const SET_O_PIPEFAIL = 'set -o pipefail; ';
 
     /**
+     * @var string|null Cached bash binary path; empty string means "not found"
+     */
+    private static $bashBinary = null;
+
+    /**
      * @param string $command
      * @param string|null $output
      * @param int $returnCode
@@ -44,10 +49,7 @@ class Exec
             throw new RuntimeException($message);
         }
 
-        if (self::isPipefailOptionAvailable()) {
-            $command = self::SET_O_PIPEFAIL . $command;
-        }
-
+        $command = self::wrapWithBashPipefail($command);
         $command .= self::REDIRECT_STDERR_TO_STDOUT;
 
         exec($command, $outputArray, $returnCode);
@@ -82,12 +84,51 @@ class Exec
     }
 
     /**
-     * @return bool
+     * Wraps a command in an explicit bash sub-shell with pipefail enabled so that
+     * errors in any segment of a pipeline propagate correctly even when /bin/sh is
+     * dash (which does not support set -o pipefail).
+     *
+     * When bash is not available the command is returned unchanged.
+     *
+     * @param string $command
+     * @return string
      */
-    private static function isPipefailOptionAvailable()
+    public static function wrapWithBashPipefail($command)
     {
-        exec('set -o | grep pipefail 2>&1', $output, $returnCode);
+        $bash = self::getBashBinary();
+        if ($bash === null) {
+            return $command;
+        }
 
-        return $returnCode == self::CODE_CLEAN_EXIT;
+        return $bash . " -c 'set -o pipefail; " . self::escapeForBash($command) . "'";
+    }
+
+    /**
+     * Returns the absolute path to bash, or null when bash is not available.
+     * The result is cached for the lifetime of the PHP process.
+     *
+     * @return string|null
+     */
+    private static function getBashBinary()
+    {
+        if (self::$bashBinary === null) {
+            $path = trim((string) shell_exec('command -v bash 2>/dev/null'));
+            self::$bashBinary = $path ?: '';
+        }
+
+        return self::$bashBinary ?: null;
+    }
+
+    /**
+     * Escapes a command string for safe embedding inside a bash single-quoted argument.
+     * Every ' is replaced with '"'"' which ends the single-quoted string, appends a
+     * double-quoted single quote, then reopens the single-quoted string.
+     *
+     * @param string $command
+     * @return string
+     */
+    private static function escapeForBash($command)
+    {
+        return str_replace("'", "'\"'\"'", $command);
     }
 }

--- a/tests/N98/Util/ExecTest.php
+++ b/tests/N98/Util/ExecTest.php
@@ -46,4 +46,55 @@ class ExecTest extends \PHPUnit\Framework\TestCase
         $this->expectException(RuntimeException::class);
         Exec::run('foobar');
     }
+
+    /**
+     * @test
+     */
+    public function wrapWithBashPipefailWrapsWhenBashAvailable()
+    {
+        $bash = trim((string) shell_exec('command -v bash 2>/dev/null'));
+        if (!$bash) {
+            $this->markTestSkipped('bash not available');
+        }
+
+        $wrapped = Exec::wrapWithBashPipefail('echo hello');
+        $this->assertStringContainsString('bash', $wrapped);
+        $this->assertStringContainsString('set -o pipefail', $wrapped);
+        $this->assertStringContainsString('echo hello', $wrapped);
+    }
+
+    /**
+     * @test
+     */
+    public function wrapWithBashPipefailHandlesSingleQuotes()
+    {
+        $bash = trim((string) shell_exec('command -v bash 2>/dev/null'));
+        if (!$bash) {
+            $this->markTestSkipped('bash not available');
+        }
+
+        $command = "echo 'hello world'";
+        $wrapped = Exec::wrapWithBashPipefail($command);
+
+        // The wrapped command must be executable and produce the right output
+        exec($wrapped, $out, $rc);
+        $this->assertSame(0, $rc);
+        $this->assertSame('hello world', $out[0]);
+    }
+
+    /**
+     * @test
+     */
+    public function wrapWithBashPipefailPropagatesPipeError()
+    {
+        $bash = trim((string) shell_exec('command -v bash 2>/dev/null'));
+        if (!$bash) {
+            $this->markTestSkipped('bash not available');
+        }
+
+        // false is a command that always exits with code 1
+        $wrapped = Exec::wrapWithBashPipefail('false | echo ok');
+        exec($wrapped . ' 2>/dev/null', $out, $rc);
+        $this->assertNotSame(0, $rc, 'pipe failure should propagate a non-zero exit code');
+    }
 }


### PR DESCRIPTION
## Problem

Two related issues are fixed in this PR:

**Dash shell compatibility (#929, #2022):** PHP's `exec()` and `passthru()` execute commands via `/bin/sh -c`. On Debian/Ubuntu, `/bin/sh` is **dash**, which does **not** support `set -o pipefail`. The previous implementation probed for pipefail support with `set -o | grep pipefail`; under dash this silently returned `false`, leaving piped commands (e.g. `mysqldump … | gzip -c > dump.sql.gz`) without any exit-code propagation. A failing `mysqldump` would produce a corrupt or empty dump while reporting success.

**Missing `indexer_batches` table group (#2021):** Tables matching `*_index_batches` (used by the data exporter and similar indexer extensions) were not covered by any strip group and therefore included in stripped dumps, even though they are fully regenerated on demand.

Closes #929. Fixes #2021. Fixes #2022.

---

## Changes

### Commit 1 — `fix(db): support dash shell by wrapping piped commands in bash with pipefail`

When bash is available, `Exec::wrapWithBashPipefail()` wraps every command as:
```
bash -c 'set -o pipefail; <escaped-cmd>'
```
This guarantees correct exit-code propagation regardless of what `/bin/sh` points to. When bash is absent the command runs unchanged.

| File | What changed |
|------|-------------|
| `src/N98/Util/Exec.php` | Replaced `isPipefailOptionAvailable()` + `SET_O_PIPEFAIL` prepend with `wrapWithBashPipefail()`. Bash path probed once and cached. |
| `src/N98/Magento/Command/Database/DumpCommand.php` | `--stdout` path calls `passthru()`, bypassing `Exec::run()`. Now wraps via `Exec::wrapWithBashPipefail()` first. |
| `src/N98/Magento/Command/Database/ImportCommand.php` | `doImport()` raw `exec()` call (decompression pipes) wrapped the same way. |
| `tests/N98/Util/ExecTest.php` | Three new tests: wrapping adds bash+pipefail, single-quote escaping is correct, pipe failures propagate a non-zero exit code. |

### Commit 2 — `feat(db): add indexer_batches table group and include it in @stripped`

| File | What changed |
|------|-------------|
| `config.yaml` | New `@indexer_batches` group matching `*_index_batches`. Extended `@stripped` to include `@ee_changelog` and `@indexer_batches`; updated description to reflect broader indexer-noise scope. |

---

## Test plan

- [x] `vendor/bin/phpunit tests/N98/Util/ExecTest.php` — 6/6 tests pass
- [x] `n98-magerun2 db:dump /tmp/test.sql.gz --compression=gzip` — produces valid dump
- [x] `n98-magerun2 db:dump --stdout | gzip -c > /tmp/test.sql.gz` — pipe error propagates
- [x] `n98-magerun2 db:import /tmp/test.sql.gz` — import succeeds
- [x] Reproduce with dash as `/bin/sh` (Debian/Ubuntu) and confirm exit codes are correct
- [x] `n98-magerun2 db:dump --strip="@stripped"` — verify `*_index_batches` tables are stripped