### PR TITLE
Fix MCP proxy commands returning generic bin/magento list

### DIFF
--- a/src/N98/Magento/Mcp/CommandToolHandler.php
+++ b/src/N98/Magento/Mcp/CommandToolHandler.php
@@ -49,7 +49,7 @@ class CommandToolHandler
             $argumentString = '--no-interaction ' . $argumentString;
         }
 
-        $input = new StringInput($argumentString);
+        $input = new StringInput($this->commandName . ' ' . $argumentString);
         $input->setInteractive(false);
 
         $output = new BufferedOutput(OutputInterface::VERBOSITY_NORMAL, false);

--- a/tests/N98/Magento/Mcp/CommandToolHandlerTest.php
+++ b/tests/N98/Magento/Mcp/CommandToolHandlerTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace N98\Magento\Mcp;
+
+use N98\Magento\Application;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class CommandToolHandlerTest extends TestCase
+{
+    public function testInvokePassesCommandNameToInput()
+    {
+        $command = new class('proxy:command') extends Command {
+            /** @var InputInterface|null */
+            public $capturedInput;
+
+            protected function configure(): void
+            {
+                $this->addArgument('foo', InputArgument::OPTIONAL);
+            }
+
+            protected function execute(InputInterface $input, OutputInterface $output): int
+            {
+                $this->capturedInput = $input;
+                $output->writeln((string) $input->getArgument('foo'));
+
+                return 0;
+            }
+        };
+
+        $application = new Application();
+        $application->setAutoExit(false);
+        $application->add($command);
+
+        $handler = new CommandToolHandler($application, 'proxy:command');
+        $result = $handler('bar');
+
+        $this->assertSame('bar', $result);
+        $this->assertNotNull($command->capturedInput);
+        $this->assertSame("'proxy:command' --no-interaction bar", (string) $command->capturedInput);
+    }
+}


### PR DESCRIPTION
## Summary
- `CommandToolHandler::__invoke()` built the `StringInput` passed to the resolved command without including the command name.
- Native commands don't need the command name in the input, but `MagentoCoreProxyCommand::execute()` reconstructs a shell command from `$input->__toString()` to proxy to `bin/magento`. Without the command name, `bin/magento` was invoked with no command argument and fell back to its generic command list.
- Fix prepends `$this->commandName` to the argument string before constructing `StringInput`. This matches Symfony's normal parsing, since `Command::run()` merges the application definition (which expects a leading `command` argument).

Fixes #2074

## Test plan
- [x] Added `tests/N98/Magento/Mcp/CommandToolHandlerTest.php` asserting the resolved command receives its name in `Input::__toString()`
- [x] `vendor/bin/phpunit tests/N98/Magento/Mcp/` passes
- [x] `vendor/bin/phpstan analyse` clean on changed files
- [x] `vendor/bin/php-cs-fixer fix --dry-run` clean