### PR TITLE
fix(command): resolve real plugin package for allow-plugins check in composer:redeploy-base-packages

### DIFF
--- a/src/N98/Magento/Command/Composer/MagentoComposer.php
+++ b/src/N98/Magento/Command/Composer/MagentoComposer.php
@@ -11,8 +11,8 @@ declare(strict_types=1);
 namespace N98\Magento\Command\Composer;
 
 use Composer\Composer;
-use Composer\Config;
-use Composer\Console\Application;
+use Composer\Factory;
+use Composer\IO\NullIO;
 
 class MagentoComposer
 {
@@ -22,25 +22,22 @@ class MagentoComposer
     private static $composer;
 
     /**
-     * @param string $composerConfigFile
+     * @param string $magentoRootDir
      * @return Composer
      * @throws \Composer\Json\JsonValidationException
      */
     public static function initBundledComposer(string $magentoRootDir)
     {
         if (! self::$composer instanceof Composer) {
-            $composerApplication = new Application();
-            $composerApplication->setAutoExit(false);
-
-            $composer = $composerApplication->getComposer();
-            $composer->setConfig(
-                new Config(
-                    true,
-                    $magentoRootDir
-                )
+            // Factory::create() forces plugins into 'local'-disabled mode whenever a non-default
+            // composer.json path is passed in, so createComposer() is called directly with $cwd
+            // set to $magentoRootDir instead, as documented in Factory::create()'s source.
+            self::$composer = (new Factory())->createComposer(
+                new NullIO(),
+                $magentoRootDir . '/composer.json',
+                false,
+                $magentoRootDir
             );
-
-            self::$composer = $composer;
         }
 
         return self::$composer;

--- a/src/N98/Magento/Command/Composer/RedeployBasePackagesCommand.php
+++ b/src/N98/Magento/Command/Composer/RedeployBasePackagesCommand.php
@@ -12,6 +12,7 @@ namespace N98\Magento\Command\Composer;
 
 use Composer\Composer;
 use Composer\IO\NullIO;
+use Composer\Package\PackageInterface;
 use MagentoHackathon\Composer\Magento\Deploy\Manager\Entry;
 use MagentoHackathon\Composer\Magento\DeployManager;
 use MagentoHackathon\Composer\Magento\Installer;
@@ -111,6 +112,7 @@ class RedeployBasePackagesCommand extends AbstractMagentoCommand
     ): array {
         $addPluginArguments = [$magentoPlugin];
         $addPluginParameters = $addPluginMethod->getParameters();
+        $sourcePackage = $this->findMagentoComposerInstallerPackage($composer);
 
         if (
             isset($addPluginParameters[1], $addPluginParameters[2])
@@ -118,16 +120,28 @@ class RedeployBasePackagesCommand extends AbstractMagentoCommand
             && $addPluginParameters[2]->getName() === 'sourcePackage'
         ) {
             $addPluginArguments[] = false;
-            $addPluginArguments[] = $composer->getPackage();
+            $addPluginArguments[] = $sourcePackage;
 
             return $addPluginArguments;
         }
 
         if (isset($addPluginParameters[1]) && $addPluginParameters[1]->getName() === 'sourcePackage') {
-            $addPluginArguments[] = $composer->getPackage();
+            $addPluginArguments[] = $sourcePackage;
         }
 
         return $addPluginArguments;
+    }
+
+    /**
+     * @param \Composer\Composer $composer
+     * @return \Composer\Package\PackageInterface|null
+     */
+    private function findMagentoComposerInstallerPackage(Composer $composer): ?PackageInterface
+    {
+        return $composer->getRepositoryManager()->getLocalRepository()->findPackage(
+            'magento/magento-composer-installer',
+            '*'
+        );
     }
 
     /**

--- a/src/N98/Magento/Command/Composer/RedeployBasePackagesCommand.php
+++ b/src/N98/Magento/Command/Composer/RedeployBasePackagesCommand.php
@@ -138,10 +138,13 @@ class RedeployBasePackagesCommand extends AbstractMagentoCommand
      */
     private function findMagentoComposerInstallerPackage(Composer $composer): ?PackageInterface
     {
-        return $composer->getRepositoryManager()->getLocalRepository()->findPackage(
-            'magento/magento-composer-installer',
-            '*'
-        );
+        foreach ($composer->getRepositoryManager()->getLocalRepository()->getPackages() as $package) {
+            if ($package->getType() === 'composer-plugin' && ($package->getExtra()['class'] ?? null) === Plugin::class) {
+                return $package;
+            }
+        }
+
+        return null;
     }
 
     /**


### PR DESCRIPTION
## Summary

`composer:redeploy-base-packages` regressed in v9.4.0: it now passes the Magento project's own root package (e.g. `vendor/project-name`) as the `$sourcePackage` argument when registering the deploy plugin with Composer's `PluginManager`. Composer checks `$sourcePackage->getName()` against `config.allow-plugins`, so it treats the project's own package name as an unapproved plugin and blocks/prompts for it:

```
In PluginManager.php line 799:
vendor/project-name contains a Composer plugin which is blocked by your allow-plugins config.
```

## Fix

Resolve the actual plugin package (`magento/magento-composer-installer`, which provides `MagentoHackathon\Composer\Magento\Plugin`) from the local repository and pass that as `$sourcePackage` instead — matching how Composer registers plugins internally (`PluginManager::registerPackage()`). This package is already a normal, approved dependency of any Magento 2 project, so no new prompts are introduced.

## Verification

Reproduced and verified the fix against a real Magento 2.4.9 install in this repo's ddev test environment (`/opt/magento-test-environments/magento_2_4_9`):

- With the old code and a non-`magento/*` root package name (simulating a typical customer project name), the command throws the exact reported error.
- With the fix, the command completes successfully.

Fixes #2064