### PR TITLE
feat(cli): make integration:create and integration:delete interactive

### DIFF
--- a/src/N98/Magento/Command/Integration/CreateCommand.php
+++ b/src/N98/Magento/Command/Integration/CreateCommand.php
@@ -8,6 +8,7 @@
 
 namespace N98\Magento\Command\Integration;
 
+use function Laravel\Prompts\text;
 use Magento\Framework\Exception\AlreadyExistsException;
 use Magento\Framework\Exception\IntegrationException;
 use Magento\Framework\Exception\LocalizedException;
@@ -77,7 +78,7 @@ class CreateCommand extends AbstractMagentoCommand
     {
         $this
             ->setName('integration:create')
-            ->addArgument('name', InputArgument::REQUIRED, 'Name of the integration')
+            ->addArgument('name', InputArgument::OPTIONAL, 'Name of the integration')
             ->addArgument('email', InputArgument::OPTIONAL, 'Email')
             ->addArgument('endpoint', InputArgument::OPTIONAL, 'Endpoint URL')
             ->addOption('consumer-key', '', InputOption::VALUE_REQUIRED, 'Consumer Key (length 32 chars)')
@@ -136,8 +137,31 @@ HELP;
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $integrationName = $input->getArgument('name');
+        if ($integrationName === null || $integrationName === '') {
+            $integrationName = text(
+                '<question>Name of the integration:</question>',
+                validate: fn ($value) => $value === '' ? 'Please enter a name for the integration' : null
+            );
+        }
+
         $integrationEmail = $input->getArgument('email');
+        if ($integrationEmail === null) {
+            $integrationEmail = text(
+                '<question>Email (optional):</question>',
+                validate: fn ($value) => $this->validateOptionalEmail($value)
+            );
+            $integrationEmail = $integrationEmail === '' ? null : $integrationEmail;
+        }
+
         $integrationEndpoint = $input->getArgument('endpoint');
+        if ($integrationEndpoint === null) {
+            $integrationEndpoint = text(
+                '<question>Endpoint URL (optional):</question>',
+                validate: fn ($value) => $this->validateOptionalUrl($value)
+            );
+            $integrationEndpoint = $integrationEndpoint === '' ? null : $integrationEndpoint;
+        }
+
         $consumerKey = $input->getOption('consumer-key');
         $consumerSecret = $input->getOption('consumer-secret');
         $accessToken = $input->getOption('access-token');
@@ -176,6 +200,32 @@ HELP;
             ->renderByFormat($output, $table, $input->getOption('format'));
 
         return Command::SUCCESS;
+    }
+
+    /**
+     * @param string $value
+     * @return string|null
+     */
+    private function validateOptionalEmail(string $value): ?string
+    {
+        if ($value !== '' && !filter_var($value, FILTER_VALIDATE_EMAIL)) {
+            return 'Please enter a valid email address';
+        }
+
+        return null;
+    }
+
+    /**
+     * @param string $value
+     * @return string|null
+     */
+    private function validateOptionalUrl(string $value): ?string
+    {
+        if ($value !== '' && !filter_var($value, FILTER_VALIDATE_URL)) {
+            return 'Please enter a valid URL';
+        }
+
+        return null;
     }
 
     /**

--- a/src/N98/Magento/Command/Integration/DeleteCommand.php
+++ b/src/N98/Magento/Command/Integration/DeleteCommand.php
@@ -9,7 +9,11 @@
 namespace N98\Magento\Command\Integration;
 
 use Exception;
+use function Laravel\Prompts\confirm;
+use function Laravel\Prompts\select;
 use Magento\Integration\Api\OauthServiceInterface;
+use Magento\Integration\Model\Integration as IntegrationAlias;
+use Magento\Integration\Model\IntegrationFactory;
 use Magento\Integration\Model\IntegrationService;
 use N98\Magento\Command\AbstractMagentoCommand;
 use Symfony\Component\Console\Command\Command;
@@ -35,24 +39,26 @@ class DeleteCommand extends AbstractMagentoCommand
     private $oauthService;
 
     /**
-     * @var TokenCollectionFactory
+     * @var IntegrationFactory
      */
