### PR TITLE
feat(command): add interactive download command for Magento/Adobe Commerce/Mage-OS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ super-linter.log
 /*.sql
 /*.sql.gz
 
+.tokensave

--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,7 @@
         "dflydev/dot-access-data": "^3.0",
         "fakerphp/faker": "~1.16",
         "laminas/laminas-filter": "^2.12",
+        "laravel/prompts": "^0.3.21",
         "mcp/sdk": "^0.6",
         "n98/junit-xml": "~1.0",
         "psr/container": "~1.1.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "82b60e46ad6f5d856e70341bbbf1f2fd",
+    "content-hash": "df19d67c150c529b72d5962e4d61ced2",
     "packages": [
         {
             "name": "dflydev/dot-access-data",
@@ -419,6 +419,65 @@
                 }
             ],
             "time": "2024-10-29T13:46:07+00:00"
+        },
+        {
+            "name": "laravel/prompts",
+            "version": "v0.3.21",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laravel/prompts.git",
+                "reference": "7753c65c281c2550c7c183f14e18062073b7d821"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laravel/prompts/zipball/7753c65c281c2550c7c183f14e18062073b7d821",
+                "reference": "7753c65c281c2550c7c183f14e18062073b7d821",
+                "shasum": ""
+            },
+            "require": {
+                "composer-runtime-api": "^2.2",
+                "ext-mbstring": "*",
+                "php": "^8.1",
+                "symfony/console": "^6.2|^7.0|^8.0"
+            },
+            "conflict": {
+                "illuminate/console": ">=10.17.0 <10.25.0",
+                "laravel/framework": ">=10.17.0 <10.25.0"
+            },
+            "require-dev": {
+                "illuminate/collections": "^10.0|^11.0|^12.0|^13.0",
+                "mockery/mockery": "^1.5",
+                "pestphp/pest": "^2.3|^3.4|^4.0",
+                "phpstan/phpstan": "^1.12.28",
+                "phpstan/phpstan-mockery": "^1.1.3"
+            },
+            "suggest": {
+                "ext-pcntl": "Required for the spinner to be animated."
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "0.3.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/helpers.php"
+                ],
+                "psr-4": {
+                    "Laravel\\Prompts\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Add beautiful and user-friendly forms to your command-line applications.",
+            "support": {
+                "issues": "https://github.com/laravel/prompts/issues",
+                "source": "https://github.com/laravel/prompts/tree/v0.3.21"
+            },
+            "time": "2026-06-26T00:11:25+00:00"
         },
         {
             "name": "mcp/sdk",
@@ -8284,5 +8343,5 @@
     "platform-overrides": {
         "php": "8.1.0"
     },
-    "plugin-api-version": "2.9.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/config.yaml
+++ b/config.yaml
@@ -184,6 +184,7 @@ commands:
     - N98\Magento\Command\Integration\ListCommand
     - N98\Magento\Command\Integration\ShowCommand
     - N98\Magento\Command\Installer\InstallCommand
+    - N98\Magento\Command\Project\DownloadCommand
     - N98\Magento\Command\ScriptCommand
     - N98\Magento\Command\SelfUpdateCommand
     - N98\Magento\Command\Route\ListCommand
@@ -261,6 +262,34 @@ commands:
       - magento/magento2-ee-base
       - magento/magento2-b2b-base
       - mage-os/magento2-base
+
+  N98\Magento\Command\Project\DownloadCommand:
+    editions:
+      - name: open-source
+        package: magento/project-community-edition
+        repository-url: https://repo.magento.com
+        requires-auth: true
+        default-dir: ./magento-open-source
+        description: "Community Edition — free, requires a Marketplace account for repo.magento.com"
+      - name: adobe-commerce
+        package: magento/project-enterprise-edition
+        repository-url: https://repo.magento.com
+        requires-auth: true
+        default-dir: ./adobe-commerce
+        description: "Commerce Edition — commercial license, requires Marketplace credentials"
+      - name: mage-os
+        package: mage-os/project-community-edition
+        repository-url: https://repo.mage-os.org
+        requires-auth: false
+        default-dir: ./mage-os
+        description: "Mage-OS"
+    git-repositories:
+      - name: magento2
+        label: "Magento 2 (official core)"
+        url: https://github.com/magento/magento2.git
+      - name: mage-os
+        label: "Mage-OS (community fork)"
+        url: https://github.com/mage-os/mage-os.git
 
   N98\Magento\Command\Database\DumpCommand:
     table-groups:

--- a/docs/docs/command-docs/project/download.md
+++ b/docs/docs/command-docs/project/download.md
@@ -1,0 +1,158 @@
+---
+title: download
+sidebar_label: download
+---
+
+Downloads Magento source code into a target directory. This is a **download-only** command - it does not
+check platform requirements, generate configuration files, or set up a database. It replaces the download
+step of the deprecated `install` command.
+
+:::info
+This command supports both an interactive wizard mode and a strict, unattended mode via `--no-interaction`.
+:::
+
+Two download strategies are available:
+
+- **`composer`** (default) - runs `composer create-project` for one of the known Magento editions.
+- **`git`** - runs `git clone`, intended for Magento core contributors who need a working copy of
+  `magento/magento2` or a fork.
+
+The interactive wizard guides you through the choices with short descriptions for each option, offers a
+preset picker for the git strategy (official `magento/magento2` core repo, `mage-os/mage-os`, or a custom
+entry), and finishes with a summary and a confirmation prompt before anything is downloaded.
+
+:::tip
+In a real terminal, the strategy/edition/repository prompts and the final confirmation support arrow-key
+navigation. On Windows, or when the command isn't attached to an interactive terminal (CI, piped input),
+it automatically falls back to typing the number or key of your choice - the available options are
+identical either way.
+:::
+
+Interactive wizard:
+
+```sh
+n98-magerun2.phar download
+```
+
+Non-interactive composer-based download:
+
+```sh
+n98-magerun2.phar download --edition=open-source --constraint=2.4.7 --dir=./my-magento-shop --no-interaction
+```
+
+Non-interactive git-based download (for Magento core contributors):
+
+```sh
+n98-magerun2.phar download --strategy=git --repo=git@github.com:my-fork/magento2.git --dir=./core-contribution --no-interaction
+```
+
+The `--repo` option also accepts a GitHub `owner/repo` shorthand, which is expanded to a full clone URL:
+
+```sh
+n98-magerun2.phar download --strategy=git --repo=magento/magento2 --dir=./core --no-interaction
+```
+
+**Options:**
+| Option                              | Description                                                                                          |
+|--------------------------------------|-------------------------------------------------------------------------------------------------------|
+| `--strategy[=STRATEGY]`              | Download strategy: `composer` or `git` [default: `"composer"`]                                        |
+| `--edition[=EDITION]`                | Edition to download (composer strategy): `open-source`, `adobe-commerce`, `mage-os`                    |
+| `--constraint[=CONSTRAINT]`          | Version constraint to install, e.g. `2.4.7` (composer strategy). Defaults to the latest stable version |
+| `--repository-url[=REPOSITORY-URL]`  | Override the composer repository URL used for the selected edition (composer strategy)                |
+| `--repo[=REPO]`                      | Git repository to clone (git strategy). Accepts a full URL or a GitHub `owner/repo` shorthand          |
+| `--branch[=BRANCH]`                  | Branch, tag or ref to check out (git strategy). Defaults to the repository default branch              |
+| `--dir[=DIR]`                        | Target directory to download into                                                                     |
+
+:::note
+The option is named `--constraint` rather than `--version` because `--version`/`-V` is reserved by
+Symfony Console to display the application version.
+:::
+
+**Editions:**
+| Edition          | Composer package                          | Repository                  | Requires auth | Description                                                            |
+|------------------|--------------------------------------------|------------------------------|---------------|--------------------------------------------------------------------------|
+| `open-source`    | `magento/project-community-edition`        | `https://repo.magento.com`   | Yes           | Community Edition — free, requires a Marketplace account                |
+| `adobe-commerce` | `magento/project-enterprise-edition`        | `https://repo.magento.com`   | Yes           | Commerce Edition — commercial license, requires Marketplace credentials |
+| `mage-os`        | `mage-os/project-community-edition`         | `https://repo.mage-os.org`   | No            | Mage-OS                                                                  |
+
+:::tip
+The list of editions is configurable. It is defined under the `editions` command config key for
+`N98\Magento\Command\Project\DownloadCommand` in `config.yaml`, and can be overridden or extended on
+project or user level (see the [configuration documentation](/extending/configuration) for details):
+
+```yaml
+commands:
+  N98\Magento\Command\Project\DownloadCommand:
+    editions:
+      - name: open-source
+        package: magento/project-community-edition
+        repository-url: https://repo.magento.com
+        requires-auth: true
+        default-dir: ./magento-open-source
+        description: "Community Edition — free, requires a Marketplace account"
+```
+:::
+
+**Git repositories:**
+| Preset     | Label                          | URL                                          |
+|------------|---------------------------------|-----------------------------------------------|
+| `magento2` | Magento 2 (official core)       | `https://github.com/magento/magento2.git`    |
+| `mage-os`  | Mage-OS (community fork)         | `https://github.com/mage-os/mage-os.git`     |
+| `custom`   | Custom                          | enter a full git URL or GitHub `owner/repo` shorthand |
+
+:::tip
+The list of preset git repositories is configurable via the `git-repositories` command config key,
+following the same pattern as `editions`:
+
+```yaml
+commands:
+  N98\Magento\Command\Project\DownloadCommand:
+    git-repositories:
+      - name: magento2
+        label: "Magento 2 (official core)"
+        url: https://github.com/magento/magento2.git
+```
+:::
+
+:::info
+In interactive mode, before the actual download starts, the wizard shows a summary of the selected
+options and asks for confirmation. Running with `--no-interaction` always skips this confirmation
+(and every other prompt), as long as all required options are supplied.
+:::
+
+:::info
+`open-source` and `adobe-commerce` require a Marketplace security key (public/private key pair) from
+[marketplace.magento.com](https://marketplace.magento.com/customer/accessKeys/). If run interactively and
+no credentials are found, you will be prompted for them and they will be stored via Composer's global
+`auth.json`. In non-interactive mode, missing credentials cause the command to fail immediately.
+:::
+
+:::info
+Before downloading, the command queries the target repository for the real list of versions available
+for the selected package. This serves two purposes:
+
+- **Credential/entitlement check**: if the repository rejects the request (invalid or expired
+  Marketplace keys, or an account that isn't entitled to the selected edition), the command fails
+  immediately with a clear, actionable error instead of the generic error `composer create-project`
+  would otherwise produce deep into the install.
+- **Version validation**: an exact version passed via `--constraint` (e.g. `2.4.7`) is checked against
+  the fetched list, and an unknown version is rejected up front with a few available versions shown as
+  suggestions. Range/expression constraints (e.g. `^2.4`, `~2.4.7`) are passed through to Composer
+  unvalidated, since Composer itself is best placed to resolve those. In interactive mode, the version
+  prompt also offers the real version list as autocomplete suggestions.
+:::
+
+:::note
+The composer strategy runs a full `composer create-project` - dependencies are resolved and installed
+into `vendor/`, not just `composer.json`.
+:::
+
+:::tip
+After a successful composer-based download, the command suggests the right next step to set up the
+application: `bin/magento setup:install`, except for **Mage-OS 3.0 and newer**, which ships a new
+interactive installer and gets pointed at `bin/magento install` instead. The version is detected
+automatically from the downloaded project - no extra configuration needed.
+:::
+
+The target directory must not exist, or must be empty - the command never overwrites or merges into an
+existing non-empty directory.

--- a/docs/docs/command-docs/project/index.md
+++ b/docs/docs/command-docs/project/index.md
@@ -1,0 +1,12 @@
+---
+sidebar_position: 1
+title: Project Commands
+---
+
+# Project Commands
+
+Commands for downloading a Magento project.
+
+## Commands
+
+- [download](./download) - Download Magento source code into a target directory

--- a/src/N98/Magento/Command/Project/DownloadCommand.php
+++ b/src/N98/Magento/Command/Project/DownloadCommand.php
@@ -1,0 +1,800 @@
+<?php
+/**
+ * This file is part of the n98-magerun2 project.
+ *
+ * For the full copyright and license information, please view the MIT-LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace N98\Magento\Command\Project;
+
+use InvalidArgumentException;
+use function Laravel\Prompts\confirm;
+use Laravel\Prompts\ConfirmPrompt;
+use Laravel\Prompts\Prompt;
+use function Laravel\Prompts\select;
+use Laravel\Prompts\SelectPrompt;
+use function Laravel\Prompts\suggest;
+use Laravel\Prompts\SuggestPrompt;
+use N98\Magento\Command\AbstractMagentoCommand;
+use N98\Util\Console\Helper\ComposerHelper;
+use N98\Util\OperatingSystem;
+use N98\Util\ProcessArguments;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Exception\RuntimeException;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\Question;
+
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Process\Process;
+
+class DownloadCommand extends AbstractMagentoCommand
+{
+    private const DEFAULT_EDITIONS = [
+        'open-source' => [
+            'package' => 'magento/project-community-edition',
+            'repository-url' => 'https://repo.magento.com',
+            'requires_auth' => true,
+            'default_dir' => './magento-open-source',
+            'description' => 'Community Edition — free, requires a Marketplace account for repo.magento.com',
+        ],
+        'adobe-commerce' => [
+            'package' => 'magento/project-enterprise-edition',
+            'repository-url' => 'https://repo.magento.com',
+            'requires_auth' => true,
+            'default_dir' => './adobe-commerce',
+            'description' => 'Commerce Edition — commercial license, requires Marketplace credentials',
+        ],
+        'mage-os' => [
+            'package' => 'mage-os/project-community-edition',
+            'repository-url' => 'https://repo.mage-os.org',
+            'requires_auth' => false,
+            'default_dir' => './mage-os',
+            'description' => 'Mage-OS',
+        ],
+    ];
+
+    private const DEFAULT_GIT_REPOSITORIES = [
+        'magento2' => [
+            'label' => 'Magento 2 (official core)',
+            'url' => 'https://github.com/magento/magento2.git',
+        ],
+        'mage-os' => [
+            'label' => 'Mage-OS (community fork)',
+            'url' => 'https://github.com/mage-os/mage-os.git',
+        ],
+    ];
+
+    private const CUSTOM_GIT_REPO_KEY = 'custom';
+
+    protected function configure(): void
+    {
+        $this
+            ->setName('download')
+            ->setDescription('Downloads Magento source code (composer create-project or git clone)')
+            ->addOption(
+                'strategy',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Download strategy: composer or git [default: "composer"]'
+            )
+            ->addOption(
+                'edition',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Edition to download (composer strategy): ' . implode(', ', array_keys(self::DEFAULT_EDITIONS))
+                . '. Configurable/extendable via config.yaml.'
+            )
+            ->addOption(
+                'constraint',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Version constraint, e.g. 2.4.7 (composer strategy). NOTE: not named "--version"/"-V" because '
+                . 'those are reserved by the framework.'
+            )
+            ->addOption(
+                'repository-url',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Override composer repository URL used for selected edition (composer strategy)'
+            )
+            ->addOption(
+                'repo',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Git repository to clone (git strategy). Accepts a full git URL or a GitHub "owner/repo" shorthand.'
+            )
+            ->addOption(
+                'branch',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Branch, tag or ref to check out (git strategy). Defaults to repository default branch.'
+            )
+            ->addOption(
+                'dir',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Target directory to download into'
+            )
+            ->setHelp(
+                <<<HELP
+Downloads Magento source code into a target directory. This command only fetches source code -
+it does not check platform requirements, generate configuration files or set up the database.
+For highly customized Mage-OS builds use the external <comment>mageos-maker</comment> tool.
+
+Interactive wizard (prompts for anything not passed as an option):
+
+  $ n98-magerun2.phar download
+
+The interactive wizard offers a preset picker for the git strategy (e.g. <comment>magento/magento2</comment>,
+<comment>mage-os/mage-os</comment>) plus a custom entry accepting a full git URL or a GitHub
+<comment>owner/repo</comment> shorthand, and asks for confirmation with a summary before starting the
+download. All of this is skipped automatically when <comment>--no-interaction</comment> is used.
+
+Non-interactive composer-based download:
+
+  $ n98-magerun2.phar download --edition=mage-os --constraint=2.2.0 --dir=./my-shop --no-interaction
+
+Non-interactive git-based download (for Magento core contributors), using the GitHub shorthand:
+
+  $ n98-magerun2.phar download --strategy=git --repo=my-fork/magento2 \\
+        --dir=./core-contribution --no-interaction
+HELP
+            );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $interactive = $input->isInteractive();
+        $this->configurePrompts($io);
+
+        if ($interactive) {
+            $io->title('Magento Download Wizard');
+        }
+
+        $strategy = $input->getOption('strategy');
+        if (!$strategy) {
+            if ($interactive) {
+                $io->text([
+                    'This wizard downloads Magento (Open Source), Adobe Commerce, or Mage-OS source code. It does',
+                    'not install dependencies beyond what the chosen strategy performs, check platform',
+                    'requirements, or configure the application.',
+                    '',
+                    ' • <comment>composer</comment> — runs "composer create-project" for a known edition;',
+                    '   installs a ready-to-use application into vendor/ (recommended for shops/projects).',
+                    ' • <comment>git</comment>       — runs "git clone" against a preset or custom repository;',
+                    '   for Magento core / Mage-OS contributors who need a working git checkout.',
+                    '',
+                    'Pass --no-interaction together with all required options to skip every prompt (see --help).',
+                ]);
+
+                $strategy = select(
+                    'Download strategy',
+                    [
+                        'composer' => '<fg=cyan;options=bold>Composer</> create-project — installs a ready-to-use'
+                            . ' Magento application (recommended)',
+                        'git' => '<fg=cyan;options=bold>Git clone</> — for Magento core / Mage-OS contributors'
+                            . ' who need a working git checkout',
+                    ],
+                    'composer'
+                );
+            } else {
+                $strategy = 'composer';
+            }
+        }
+
+        if (!in_array($strategy, ['composer', 'git'], true)) {
+            throw new RuntimeException(sprintf('Invalid strategy "%s". Use "composer" or "git".', $strategy));
+        }
+
+        if ($strategy === 'git') {
+            return $this->downloadWithGit($input, $io, $interactive);
+        }
+
+        return $this->downloadWithComposer($input, $io, $interactive);
+    }
+
+    /**
+     * Wires laravel/prompts select()/confirm() to fall back to the equivalent SymfonyStyle
+     * prompt on platforms/environments that can't do raw-terminal arrow-key input.
+     */
+    private function configurePrompts(SymfonyStyle $io): void
+    {
+        Prompt::fallbackWhen($this->shouldFallbackToPlainPrompts());
+
+        SelectPrompt::fallbackUsing(static fn (SelectPrompt $prompt): int|string => $io->choice(
+            $prompt->label,
+            $prompt->options,
+            $prompt->default
+        ));
+
+        ConfirmPrompt::fallbackUsing(static fn (ConfirmPrompt $prompt): bool => $io->confirm(
+            $prompt->label,
+            $prompt->default
+        ));
+
+        SuggestPrompt::fallbackUsing(static fn (SuggestPrompt $prompt): string => (string) $io->ask(
+            $prompt->label,
+            $prompt->default
+        ));
+    }
+
+    /**
+     * laravel/prompts doesn't support Windows and reads directly from STDIN, bypassing
+     * Symfony's input stream - so it can't be driven by CommandTester either.
+     */
+    protected function shouldFallbackToPlainPrompts(): bool
+    {
+        return OperatingSystem::isWindows() || !stream_isatty(STDIN);
+    }
+
+    private function downloadWithComposer(InputInterface $input, SymfonyStyle $io, bool $interactive): int
+    {
+        $editions = $this->getEditions();
+
+        $edition = $input->getOption('edition');
+        if (!$edition) {
+            if (!$interactive) {
+                throw new RuntimeException(
+                    'The "--edition" option is required in non-interactive mode. Provide one of: '
+                    . implode(', ', array_keys($editions)) . '.'
+                );
+            }
+            $edition = select('Edition', $this->buildEditionChoices($editions), array_key_first($editions));
+        }
+
+        if (!isset($editions[$edition])) {
+            throw new RuntimeException(sprintf(
+                'Invalid edition "%s". Use one of: %s.',
+                $edition,
+                implode(', ', array_keys($editions))
+            ));
+        }
+
+        $editionConfig = $editions[$edition];
+        $repositoryUrl = $input->getOption('repository-url') ?: $editionConfig['repository-url'];
+
+        if ($editionConfig['requires_auth']
+            && $repositoryUrl
+            && strpos($repositoryUrl, 'repo.magento.com') !== false
+        ) {
+            $this->ensureMagentoConnectCredentials($input, $io, $interactive);
+        }
+
+        $composerHelper = $this->getComposerHelper();
+        $composerBin = $composerHelper->getBinPath();
+        if ($composerBin === '') {
+            throw new RuntimeException(
+                'Could not find composer. Install it from https://getcomposer.org/ and ensure it is on your PATH.'
+            );
+        }
+
+        $availableVersions = [];
+        if ($repositoryUrl !== '') {
+            if ($interactive) {
+                $io->text(sprintf('Checking available versions for %s...', $editionConfig['package']));
+            }
+            $availableVersions = $this->fetchAvailableVersions($composerBin, $editionConfig['package'], (string) $repositoryUrl);
+        }
+
+        $version = $input->getOption('constraint');
+        if ($version === null) {
+            $version = $interactive
+                ? suggest(
+                    'Version constraint (leave empty for latest stable)',
+                    self::sortVersionsDescending(self::filterStableVersions($availableVersions))
+                )
+                : '';
+        }
+
+        if ($version !== ''
+            && $availableVersions !== []
+            && self::looksLikeExactVersion((string) $version)
+            && !in_array($version, $availableVersions, true)
+        ) {
+            throw new RuntimeException(sprintf(
+                'Version "%s" is not available for "%s". Available versions include: %s.',
+                $version,
+                $editionConfig['package'],
+                implode(', ', array_slice(self::sortVersionsDescending(self::filterStableVersions($availableVersions)), 0, 10))
+            ));
+        }
+
+        $dir = $this->resolveTargetDirectory($input, $io, $interactive, $editionConfig['default_dir']);
+        $this->assertTargetUsable($dir);
+
+        $proceed = $this->confirmProceed($io, $interactive, [
+            ['Strategy', 'composer'],
+            ['Edition', $edition],
+            ['Composer package', $editionConfig['package']],
+            ['Version constraint', $version !== '' ? $version : '(latest stable)'],
+            ['Repository URL', $repositoryUrl !== '' ? (string) $repositoryUrl : '(none)'],
+            ['Requires authentication', $editionConfig['requires_auth'] ? 'Yes' : 'No'],
+            ['Target directory', $dir],
+        ]);
+
+        if (!$proceed) {
+            $io->note('Download cancelled.');
+
+            return Command::SUCCESS;
+        }
+
+        $exitCode = $this->runComposerCreateProject(
+            $composerBin,
+            $editionConfig['package'],
+            (string) $repositoryUrl,
+            (string) $version,
+            $dir,
+            $io
+        );
+
+        if ($exitCode === Command::SUCCESS) {
+            $this->printPostInstallHint($io, $editionConfig['package'], $dir);
+        }
+
+        return $exitCode;
+    }
+
+    /**
+     * Suggests the right next command to set up the downloaded application. Mage-OS 3.0 replaced the
+     * classic multi-step "setup:install" flow with a single interactive "bin/magento install" wizard.
+     */
+    private function printPostInstallHint(SymfonyStyle $io, string $package, string $dir): void
+    {
+        if (str_starts_with($package, 'mage-os/')) {
+            $installedVersion = $this->resolveInstalledMageOsVersion($dir);
+            if ($installedVersion !== null && version_compare($installedVersion, '3.0.0', '>=')) {
+                $io->note([
+                    'Mage-OS 3.0+ ships a new interactive installer.',
+                    'Run "bin/magento install" inside the project directory to set up the application.',
+                ]);
+
+                return;
+            }
+        }
+
+        $io->note('Next step: run "bin/magento setup:install" inside the project directory to set up the application.');
+    }
+
+    /**
+     * Reads the exact resolved Mage-OS version that "composer create-project" pinned into the
+     * generated composer.json's "mage-os/product-community-edition" requirement.
+     */
+    protected function resolveInstalledMageOsVersion(string $dir): ?string
+    {
+        $composerJsonPath = rtrim($dir, '/') . '/composer.json';
+        if (!is_file($composerJsonPath)) {
+            return null;
+        }
+
+        $composerJson = json_decode((string) file_get_contents($composerJsonPath), true);
+        $version = is_array($composerJson) ? ($composerJson['require']['mage-os/product-community-edition'] ?? null) : null;
+
+        return is_string($version) ? ltrim($version, 'v') : null;
+    }
+
+    /**
+     * Queries composer for the real list of available versions of a package on a repository.
+     * Doubles as a credential/entitlement pre-flight check: an authenticated repository with
+     * invalid or unentitled credentials fails here exactly the way "composer create-project"
+     * would fail later, just earlier and with a more actionable error message.
+     *
+     * @return list<string>
+     */
+    protected function fetchAvailableVersions(string $composerBin, string $package, string $repositoryUrl): array
+    {
+        $manifest = tempnam(sys_get_temp_dir(), 'n98-magerun2-composer-');
+        if ($manifest === false) {
+            throw new RuntimeException('Could not create a temporary composer manifest file.');
+        }
+
+        file_put_contents($manifest, (string) json_encode([
+            'repositories' => [
+                ['type' => 'composer', 'url' => $repositoryUrl],
+            ],
+        ]));
+
+        try {
+            $process = new Process(
+                [$composerBin, 'show', $package, '--all', '--format=json', '--no-interaction'],
+                null,
+                ['COMPOSER' => $manifest]
+            );
+            $process->setTimeout(30);
+            $process->run();
+
+            if (!$process->isSuccessful()) {
+                throw new RuntimeException(sprintf(
+                    'Could not find package "%s" on "%s". This usually means your Marketplace '
+                    . 'credentials are invalid or expired, or your account is not entitled to this '
+                    . 'edition. Verify your keys at https://marketplace.magento.com/customer/accessKeys/.',
+                    $package,
+                    $repositoryUrl
+                ));
+            }
+
+            $data = json_decode($process->getOutput(), true);
+        } finally {
+            unlink($manifest);
+        }
+
+        $versions = is_array($data) ? ($data['versions'] ?? null) : null;
+
+        return is_array($versions) ? array_values(array_filter($versions, 'is_string')) : [];
+    }
+
+    private static function looksLikeExactVersion(string $value): bool
+    {
+        return preg_match('/^[\d.]+(-\w+)?$/', $value) === 1;
+    }
+
+    /**
+     * @param list<string> $versions
+     * @return list<string>
+     */
+    private static function filterStableVersions(array $versions): array
+    {
+        return array_values(array_filter($versions, static function (string $version): bool {
+            return !str_starts_with($version, 'dev-')
+                && preg_match('/(dev|alpha|beta|rc)\b/i', $version) !== 1;
+        }));
+    }
+
+    /**
+     * @param list<string> $versions
+     * @return list<string>
+     */
+    private static function sortVersionsDescending(array $versions): array
+    {
+        usort($versions, static fn (string $a, string $b): int => version_compare($b, $a));
+
+        return $versions;
+    }
+
+    /**
+     * @return array<string, array{package: string, repository-url: string, requires_auth: bool, default_dir: string, description: string}>
+     */
+    protected function getEditions(): array
+    {
+        $configuredEditions = $this->getCommandConfig()['editions'] ?? [];
+        if ($configuredEditions === []) {
+            return self::DEFAULT_EDITIONS;
+        }
+
+        $editions = [];
+        foreach ($configuredEditions as $editionConfig) {
+            $name = $editionConfig['name'];
+            $editions[$name] = [
+                'package' => $editionConfig['package'],
+                'repository-url' => $editionConfig['repository-url'] ?? '',
+                'requires_auth' => $editionConfig['requires-auth'] ?? false,
+                'default_dir' => $editionConfig['default-dir'] ?? ('./' . $name),
+                'description' => $editionConfig['description'] ?? '',
+            ];
+        }
+
+        return $editions;
+    }
+
+    /**
+     * @param array<string, array{package: string, repository-url: string, requires_auth: bool, default_dir: string, description: string}> $editions
+     * @return array<string, string>
+     */
+    private function buildEditionChoices(array $editions): array
+    {
+        $choices = [];
+        foreach ($editions as $name => $editionConfig) {
+            $description = $editionConfig['description'] ?? '';
+            $choices[$name] = $description !== ''
+                ? $description
+                : sprintf('Composer package: %s', $editionConfig['package']);
+        }
+
+        return $choices;
+    }
+
+    /**
+     * @return array<string, array{label: string, url: string}>
+     */
+    protected function getGitRepositories(): array
+    {
+        $configuredRepositories = $this->getCommandConfig()['git-repositories'] ?? [];
+        if ($configuredRepositories === []) {
+            return self::DEFAULT_GIT_REPOSITORIES;
+        }
+
+        $repositories = [];
+        foreach ($configuredRepositories as $repositoryConfig) {
+            $name = $repositoryConfig['name'];
+            $repositories[$name] = [
+                'label' => $repositoryConfig['label'] ?? $name,
+                'url' => $repositoryConfig['url'],
+            ];
+        }
+
+        return $repositories;
+    }
+
+    /**
+     * Normalizes a git URL or a GitHub "owner/repo" shorthand into a clonable URL.
+     */
+    public static function normalizeGitRepoUrl(string $value): string
+    {
+        $value = trim($value);
+        if ($value === '') {
+            throw new InvalidArgumentException('Please enter a git URL or a GitHub "owner/repo" shorthand.');
+        }
+
+        // Full URL (scheme://...) or SCP-like SSH syntax (user@host:path) -> use as-is.
+        if (preg_match('#^([a-z][a-z0-9+.-]*://|[\w.-]+@[\w.-]+:)#i', $value) === 1) {
+            return $value;
+        }
+
+        // GitHub "owner/repo" shorthand, optionally with a trailing ".git".
+        if (preg_match('#^([\w.-]+)/([\w.-]+?)(?:\.git)?$#', $value, $matches) === 1) {
+            return sprintf('https://github.com/%s/%s.git', $matches[1], $matches[2]);
+        }
+
+        throw new InvalidArgumentException(sprintf(
+            'Could not understand "%s". Enter a full git URL (e.g. https://github.com/owner/repo.git or '
+            . 'git@github.com:owner/repo.git) or a GitHub "owner/repo" shorthand.',
+            $value
+        ));
+    }
+
+    protected function runComposerCreateProject(
+        string $composerBin,
+        string $package,
+        string $repositoryUrl,
+        string $version,
+        string $dir,
+        SymfonyStyle $io
+    ): int {
+        $args = new ProcessArguments([$composerBin, 'create-project']);
+        if ($repositoryUrl !== '') {
+            $args->addArgs(['repository-url' => $repositoryUrl]);
+        }
+        $args->addArg('--no-dev')
+            ->addArg($package)
+            ->addArg($dir);
+
+        if ($version !== '') {
+            $args->addArg($version);
+        }
+
+        if (OutputInterface::VERBOSITY_VERBOSE <= $io->getVerbosity()) {
+            $args->addArg('-vvv');
+        }
+
+        $process = $args->createProcess();
+        $process->setTimeout(86400);
+        $process->start();
+        $code = $process->wait(function ($type, $buffer) use ($io): void {
+            $io->write($buffer, false, OutputInterface::OUTPUT_RAW);
+        });
+
+        if ($code !== 0) {
+            $io->error(sprintf('composer create-project failed (exit code %d).', $code));
+
+            return Command::FAILURE;
+        }
+
+        $io->success(sprintf('Successfully downloaded to %s', $dir));
+
+        return Command::SUCCESS;
+    }
+
+    private function ensureMagentoConnectCredentials(
+        InputInterface $input,
+        SymfonyStyle $io,
+        bool $interactive
+    ): void {
+        $configKey = 'http-basic.repo.magento.com';
+        $composerHelper = $this->getComposerHelper();
+        $authConfig = $composerHelper->getConfigValue($configKey);
+
+        if (isset($authConfig->username, $authConfig->password)) {
+            return;
+        }
+
+        if (!$interactive) {
+            throw new RuntimeException(
+                'This edition requires repo.magento.com credentials. Configure them in auth.json '
+                . '(or COMPOSER_AUTH) before running in non-interactive mode.'
+            );
+        }
+
+        $io->note([
+            'You need a Marketplace security key. Login at https://marketplace.magento.com/customer/accessKeys/.',
+            'My Profile -> Access Keys. Use the public key as username and the private key as password.',
+        ]);
+
+        $publicKeyQuestion = new Question('Please enter your public key');
+        $publicKeyQuestion->setMaxAttempts(20);
+        $publicKeyQuestion->setValidator(function ($value) {
+            if ($value === '') {
+                throw new InvalidArgumentException('The public key (auth token) can not be empty');
+            }
+
+            return $value;
+        });
+        $username = $io->askQuestion($publicKeyQuestion);
+
+        $privateKeyQuestion = new Question('Please enter your private key');
+        $privateKeyQuestion->setHidden(true);
+        $privateKeyQuestion->setMaxAttempts(20);
+        $privateKeyQuestion->setValidator(function ($value) {
+            if ($value === '') {
+                throw new InvalidArgumentException('The private key (auth token) can not be empty');
+            }
+
+            return $value;
+        });
+        $password = $io->askQuestion($privateKeyQuestion);
+
+        $composerHelper->setConfigValue($configKey, [$username, $password]);
+    }
+
+    private function downloadWithGit(InputInterface $input, SymfonyStyle $io, bool $interactive): int
+    {
+        $repo = $this->resolveGitRepo($input, $io, $interactive);
+
+        $branch = $input->getOption('branch');
+        if ($branch === null) {
+            $branch = $interactive
+                ? $io->ask('Branch/tag/ref (leave empty for default branch)', '')
+                : '';
+        }
+
+        $dir = $this->resolveTargetDirectory($input, $io, $interactive, './magento2');
+        $this->assertTargetUsable($dir);
+
+        if (!OperatingSystem::isProgramInstalled('git')) {
+            $io->error('git is not installed or not on PATH.');
+
+            return Command::FAILURE;
+        }
+
+        $proceed = $this->confirmProceed($io, $interactive, [
+            ['Strategy', 'git'],
+            ['Repository', $repo],
+            ['Branch/ref', $branch !== '' ? $branch : '(repository default)'],
+            ['Target directory', $dir],
+        ]);
+
+        if (!$proceed) {
+            $io->note('Download cancelled.');
+
+            return Command::SUCCESS;
+        }
+
+        return $this->runGitClone($repo, (string) $branch, $dir, $io);
+    }
+
+    private function resolveGitRepo(InputInterface $input, SymfonyStyle $io, bool $interactive): string
+    {
+        $repo = $input->getOption('repo');
+        if ($repo) {
+            try {
+                return self::normalizeGitRepoUrl((string) $repo);
+            } catch (InvalidArgumentException $exception) {
+                throw new RuntimeException($exception->getMessage(), 0, $exception);
+            }
+        }
+
+        if (!$interactive) {
+            throw new RuntimeException('The "--repo" option is required in non-interactive mode.');
+        }
+
+        $repositories = $this->getGitRepositories();
+        $choices = [];
+        foreach ($repositories as $name => $repositoryConfig) {
+            $choices[$name] = $repositoryConfig['label'];
+        }
+        $choices[self::CUSTOM_GIT_REPO_KEY] = 'Custom — enter a full git URL or GitHub "owner/repo" shorthand';
+
+        $selected = select('Repository', $choices, array_key_first($choices));
+
+        if ($selected === self::CUSTOM_GIT_REPO_KEY) {
+            $question = new Question('Git URL or GitHub "owner/repo"');
+            $question->setMaxAttempts(20);
+            $question->setValidator(static function ($value) {
+                return self::normalizeGitRepoUrl((string) $value);
+            });
+
+            return (string) $io->askQuestion($question);
+        }
+
+        return $repositories[$selected]['url'];
+    }
+
+    protected function runGitClone(string $repo, string $branch, string $dir, SymfonyStyle $io): int
+    {
+        $cmd = ['git', 'clone'];
+        if ($branch !== '') {
+            $cmd[] = '--branch';
+            $cmd[] = $branch;
+        }
+        $cmd[] = $repo;
+        $cmd[] = $dir;
+
+        $process = new Process($cmd);
+        $process->setTimeout(86400);
+        $process->run(function ($type, $buffer) use ($io): void {
+            $io->write($buffer, false, OutputInterface::OUTPUT_RAW);
+        });
+
+        if (!$process->isSuccessful()) {
+            $io->error('git clone failed.');
+
+            return Command::FAILURE;
+        }
+
+        $io->success(sprintf('Successfully cloned into %s', $dir));
+
+        return Command::SUCCESS;
+    }
+
+    private function resolveTargetDirectory(
+        InputInterface $input,
+        SymfonyStyle $io,
+        bool $interactive,
+        string $default
+    ): string {
+        $dir = $input->getOption('dir');
+        if (!$dir) {
+            if (!$interactive) {
+                throw new RuntimeException('The "--dir" option is required in non-interactive mode.');
+            }
+            $dir = $io->ask('Target directory', $default);
+        }
+
+        return rtrim((string) $dir, '/');
+    }
+
+    /**
+     * @param list<array{0: string, 1: string}> $summaryRows
+     */
+    private function confirmProceed(SymfonyStyle $io, bool $interactive, array $summaryRows): bool
+    {
+        if (!$interactive) {
+            return true;
+        }
+
+        $io->section('Summary');
+        $io->table(['Setting', 'Value'], $summaryRows);
+
+        return confirm('Proceed with the download?', true);
+    }
+
+    private function assertTargetUsable(string $dir): void
+    {
+        if (file_exists($dir) && !is_dir($dir)) {
+            throw new RuntimeException(sprintf('Target "%s" exists and is not a directory.', $dir));
+        }
+
+        if (is_dir($dir)) {
+            $entries = array_diff((array) scandir($dir), ['.', '..']);
+            if (count($entries) > 0) {
+                throw new RuntimeException(sprintf(
+                    'Target directory "%s" already exists and is not empty. Choose an empty or non-existent'
+                    . ' directory.',
+                    $dir
+                ));
+            }
+        }
+    }
+
+    private function getComposerHelper(): ComposerHelper
+    {
+        /** @var ComposerHelper $composerHelper */
+        $composerHelper = $this->getHelper('composer');
+
+        return $composerHelper;
+    }
+}

