### PR TITLE
feat(db): support --only-command option without mysqldump or mariadb-dump

### DIFF
--- a/src/N98/Magento/Command/Database/DumpCommand.php
+++ b/src/N98/Magento/Command/Database/DumpCommand.php
@@ -747,17 +747,21 @@ HELP;
             && !$input->getOption('print-only-filename');
     }
 
-    /**
-     * Checks if 'column statistics' are present in the current MySQL distribution
-     *
-     * @return bool
-     */
     private function checkColumnStatistics()
     {
-        Exec::run('mysqldump --help | grep -c column-statistics || true', $output, $returnCode);
+        $database = $this->getDatabaseHelper();
+        $dumpBinary = $database->getMysqlDumpBinary();
+        if (!$database->commandExists($dumpBinary)) {
+            return false;
+        }
 
-        if ($output > 0) {
-            return true;
+        try {
+            Exec::run($dumpBinary . ' --help | grep -c column-statistics || true', $output, $returnCode);
+            if ($output > 0) {
+                return true;
+            }
+        } catch (\Throwable $e) {
+            // Ignore exception if binary not found/not executable
         }
 
         return false;

--- a/src/N98/Util/Console/Helper/DatabaseHelper.php
+++ b/src/N98/Util/Console/Helper/DatabaseHelper.php
@@ -349,8 +349,15 @@ class DatabaseHelper extends AbstractHelper implements CommandAware
      */
     public function isMariaDbClientToolUsed(): bool
     {
-        Exec::run('mysqldump --help', $output, $exitCode);
-        return stripos($output, 'MariaDB') !== false;
+        if (!$this->commandExists('mysqldump')) {
+            return false;
+        }
+        try {
+            Exec::run('mysqldump --help', $output, $exitCode);
+            return stripos($output, 'MariaDB') !== false;
+        } catch (Throwable $e) {
+            return false;
+        }
     }
 
     /**
@@ -361,8 +368,15 @@ class DatabaseHelper extends AbstractHelper implements CommandAware
     public function isSslModeOptionSupported(): bool
     {
         $dumpBinary = $this->getMysqlDumpBinary();
-        Exec::run($dumpBinary . ' --help', $output, $exitCode);
-        return str_contains($output, '--ssl-mode');
+        if (!$this->commandExists($dumpBinary)) {
+            return false;
+        }
+        try {
+            Exec::run($dumpBinary . ' --help', $output, $exitCode);
+            return str_contains($output, '--ssl-mode');
+        } catch (Throwable $e) {
+            return false;
+        }
     }
 
     /**
@@ -378,7 +392,7 @@ class DatabaseHelper extends AbstractHelper implements CommandAware
         }
     }
 
-    private function commandExists(string $command): bool
+    public function commandExists(string $command): bool
     {
         exec('command -v ' . escapeshellarg($command) . ' >/dev/null 2>&1', $o, $r);
         return $r === 0;

--- a/tests/N98/Magento/Command/Database/DumpCommandUnitTest.php
+++ b/tests/N98/Magento/Command/Database/DumpCommandUnitTest.php
@@ -268,4 +268,82 @@ class DumpCommandUnitTest extends TestCase
         $this->assertStringContainsString('--ignore-table=magento.table2', $fullOutput, 'table2 should be ignored (excluded)');
         $this->assertStringNotContainsString('--ignore-table=magento.table3', $fullOutput, 'table3 should NOT be ignored (not excluded)');
     }
+
+    public function testOnlyCommandSupportsNoBinaryInstalled()
+    {
+        // Mock Input
+        $input = $this->createMock(InputInterface::class);
+        $input->method('getOption')->will($this->returnValueMap([
+            ['include', null],
+            ['exclude', null],
+            ['strip', null],
+            ['no-views', false],
+            ['compression', null],
+            ['no-single-transaction', true],
+            ['human-readable', false],
+            ['set-gtid-purged-off', false],
+            ['add-routines', false],
+            ['no-tablespaces', false],
+            ['keep-column-statistics', false],
+            ['git-friendly', false],
+            ['keep-definer', false],
+            ['mydumper', false],
+            ['stdout', false],
+            ['only-command', true],
+            ['print-only-filename', false],
+            ['dry-run', false],
+            ['views', false],
+            ['force', true],
+            ['add-time', 'no'],
+        ]));
+
+        $input->method('getArgument')->will($this->returnValueMap([
+            ['filename', 'dump.sql']
+        ]));
+
+        $output = $this->createMock(OutputInterface::class);
+        $outputBuffer = [];
+        $output->method('writeln')->will($this->returnCallback(function ($message) use (&$outputBuffer) {
+            $outputBuffer[] = $message;
+        }));
+
+        $databaseHelper = $this->createMock(DatabaseHelper::class);
+        $databaseHelper->method('getDbSettings')->willReturn([
+            'host' => 'localhost',
+            'username' => 'user',
+            'password' => 'pass',
+            'dbname' => 'magento',
+            'prefix' => '',
+        ]);
+        $databaseHelper->method('getMysqlDumpBinary')->willReturn('mysqldump');
+        $databaseHelper->method('getViews')->willReturn([]);
+        $databaseHelper->method('getTables')->willReturn([]);
+        $databaseHelper->method('getMysqlClientToolConnectionString')->willReturn('-h localhost -u user -p pass magento');
+        $databaseHelper->method('getTableDefinitions')->willReturn([]);
+        // Simulate missing binary
+        $databaseHelper->method('commandExists')->with('mysqldump')->willReturn(false);
+
+        $questionHelper = $this->createMock(QuestionHelper::class);
+        $helperSet = $this->createMock(HelperSet::class);
+        $helperSet->method('get')->will($this->returnValueMap([
+            ['database', $databaseHelper],
+            ['question', $questionHelper]
+        ]));
+
+        $application = $this->createMock(Application::class);
+        $application->method('getConfig')->willReturn(['commands' => []]);
+
+        $command = new DumpCommand();
+        $command->setApplication($application);
+        $command->setHelperSet($helperSet);
+
+        // Run the command. It should not throw any exception even though 'mysqldump' binary is missing.
+        $command->run($input, $output);
+
+        $fullOutput = implode("\n", $outputBuffer);
+
+        // Verify the generated command output contains 'mysqldump' even if the binary is not present on system
+        $this->assertStringContainsString('mysqldump', $fullOutput);
+        $this->assertStringContainsString('-h localhost -u user -p pass magento', $fullOutput);
+    }
 }


### PR DESCRIPTION
Resolves #2026. This PR ensures that the `db:dump --only-command` option works even if `mysqldump` or `mariadb-dump` are not installed on the system.