-    private $tokenCollectionFactory;
+    private $integrationFactory;
 
     protected function configure()
     {
         $this
             ->setName('integration:delete')
-            ->addArgument('name', InputArgument::REQUIRED, 'Name or ID of the integration')
+            ->addArgument('name', InputArgument::OPTIONAL, 'Name or ID of the integration')
             ->setDescription('Delete an existing integration.');
     }
 
     public function inject(
         IntegrationService $integrationService,
-        OauthServiceInterface $oauthService
+        OauthServiceInterface $oauthService,
+        IntegrationFactory $integrationFactory
     ) {
         $this->integrationService = $integrationService;
         $this->oauthService = $oauthService;
+        $this->integrationFactory = $integrationFactory;
     }
 
     /**
@@ -64,6 +70,15 @@ class DeleteCommand extends AbstractMagentoCommand
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $integrationName = $input->getArgument('name');
+        $selectedInteractively = false;
+
+        if ($integrationName === null || $integrationName === '') {
+            $integrationName = $this->selectIntegration($output);
+            if ($integrationName === null) {
+                return Command::SUCCESS;
+            }
+            $selectedInteractively = true;
+        }
 
         $integrationModel = $this->integrationService->findByName($integrationName);
 
@@ -73,6 +88,18 @@ class DeleteCommand extends AbstractMagentoCommand
 
         if ($integrationModel->getId() <= 0) {
             throw new RuntimeException('Integration with this name or ID does not exist.');
+        }
+
+        if ($selectedInteractively && !confirm(
+            sprintf(
+                '<question>Are you sure you want to delete integration "%s" (ID: %d)?</question>',
+                $integrationModel->getName(),
+                $integrationModel->getId()
+            ),
+            false
+        )) {
+            $output->writeln('<error>Operation cancelled.</error>');
+            return Command::FAILURE;
         }
 
         $this->integrationService->delete($integrationModel->getId());
@@ -94,5 +121,31 @@ class DeleteCommand extends AbstractMagentoCommand
         );
 
         return Command::SUCCESS;
+    }
+
+    /**
+     * @return string|null Name of the selected integration, or null if there was nothing to select
+     */
+    private function selectIntegration(OutputInterface $output): ?string
+    {
+        $integrations = $this->integrationFactory->create()->getCollection()->getItems();
+
+        if (count($integrations) === 0) {
+            $output->writeln('<info>No integrations found.</info>');
+            return null;
+        }
+
+        $options = [];
+        /** @var IntegrationAlias $integration */
+        foreach ($integrations as $integration) {
+            $options[$integration->getName()] = sprintf(
+                '%s (ID: %d, email: %s)',
+                $integration->getName(),
+                $integration->getId(),
+                $integration->getEmail() ?: '-'
+            );
+        }
+
+        return select('<question>Select an integration to delete:</question>', $options);
     }
 }


### PR DESCRIPTION
## Summary
- `integration:create`: prompt for `name`, `email`, and `endpoint` via Laravel Prompts when they aren't passed as arguments, with validation matching the existing manual checks.
- `integration:delete`: when no `name`/ID argument is given, list existing integrations via a `select()` prompt and ask for confirmation before deleting. Deleting by an explicit `name`/ID argument still works non-interactively, unchanged.

## Test plan
- [x] `ddev exec vendor/bin/phpunit tests/N98/Magento/Command/Integration/CreateReadDeleteTest.php` passes
- [x] `php -l` on both changed files
- [x] `vendor/bin/php-cs-fixer fix --dry-run` reports no issues on either file
- [x] `vendor/bin/phpstan analyse` shows no new error categories vs. the pre-change baseline