--- a/tests/N98/Magento/Command/Project/DownloadCommandTest.php
+++ b/tests/N98/Magento/Command/Project/DownloadCommandTest.php
@@ -1,0 +1,693 @@
+<?php
+/**
+ * This file is part of the n98-magerun2 project.
+ *
+ * For the full copyright and license information, please view the MIT-LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+namespace N98\Magento\Command\Project;
+
+use InvalidArgumentException;
+use N98\Util\Console\Helper\ComposerHelper;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Exception\RuntimeException;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class DownloadCommandTest extends TestCase
+{
+    /**
+     * @var string[]
+     */
+    private $tempDirs = [];
+
+    protected function tearDown(): void
+    {
+        foreach ($this->tempDirs as $dir) {
+            $this->removeDirectory($dir);
+        }
+        $this->tempDirs = [];
+    }
+
+    public function testComposerNonInteractiveSuccessForNoAuthEdition(): void
+    {
+        $composerCalls = [];
+        $tester = $this->createTester($composerCalls, $gitCalls, 0, 0, true);
+        $dir = $this->makeTempPath();
+
+        $exitCode = $tester->execute([
+            '--edition' => 'mage-os',
+            '--constraint' => '2.2.0',
+            '--dir' => $dir,
+        ], ['interactive' => false]);
+
+        $this->assertSame(0, $exitCode);
+        $this->assertCount(1, $composerCalls);
+        $this->assertSame('mage-os/project-community-edition', $composerCalls[0]['package']);
+        $this->assertSame('https://repo.mage-os.org', $composerCalls[0]['repositoryUrl']);
+        $this->assertSame('2.2.0', $composerCalls[0]['version']);
+        $this->assertSame($dir, $composerCalls[0]['dir']);
+    }
+
+    public function testComposerNonInteractiveSuccessForAuthenticatedEdition(): void
+    {
+        $composerCalls = [];
+        $authConfig = (object) ['username' => 'pub', 'password' => 'priv'];
+        $tester = $this->createTester($composerCalls, $gitCalls, 0, 0, true, $authConfig);
+        $dir = $this->makeTempPath();
+
+        $exitCode = $tester->execute([
+            '--edition' => 'adobe-commerce',
+            '--dir' => $dir,
+        ], ['interactive' => false]);
+
+        $this->assertSame(0, $exitCode);
+        $this->assertSame('magento/project-enterprise-edition', $composerCalls[0]['package']);
+        $this->assertSame('https://repo.magento.com', $composerCalls[0]['repositoryUrl']);
+        $this->assertSame('', $composerCalls[0]['version']);
+    }
+
+    public function testComposerMissingCredentialsFailsInNonInteractiveMode(): void
+    {
+        $composerCalls = [];
+        $tester = $this->createTester($composerCalls, $gitCalls, 0, 0, true, (object) []);
+        $dir = $this->makeTempPath();
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('repo.magento.com credentials');
+
+        $tester->execute([
+            '--edition' => 'open-source',
+            '--dir' => $dir,
+        ], ['interactive' => false]);
+    }
+
+    public function testGitNonInteractiveSuccess(): void
+    {
+        $gitCalls = [];
+        $tester = $this->createTester($composerCalls, $gitCalls, 0, 0, true);
+        $dir = $this->makeTempPath();
+
+        $exitCode = $tester->execute([
+            '--strategy' => 'git',
+            '--repo' => 'git@github.com:my-fork/magento2.git',
+            '--branch' => '2.4-develop',
+            '--dir' => $dir,
+        ], ['interactive' => false]);
+
+        $this->assertSame(0, $exitCode);
+        $this->assertCount(1, $gitCalls);
+        $this->assertSame('git@github.com:my-fork/magento2.git', $gitCalls[0]['repo']);
+        $this->assertSame('2.4-develop', $gitCalls[0]['branch']);
+        $this->assertSame($dir, $gitCalls[0]['dir']);
+    }
+
+    public function testGitNonInteractiveSuccessWithoutBranch(): void
+    {
+        $gitCalls = [];
+        $tester = $this->createTester($composerCalls, $gitCalls, 0, 0, true);
+        $dir = $this->makeTempPath();
+
+        $tester->execute([
+            '--strategy' => 'git',
+            '--repo' => 'https://github.com/magento/magento2.git',
+            '--dir' => $dir,
+        ], ['interactive' => false]);
+
+        $this->assertSame('', $gitCalls[0]['branch']);
+    }
+
+    public function testMissingEditionFailsInNonInteractiveMode(): void
+    {
+        $tester = $this->createTester($composerCalls, $gitCalls, 0, 0, true);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('"--edition" option is required');
+
+        $tester->execute([
+            '--dir' => $this->makeTempPath(),
+        ], ['interactive' => false]);
+    }
+
+    public function testMissingRepoFailsInNonInteractiveMode(): void
+    {
+        $tester = $this->createTester($composerCalls, $gitCalls, 0, 0, true);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('"--repo" option is required');
+
+        $tester->execute([
+            '--strategy' => 'git',
+            '--dir' => $this->makeTempPath(),
+        ], ['interactive' => false]);
+    }
+
+    public function testMissingDirFailsInNonInteractiveMode(): void
+    {
+        $tester = $this->createTester($composerCalls, $gitCalls, 0, 0, true);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('"--dir" option is required');
+
+        $tester->execute([
+            '--edition' => 'mage-os',
+        ], ['interactive' => false]);
+    }
+
+    public function testInvalidEditionFailsInNonInteractiveMode(): void
+    {
+        $tester = $this->createTester($composerCalls, $gitCalls, 0, 0, true);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Invalid edition "bogus"');
+
+        $tester->execute([
+            '--edition' => 'bogus',
+            '--dir' => $this->makeTempPath(),
+        ], ['interactive' => false]);
+    }
+
+    public function testInteractiveModePromptsOnlyForMissingDirectory(): void
+    {
+        $composerCalls = [];
+        $tester = $this->createTester($composerCalls, $gitCalls, 0, 0, true);
+        $dir = $this->makeTempPath();
+
+        $tester->setInputs([$dir, '']);
+        $exitCode = $tester->execute([
+            '--strategy' => 'composer',
+            '--edition' => 'mage-os',
+            '--constraint' => '2.2.0',
+        ], ['interactive' => true]);
+
+        $this->assertSame(0, $exitCode);
+        $this->assertSame($dir, $composerCalls[0]['dir']);
+        $this->assertSame('mage-os/project-community-edition', $composerCalls[0]['package']);
+    }
+
+    public function testInteractiveModePromptsForStrategy(): void
+    {
+        $gitCalls = [];
+        $tester = $this->createTester($composerCalls, $gitCalls, 0, 0, true);
+        $dir = $this->makeTempPath();
+
+        $tester->setInputs(['git', 'custom', 'https://github.com/my-fork/magento2.git', '', $dir, '']);
+        $exitCode = $tester->execute([], ['interactive' => true]);
+
+        $this->assertSame(0, $exitCode);
+        $this->assertCount(1, $gitCalls);
+        $this->assertSame('https://github.com/my-fork/magento2.git', $gitCalls[0]['repo']);
+        $this->assertSame($dir, $gitCalls[0]['dir']);
+    }
+
+    public function testTargetDirectoryNotEmptyIsRejected(): void
+    {
+        $composerCalls = [];
+        $tester = $this->createTester($composerCalls, $gitCalls, 0, 0, true);
+        $dir = $this->makeTempPath(true);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('already exists and is not empty');
+
+        try {
+            $tester->execute([
+                '--edition' => 'mage-os',
+                '--dir' => $dir,
+            ], ['interactive' => false]);
+        } finally {
+            $this->assertCount(0, $composerCalls);
+        }
+    }
+
+    public function testComposerNotFoundFailsClearly(): void
+    {
+        $composerCalls = [];
+        $tester = $this->createTester($composerCalls, $gitCalls, 0, 0, false);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Could not find composer');
+
+        $tester->execute([
+            '--edition' => 'mage-os',
+            '--dir' => $this->makeTempPath(),
+        ], ['interactive' => false]);
+    }
+
+    public function testGitPresetSelectionUsesConfiguredUrl(): void
+    {
+        $gitCalls = [];
+        $tester = $this->createTester($composerCalls, $gitCalls, 0, 0, true);
+        $dir = $this->makeTempPath();
+
+        $tester->setInputs(['git', 'mage-os', '', $dir, '']);
+        $exitCode = $tester->execute([], ['interactive' => true]);
+
+        $this->assertSame(0, $exitCode);
+        $this->assertCount(1, $gitCalls);
+        $this->assertSame('https://github.com/mage-os/mage-os.git', $gitCalls[0]['repo']);
+    }
+
+    public function testGitCustomShorthandIsNormalized(): void
+    {
+        $gitCalls = [];
+        $tester = $this->createTester($composerCalls, $gitCalls, 0, 0, true);
+        $dir = $this->makeTempPath();
+
+        $tester->setInputs(['git', 'custom', 'my-fork/magento2', '', $dir, '']);
+        $exitCode = $tester->execute([], ['interactive' => true]);
+
+        $this->assertSame(0, $exitCode);
+        $this->assertSame('https://github.com/my-fork/magento2.git', $gitCalls[0]['repo']);
+    }
+
+    public function testConfirmationDeclineCancelsDownload(): void
+    {
+        $composerCalls = [];
+        $tester = $this->createTester($composerCalls, $gitCalls, 0, 0, true);
+        $dir = $this->makeTempPath();
+
+        $tester->setInputs([$dir, 'no']);
+        $exitCode = $tester->execute([
+            '--strategy' => 'composer',
+            '--edition' => 'mage-os',
+            '--constraint' => '2.2.0',
+        ], ['interactive' => true]);
+
+        $this->assertSame(0, $exitCode);
+        $this->assertCount(0, $composerCalls);
+        $this->assertStringContainsString('cancelled', $tester->getDisplay());
+    }
+
+    public function testConfirmationAcceptRunsDownload(): void
+    {
+        $composerCalls = [];
+        $tester = $this->createTester($composerCalls, $gitCalls, 0, 0, true);
+        $dir = $this->makeTempPath();
+
+        $tester->setInputs([$dir, 'yes']);
+        $exitCode = $tester->execute([
+            '--strategy' => 'composer',
+            '--edition' => 'mage-os',
+            '--constraint' => '2.2.0',
+        ], ['interactive' => true]);
+
+        $this->assertSame(0, $exitCode);
+        $this->assertCount(1, $composerCalls);
+    }
+
+    public function testComposerRejectsUnavailableExactVersion(): void
+    {
+        $composerCalls = [];
+        $tester = $this->createTester($composerCalls, $gitCalls, 0, 0, true, null, ['1.0.0', '2.2.0']);
+        $dir = $this->makeTempPath();
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('is not available');
+
+        $tester->execute([
+            '--edition' => 'mage-os',
+            '--constraint' => '9.9.9',
+            '--dir' => $dir,
+        ], ['interactive' => false]);
+    }
+
+    public function testComposerAcceptsAvailableExactVersion(): void
+    {
+        $composerCalls = [];
+        $tester = $this->createTester($composerCalls, $gitCalls, 0, 0, true, null, ['1.0.0', '2.2.0']);
+        $dir = $this->makeTempPath();
+
+        $exitCode = $tester->execute([
+            '--edition' => 'mage-os',
+            '--constraint' => '2.2.0',
+            '--dir' => $dir,
+        ], ['interactive' => false]);
+
+        $this->assertSame(0, $exitCode);
+        $this->assertCount(1, $composerCalls);
+    }
+
+    public function testComposerAllowsConstraintRangesWithoutValidation(): void
+    {
+        $composerCalls = [];
+        $tester = $this->createTester($composerCalls, $gitCalls, 0, 0, true, null, ['1.0.0', '2.2.0']);
+        $dir = $this->makeTempPath();
+
+        $exitCode = $tester->execute([
+            '--edition' => 'mage-os',
+            '--constraint' => '^2.4',
+            '--dir' => $dir,
+        ], ['interactive' => false]);
+
+        $this->assertSame(0, $exitCode);
+        $this->assertCount(1, $composerCalls);
+        $this->assertSame('^2.4', $composerCalls[0]['version']);
+    }
+
+    public function testAvailableVersionsSuggestionIsSortedDescending(): void
+    {
+        $composerCalls = [];
+        $tester = $this->createTester(
+            $composerCalls,
+            $gitCalls,
+            0,
+            0,
+            true,
+            null,
+            ['1.0.0', '2.4.10', '2.2.0', '2.4.7']
+        );
+        $dir = $this->makeTempPath();
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Available versions include: 2.4.10, 2.4.7, 2.2.0, 1.0.0.');
+
+        $tester->execute([
+            '--edition' => 'mage-os',
+            '--constraint' => '9.9.9',
+            '--dir' => $dir,
+        ], ['interactive' => false]);
+    }
+
+    public function testComposerFetchFailurePresentsClearErrorMessage(): void
+    {
+        $composerCalls = [];
+        $tester = $this->createTester($composerCalls, $gitCalls, 0, 0, true, null, null, true);
+        $dir = $this->makeTempPath();
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('entitled');
+
+        $tester->execute([
+            '--edition' => 'adobe-commerce',
+            '--dir' => $dir,
+        ], ['interactive' => false]);
+    }
+
+    public function testInteractiveModePromptsForVersionUsingAvailableVersions(): void
+    {
+        $composerCalls = [];
+        $tester = $this->createTester($composerCalls, $gitCalls, 0, 0, true, null, ['1.0.0', '2.2.0']);
+        $dir = $this->makeTempPath();
+
+        $tester->setInputs(['mage-os', '2.2.0', $dir, '']);
+        $exitCode = $tester->execute([
+            '--strategy' => 'composer',
+        ], ['interactive' => true]);
+
+        $this->assertSame(0, $exitCode);
+        $this->assertSame('2.2.0', $composerCalls[0]['version']);
+    }
+
+    public function testMageOsThreeOrNewerSuggestsBinMagentoInstall(): void
+    {
+        $composerCalls = [];
+        $tester = $this->createTester($composerCalls, $gitCalls, 0, 0, true, null, null, false, '3.1.0');
+        $dir = $this->makeTempPath();
+
+        $tester->execute([
+            '--edition' => 'mage-os',
+            '--constraint' => '3.1.0',
+            '--dir' => $dir,
+        ], ['interactive' => false]);
+
+        $this->assertStringContainsString('bin/magento install', $tester->getDisplay());
+        $this->assertStringNotContainsString('setup:install', $tester->getDisplay());
+    }
+
+    public function testMageOsBelowThreeSuggestsSetupInstall(): void
+    {
+        $composerCalls = [];
+        $tester = $this->createTester($composerCalls, $gitCalls, 0, 0, true, null, null, false, '2.2.0');
+        $dir = $this->makeTempPath();
+
+        $tester->execute([
+            '--edition' => 'mage-os',
+            '--constraint' => '2.2.0',
+            '--dir' => $dir,
+        ], ['interactive' => false]);
+
+        $this->assertStringContainsString('bin/magento setup:install', $tester->getDisplay());
+    }
+
+    public function testOtherEditionsAlwaysSuggestSetupInstall(): void
+    {
+        $composerCalls = [];
+        $tester = $this->createTester($composerCalls, $gitCalls, 0, 0, true, null, null, false, '3.1.0');
+        $dir = $this->makeTempPath();
+
+        $tester->execute([
+            '--edition' => 'adobe-commerce',
+            '--dir' => $dir,
+        ], ['interactive' => false]);
+
+        $this->assertStringContainsString('bin/magento setup:install', $tester->getDisplay());
+    }
+
+    /**
+     * @dataProvider gitRepoUrlProvider
+     */
+    public function testNormalizeGitRepoUrl(string $input, string $expected): void
+    {
+        $this->assertSame($expected, DownloadCommand::normalizeGitRepoUrl($input));
+    }
+
+    /**
+     * @return array<string, array{0: string, 1: string}>
+     */
+    public static function gitRepoUrlProvider(): array
+    {
+        return [
+            'full https url' => [
+                'https://github.com/magento/magento2.git',
+                'https://github.com/magento/magento2.git',
+            ],
+            'ssh scp-style url' => [
+                'git@github.com:magento/magento2.git',
+                'git@github.com:magento/magento2.git',
+            ],
+            'shorthand' => [
+                'magento/magento2',
+                'https://github.com/magento/magento2.git',
+            ],
+            'shorthand with .git suffix' => [
+                'magento/magento2.git',
+                'https://github.com/magento/magento2.git',
+            ],
+        ];
+    }
+
+    public function testNormalizeGitRepoUrlRejectsEmptyValue(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        DownloadCommand::normalizeGitRepoUrl('   ');
+    }
+
+    public function testNormalizeGitRepoUrlRejectsMalformedValue(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        DownloadCommand::normalizeGitRepoUrl('not a valid repo');
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $composerCalls
+     * @param array<int, array<string, mixed>> $gitCalls
+     */
+    private function createTester(
+        &$composerCalls,
+        &$gitCalls,
+        int $composerExitCode = 0,
+        int $gitExitCode = 0,
+        bool $composerAvailable = true,
+        ?object $authConfig = null,
+        ?array $availableVersions = null,
+        bool $fetchVersionsFails = false,
+        ?string $installedMageOsVersion = null
+    ): CommandTester {
+        $composerCalls = [];
+        $gitCalls = [];
+        $authConfig = $authConfig ?? (object) ['username' => 'pub', 'password' => 'priv'];
+
+        $command = new class($composerCalls, $gitCalls, $composerExitCode, $gitExitCode, $availableVersions ?? [], $fetchVersionsFails, $installedMageOsVersion) extends DownloadCommand {
+            private $composerCallsRef;
+
+            private $gitCallsRef;
+
+            private $composerExitCode;
+
+            private $gitExitCode;
+
+            private $availableVersions;
+
+            private $fetchVersionsFails;
+
+            private $installedMageOsVersion;
+
+            public function __construct(
+                array &$composerCalls,
+                array &$gitCalls,
+                int $composerExitCode,
+                int $gitExitCode,
+                array $availableVersions,
+                bool $fetchVersionsFails,
+                ?string $installedMageOsVersion
+            ) {
+                parent::__construct();
+                $this->composerCallsRef = &$composerCalls;
+                $this->gitCallsRef = &$gitCalls;
+                $this->composerExitCode = $composerExitCode;
+                $this->gitExitCode = $gitExitCode;
+                $this->availableVersions = $availableVersions;
+                $this->fetchVersionsFails = $fetchVersionsFails;
+                $this->installedMageOsVersion = $installedMageOsVersion;
+            }
+
+            protected function shouldFallbackToPlainPrompts(): bool
+            {
+                return true;
+            }
+
+            protected function fetchAvailableVersions(string $composerBin, string $package, string $repositoryUrl): array
+            {
+                if ($this->fetchVersionsFails) {
+                    throw new RuntimeException(sprintf(
+                        'Could not find package "%s" on "%s". This usually means your Marketplace '
+                        . 'credentials are invalid or expired, or your account is not entitled to this '
+                        . 'edition. Verify your keys at https://marketplace.magento.com/customer/accessKeys/.',
+                        $package,
+                        $repositoryUrl
+                    ));
+                }
+
+                return $this->availableVersions;
+            }
+
+            protected function resolveInstalledMageOsVersion(string $dir): ?string
+            {
+                return $this->installedMageOsVersion;
+            }
+
+            protected function getEditions(): array
+            {
+                return [
+                    'open-source' => [
+                        'package' => 'magento/project-community-edition',
+                        'repository-url' => 'https://repo.magento.com',
+                        'requires_auth' => true,
+                        'default_dir' => './magento-open-source',
+                    ],
+                    'adobe-commerce' => [
+                        'package' => 'magento/project-enterprise-edition',
+                        'repository-url' => 'https://repo.magento.com',
+                        'requires_auth' => true,
+                        'default_dir' => './adobe-commerce',
+                    ],
+                    'mage-os' => [
+                        'package' => 'mage-os/project-community-edition',
+                        'repository-url' => 'https://repo.mage-os.org',
+                        'requires_auth' => false,
+                        'default_dir' => './mage-os',
+                    ],
+                ];
+            }
+
+            protected function getGitRepositories(): array
+            {
+                return [
+                    'magento2' => [
+                        'label' => 'Magento 2 (official core)',
+                        'url' => 'https://github.com/magento/magento2.git',
+                    ],
+                    'mage-os' => [
+                        'label' => 'Mage-OS (community fork)',
+                        'url' => 'https://github.com/mage-os/mage-os.git',
+                    ],
+                ];
+            }
+
+            protected function runComposerCreateProject(
+                string $composerBin,
+                string $package,
+                string $repositoryUrl,
+                string $version,
+                string $dir,
+                SymfonyStyle $output
+            ): int {
+                $this->composerCallsRef[] = compact('composerBin', 'package', 'repositoryUrl', 'version', 'dir');
+
+                return $this->composerExitCode;
+            }
+
+            protected function runGitClone(string $repo, string $branch, string $dir, SymfonyStyle $output): int
+            {
+                $this->gitCallsRef[] = compact('repo', 'branch', 'dir');
+
+                return $this->gitExitCode;
+            }
+        };
+
+        $application = new Application();
+        $application->add($command);
+
+        $composerHelper = new class($composerAvailable, $authConfig) extends ComposerHelper {
+            private $available;
+
+            private $authConfig;
+
+            public function __construct(bool $available, object $authConfig)
+            {
+                $this->available = $available;
+                $this->authConfig = $authConfig;
+            }
+
+            public function getBinPath()
+            {
+                return $this->available ? 'composer' : '';
+            }
+
+            public function getConfigValue($key, $useGlobalConfig = true)
+            {
+                return $this->authConfig;
+            }
+
+            public function setConfigValue($key, $values, $useGlobalConfig = true)
+            {
+                return '';
+            }
+        };
+        $application->getHelperSet()->set($composerHelper, 'composer');
+
+        /** @var DownloadCommand $foundCommand */
+        $foundCommand = $application->find('download');
+
+        return new CommandTester($foundCommand);
+    }
+
+    private function makeTempPath(bool $withFile = false): string
+    {
+        $dir = sys_get_temp_dir() . '/n98-magerun2-download-test-' . uniqid();
+        if ($withFile) {
+            mkdir($dir, 0777, true);
+            file_put_contents($dir . '/existing.txt', 'x');
+        }
+        $this->tempDirs[] = $dir;
+
+        return $dir;
+    }
+
+    private function removeDirectory(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        $items = array_diff((array) scandir($dir), ['.', '..']);
+        foreach ($items as $item) {
+            $path = $dir . '/' . $item;
+            is_dir($path) ? $this->removeDirectory($path) : unlink($path);
+        }
+        rmdir($dir);
+    }
+}


### PR DESCRIPTION
- [x] This pull request targets the `develop` branch
- [x] Documentation in the `docs/docs` directory reflects any relevant changes
- [x] All tests pass
- [x] I have read and followed the [Contribution Guide](https://netz98.github.io/n98-magerun2/contributing/)

---

## Related Issue(s)

Closes #2055

## Summary

Introduces a new `download` command that focuses purely on fetching Magento
source code, as a "download only" replacement for the download step of the
deprecated `install` command:

- Two strategies: `composer` (runs `composer create-project` for a known
  edition — Magento Open Source, Adobe Commerce, or Mage-OS) and `git` (runs
  `git clone` for core/Mage-OS contributors), selectable via `--strategy` or
  an interactive wizard.
- Interactive UX built with SymfonyStyle + `laravel/prompts` (arrow-key
  select/confirm/suggest), with automatic fallback to plain SymfonyStyle
  prompts on Windows or when not attached to an interactive terminal.
- Preset pickers for editions and git repositories, plus GitHub `owner/repo`
  shorthand expansion for the `--repo` option.
- A pre-flight check that queries the target composer repository
  (`composer show <package> --all --format=json`) before running
  `create-project`, to catch invalid/unentitled Marketplace credentials early
  with an actionable error instead of composer's generic failure.
- Version validation: exact `--constraint` values are checked against the
  real list of available versions (sorted descending, real versions offered
  as autocomplete suggestions); range/expression constraints are passed
  through to composer unvalidated.
- A post-install hint tailored to the resolved edition/version: `bin/magento
  install` for Mage-OS >= 3.0, `bin/magento setup:install` otherwise.
- A confirmation summary step before the actual download in interactive mode
  (always skipped under `--no-interaction`).
- Fully scriptable non-interactive mode for CI/CD usage.

## Additional Notes

- New command docs at `docs/docs/command-docs/project/download.md`.
- Unit tests in `tests/N98/Magento/Command/Project/DownloadCommandTest.php`
  cover both strategies, interactive and non-interactive modes, preset
  resolution, shorthand normalization, the credential/version pre-flight
  check, and the post-install hint logic.