### PR TITLE
feat(console): overhaul command output look and feel

### DIFF
--- a/src/N98/Magento/Application.php
+++ b/src/N98/Magento/Application.php
@@ -11,6 +11,7 @@ namespace N98\Magento;
 use BadMethodCallException;
 use Composer\Autoload\ClassLoader;
 use Exception;
+use Laravel\Prompts\Prompt;
 use Magento\Framework\App\DistributionMetadataInterface;
 use Magento\Framework\App\ProductMetadataInterface;
 use Magento\Framework\Exception\FileSystemException;
@@ -19,6 +20,10 @@ use N98\Magento\Application\ApplicationAwareInterface;
 use N98\Magento\Application\ArgsParser\AddModuleDirOptionParser;
 use N98\Magento\Application\Config;
 use N98\Magento\Application\ConfigurationLoader;
+use N98\Magento\Application\Console\Command\HelpCommand;
+use N98\Magento\Application\Console\Command\ListCommand;
+use N98\Magento\Application\Console\CommandPalette;
+use N98\Magento\Application\Console\ErrorRenderer;
 use N98\Magento\Application\Console\Events;
 use N98\Magento\Application\DetectionResult;
 use N98\Magento\Application\Magento1Initializer;
@@ -28,11 +33,14 @@ use N98\Magento\Application\MagentoDetector;
 use N98\Magento\Command\DummyCommand;
 use N98\Magento\Command\MagentoCoreProxyCommandFactory;
 use N98\Util\Console\Helper\TwigHelper;
+use N98\Util\Console\Theme;
 use Symfony\Component\Console\Application as BaseApplication;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Command\HelpCommand as SymfonyHelpCommand;
+use Symfony\Component\Console\Command\ListCommand as SymfonyListCommand;
 use Symfony\Component\Console\Event\ConsoleEvent;
-use Symfony\Component\Console\Formatter\OutputFormatterStyle;
 use Symfony\Component\Console\Input\ArgvInput;
+use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -142,6 +150,14 @@ class Application extends BaseApplication
     private $isSelfUpdate = false;
 
     /**
+     * @var string|null name of the command currently executing
+     *
+     * Symfony tracks this privately, so it is mirrored here for the error report.
+     * @see renderThrowable()
+     */
+    private $runningCommandName;
+
+    /**
      * @param ClassLoader $autoloader
      */
     public function __construct($autoloader = null)
@@ -187,12 +203,36 @@ class Application extends BaseApplication
      */
     public function getHelp(): string
     {
-        return self::$logo . parent::getHelp();
+        // The banner already ends with the version line that parent::getHelp() would return.
+        return $this->getBanner();
     }
 
     public function getLongVersion()
     {
-        return parent::getLongVersion() . ' (commit: @git_commit_short@) by <info>valantic CEC</info>';
+        return sprintf(
+            '<emphasis>%s</emphasis> <accent>%s</accent> <muted>(commit: @git_commit_short@)</muted> ' .
+            '<muted>by</muted> valantic CEC',
+            $this->getName(),
+            $this->getVersion()
+        );
+    }
+
+    /**
+     * The ASCII logo, tinted and followed by the version line.
+     *
+     * The tag wraps each line individually because a style tag spanning newlines is reset by most
+     * terminals at the line break, which would leave only the first line coloured.
+     */
+    public function getBanner(): string
+    {
+        $lines = explode("\n", trim(self::$logo, "\n"));
+
+        $banner = '';
+        foreach ($lines as $line) {
+            $banner .= sprintf("<accent>%s</accent>\n", $line);
+        }
+
+        return "\n" . $banner . "\n" . $this->getLongVersion() . "\n";
     }
 
     /**
@@ -292,11 +332,49 @@ class Application extends BaseApplication
     public function doRun(InputInterface $input, OutputInterface $output)
     {
         $input = $this->config->checkConfigCommandAlias($input);
+        $input = $this->askForCommand($input, $output);
 
         $event = new ConsoleEvent(new DummyCommand(), $input, $output);
         $this->dispatcher->dispatch($event, Events::RUN_BEFORE);
 
         return parent::doRun($input, $output);
+    }
+
+    /**
+     * Offer the interactive command palette when magerun was started without a command.
+     *
+     * Returns the input unchanged for every invocation the palette does not apply to, so
+     * non-interactive callers keep getting the full `list` output.
+     *
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     *
+     * @return InputInterface
+     */
+    private function askForCommand(InputInterface $input, OutputInterface $output)
+    {
+        $palette = new CommandPalette($this);
+
+        if (!$palette->isApplicable($input, $output)) {
+            return $input;
+        }
+
+        $commandName = $palette->choose($output);
+        CommandPalette::restoreTerminal();
+
+        if ($commandName === null) {
+            // Aborted: fall through to `list` so the user is not left with a blank screen.
+            return $input;
+        }
+
+        $output->writeln('');
+
+        if ($input instanceof ArgvInput) {
+            // Splice the choice into the original argv so global options already typed survive.
+            return $palette->buildInput($_SERVER['argv'] ?? [$this->getName()], $commandName);
+        }
+
+        return new ArrayInput(['command' => $commandName]);
     }
 
     /**
@@ -398,11 +476,14 @@ class Application extends BaseApplication
             $output = new ConsoleOutput();
         }
         $this->_addOutputStyles($output);
-        if ($output instanceof ConsoleOutput) {
-            $this->_addOutputStyles($output->getErrorOutput());
-        }
 
         $this->configureIO($input, $output);
+
+        // laravel/prompts renders to its own global stream by default, which bypasses the
+        // OutputInterface the command was given (and with it --no-ansi, verbosity and any
+        // redirection). Point it at the real output so prompts honour the same rules as
+        // everything else.
+        Prompt::setOutput($output);
 
         try {
             $this->init([], $input, $output);
@@ -428,12 +509,89 @@ class Application extends BaseApplication
     }
 
     /**
+     * Register magerun's semantic output styles on an output and its error stream.
+     *
      * @param OutputInterface $output
      */
     protected function _addOutputStyles(OutputInterface $output)
     {
-        $output->getFormatter()->setStyle('debug', new OutputFormatterStyle('magenta', 'white'));
-        $output->getFormatter()->setStyle('warning', new OutputFormatterStyle('red', 'yellow', ['bold']));
+        Theme::apply($output);
+    }
+
+    /**
+     * Swap Symfony's `help` and `list` for the variants that use magerun's text descriptor.
+     *
+     * @return array<int, Command>
+     */
+    protected function getDefaultCommands(): array
+    {
+        $commands = [];
+
+        foreach (parent::getDefaultCommands() as $command) {
+            if ($command instanceof SymfonyHelpCommand) {
+                $commands[] = new HelpCommand();
+                continue;
+            }
+
+            if ($command instanceof SymfonyListCommand) {
+                $commands[] = new ListCommand();
+                continue;
+            }
+
+            $commands[] = $command;
+        }
+
+        return $commands;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function doRunCommand(Command $command, InputInterface $input, OutputInterface $output)
+    {
+        $this->runningCommandName = $command->getName();
+
+        // Deliberately not cleared in a finally block: when the command throws, the name must
+        // still be set for renderThrowable() to report which command failed.
+        $exitCode = parent::doRunCommand($command, $input, $output);
+
+        $this->runningCommandName = null;
+
+        return $exitCode;
+    }
+
+    /**
+     * Render an uncaught throwable as a compact, actionable report instead of Symfony's
+     * full-width red block.
+     */
+    public function renderThrowable(Throwable $e, OutputInterface $output): void
+    {
+        // Styles are registered in run(), but renderThrowable() is also reachable from callers
+        // that built their own output (and from the init() failure path below).
+        Theme::apply($output);
+
+        (new ErrorRenderer())->render($e, $output, $this->runningCommandName, $this->getAllCommandNames());
+    }
+
+    /**
+     * Every registered command name and alias, used to suggest alternatives for a typo.
+     *
+     * @return array<int, string>
+     */
+    private function getAllCommandNames(): array
+    {
+        $names = [];
+
+        try {
+            foreach ($this->all() as $name => $command) {
+                $names[] = $name;
+            }
+        } catch (Throwable $e) {
+            // Command registration itself may be what failed; suggestions are optional.
+            return [];
+        }
+
+        return $names;
     }
 
     /**

--- a/src/N98/Magento/Application/Console/Command/HelpCommand.php
+++ b/src/N98/Magento/Application/Console/Command/HelpCommand.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * This file is part of the n98-magerun2 project.
+ *
+ * For the full copyright and license information, please view the MIT-LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace N98\Magento\Application\Console\Command;
+
+use N98\Magento\Application\Console\Descriptor\MagerunTextDescriptor;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Command\HelpCommand as BaseHelpCommand;
+use Symfony\Component\Console\Helper\DescriptorHelper;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Symfony's `help` with magerun's text descriptor.
+ *
+ * @see ListCommand for why the command rather than the helper is replaced
+ */
+class HelpCommand extends BaseHelpCommand
+{
+    /**
+     * @var Command|null
+     */
+    private $describedCommand;
+
+    /**
+     * @return void
+     */
+    public function setCommand(Command $command)
+    {
+        $this->describedCommand = $command;
+
+        parent::setCommand($command);
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $this->describedCommand ??= $this->getApplication()->find($input->getArgument('command_name'));
+
+        $helper = new DescriptorHelper();
+        $helper->register('txt', new MagerunTextDescriptor());
+
+        $helper->describe($output, $this->describedCommand, [
+            'format' => $input->getOption('format'),
+            'raw_text' => $input->getOption('raw'),
+        ]);
+
+        $this->describedCommand = null;
+
+        return 0;
+    }
+}

--- a/src/N98/Magento/Application/Console/Command/ListCommand.php
+++ b/src/N98/Magento/Application/Console/Command/ListCommand.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * This file is part of the n98-magerun2 project.
+ *
+ * For the full copyright and license information, please view the MIT-LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace N98\Magento\Application\Console\Command;
+
+use N98\Magento\Application\Console\Descriptor\MagerunTextDescriptor;
+use Symfony\Component\Console\Command\ListCommand as BaseListCommand;
+use Symfony\Component\Console\Helper\DescriptorHelper;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Symfony's `list` with magerun's text descriptor.
+ *
+ * Symfony's ListCommand builds a DescriptorHelper inline rather than resolving one from the helper
+ * set, so replacing the `txt` descriptor means replacing the command. The machine-readable formats
+ * (xml, json, md) keep Symfony's own descriptors.
+ */
+class ListCommand extends BaseListCommand
+{
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $helper = new DescriptorHelper();
+        $helper->register('txt', new MagerunTextDescriptor());
+
+        $helper->describe($output, $this->getApplication(), [
+            'format' => $input->getOption('format'),
+            'raw_text' => $input->getOption('raw'),
+            'namespace' => $input->getArgument('namespace'),
+            'short' => $input->getOption('short'),
+        ]);
+
+        return 0;
+    }
+}

--- a/src/N98/Magento/Application/Console/CommandPalette.php
+++ b/src/N98/Magento/Application/Console/CommandPalette.php
@@ -1,0 +1,203 @@
+<?php
+/**
+ * This file is part of the n98-magerun2 project.
+ *
+ * For the full copyright and license information, please view the MIT-LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace N98\Magento\Application\Console;
+
+use Laravel\Prompts\Prompt;
+use function Laravel\Prompts\search;
+use N98\Util\Console\Interaction;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\ArgvInput;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Throwable;
+
+/**
+ * Fuzzy command finder shown when magerun is started without a command.
+ *
+ * Dumping 200+ commands at someone who typed `n98-magerun2` and pressed enter is not an answer to
+ * the question they were asking. On an interactive terminal they get a search box instead; every
+ * non-interactive caller still gets the full `list` output, unchanged.
+ */
+final class CommandPalette
+{
+    /**
+     * Rows of the result list to keep on screen.
+     */
+    private const SCROLL = 12;
+
+    /**
+     * @var Application
+     */
+    private $application;
+
+    public function __construct(Application $application)
+    {
+        $this->application = $application;
+    }
+
+    /**
+     * Whether the palette should replace the default `list` behaviour for this invocation.
+     */
+    public function isApplicable(InputInterface $input, OutputInterface $output): bool
+    {
+        // Only when no command at all was given - `magerun --root-dir=/x` still lands here.
+        if ($input->getFirstArgument() !== null) {
+            return false;
+        }
+
+        // `--help` and `--version` are handled by Symfony before a command is resolved.
+        if ($input->hasParameterOption(['--help', '-h'], true)
+            || $input->hasParameterOption(['--version', '-V'], true)) {
+            return false;
+        }
+
+        return Interaction::isPromptable($input, $output);
+    }
+
+    /**
+     * Ask the user to pick a command.
+     *
+     * @return string|null the chosen command name, or null if the user aborted
+     */
+    public function choose(OutputInterface $output): ?string
+    {
+        $commands = $this->selectableCommands();
+
+        if ($commands === []) {
+            return null;
+        }
+
+        $output->writeln($this->application->getHelp());
+
+        try {
+            $chosen = search(
+                label: 'Which command do you want to run?',
+                options: fn (string $value): array => $this->match($commands, $value),
+                placeholder: 'Start typing, e.g. cache, db:dump, sys:info',
+                scroll: self::SCROLL,
+                hint: sprintf('%d commands available. Ctrl+C to quit.', count($commands))
+            );
+        } catch (Throwable $e) {
+            // Ctrl+C and a terminal that turns out not to support raw input both land here; either
+            // way, quietly fall back to doing nothing rather than dumping a stack trace.
+            return null;
+        }
+
+        return is_string($chosen) && $chosen !== '' ? $chosen : null;
+    }
+
+    /**
+     * Restore the terminal after the palette so the chosen command starts from a clean state.
+     */
+    public static function restoreTerminal(): void
+    {
+        try {
+            Prompt::terminal()->restoreTty();
+        } catch (Throwable $e) {
+            // Nothing to restore, e.g. when no prompt ever grabbed the terminal.
+        }
+    }
+
+    /**
+     * Insert the chosen command into the original argv so global options the user already typed
+     * are preserved.
+     *
+     * @param array<int, string> $argv
+     */
+    public function buildInput(array $argv, string $commandName): ArgvInput
+    {
+        array_splice($argv, 1, 0, [$commandName]);
+
+        return new ArgvInput($argv, $this->application->getDefinition());
+    }
+
+    /**
+     * @return array<string, string> command name => description
+     */
+    private function selectableCommands(): array
+    {
+        $commands = [];
+
+        foreach ($this->application->all() as $name => $command) {
+            if ($this->isHidden($command, $name)) {
+                continue;
+            }
+
+            $commands[$name] = $command->getDescription();
+        }
+
+        ksort($commands);
+
+        return $commands;
+    }
+
+    private function isHidden(Command $command, string $name): bool
+    {
+        // `all()` is keyed by name *and* alias; keep only the canonical entry.
+        if ($command->getName() !== $name) {
+            return true;
+        }
+
+        if ($command->isHidden() || !$command->isEnabled()) {
+            return true;
+        }
+
+        // Symfony's completion plumbing is not something a human picks from a menu.
+        return in_array($name, ['_complete', 'completion', 'help', 'list'], true);
+    }
+
+    /**
+     * Rank commands against what the user has typed.
+     *
+     * A name match always outranks a description match, so typing "dump" offers `db:dump` before
+     * the commands that merely mention dumping.
+     *
+     * @param array<string, string> $commands
+     * @return array<string, string> command name => label shown in the list
+     */
+    private function match(array $commands, string $value): array
+    {
+        $needle = trim(mb_strtolower($value));
+
+        $nameMatches = [];
+        $descriptionMatches = [];
+
+        foreach ($commands as $name => $description) {
+            $label = $this->label($name, $description);
+
+            if ($needle === '') {
+                $nameMatches[$name] = $label;
+                continue;
+            }
+
+            if (str_contains(mb_strtolower($name), $needle)) {
+                $nameMatches[$name] = $label;
+                continue;
+            }
+
+            if (str_contains(mb_strtolower($description), $needle)) {
+                $descriptionMatches[$name] = $label;
+            }
+        }
+
+        return $nameMatches + $descriptionMatches;
+    }
+
+    private function label(string $name, string $description): string
+    {
+        if ($description === '') {
+            return $name;
+        }
+
+        return sprintf('%s  —  %s', $name, $description);
+    }
+}

--- a/src/N98/Magento/Application/Console/Descriptor/MagerunTextDescriptor.php
+++ b/src/N98/Magento/Application/Console/Descriptor/MagerunTextDescriptor.php
@@ -1,0 +1,328 @@
+<?php
+/**
+ * This file is part of the n98-magerun2 project.
+ *
+ * For the full copyright and license information, please view the MIT-LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace N98\Magento\Application\Console\Descriptor;
+
+use N98\Util\Console\Glyph;
+use N98\Util\Console\Theme;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Descriptor\ApplicationDescription;
+use Symfony\Component\Console\Descriptor\TextDescriptor;
+use Symfony\Component\Console\Formatter\OutputFormatter;
+use Symfony\Component\Console\Helper\Helper;
+use Symfony\Component\Console\Input\InputDefinition;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Renders `list` and `help` in magerun's dense visual language.
+ *
+ * Only the surrounding structure changes - section headings become upper-case rules, namespaces
+ * are indented groups, and descriptions are de-emphasised. Every piece of text Symfony generates
+ * (command synopses, option descriptions, argument defaults) is passed through untouched, because
+ * users and the functional test suite both match on those strings.
+ *
+ * Individual argument and option lines are delegated to the parent so their layout, default-value
+ * rendering and escaping stay in sync with whatever Symfony version is installed.
+ */
+final class MagerunTextDescriptor extends TextDescriptor
+{
+    /**
+     * Extra gap between a name column and its description.
+     */
+    private const COLUMN_GAP = 2;
+
+    /**
+     * @var bool whether the target output can render the redesigned layout
+     */
+    private $styled = false;
+
+    public function describe(OutputInterface $output, object $object, array $options = []): void
+    {
+        // Styles are registered in Application::run(), but a descriptor is also reachable from
+        // callers that built their own output - the command tester, embedded shells. Symfony emits
+        // unregistered tags verbatim, so without this the banner's <emphasis>/<accent> would be
+        // printed as literal text instead of being coloured or stripped.
+        Theme::apply($output);
+
+        $this->styled = $output->isDecorated() && !Theme::colorDisabledByEnvironment();
+
+        parent::describe($output, $object, $options);
+    }
+
+    protected function describeApplication(Application $application, array $options = []): void
+    {
+        if (!$this->styled) {
+            // Piped `list` output is a documented interface - shell completion, scripts and the
+            // functional suite all parse it - so it stays exactly as Symfony renders it.
+            parent::describeApplication($application, $options);
+
+            return;
+        }
+
+        $describedNamespace = $options['namespace'] ?? null;
+        $description = new ApplicationDescription($application, $describedNamespace);
+
+        if ($options['raw_text'] ?? false) {
+            $this->describeApplicationRaw($description, $options);
+
+            return;
+        }
+
+        if ('' !== $help = $application->getHelp()) {
+            $this->writeRaw($help, $options);
+        }
+
+        $this->heading('Usage', null, $options);
+        $this->writeRaw(sprintf(
+            "  %s %s [options] [arguments]\n",
+            $application->getName(),
+            OutputFormatter::escape('<command>')
+        ), $options);
+        $this->writeRaw(sprintf(
+            "  <hint>Run %s help %s for details on a single command.</hint>\n",
+            $application->getName(),
+            OutputFormatter::escape('<command>')
+        ), $options);
+
+        $globalOptions = new InputDefinition($application->getDefinition()->getOptions());
+        if ($globalOptions->getOptions()) {
+            $this->heading('Global options', null, $options);
+            $this->describeOptionList($globalOptions, $options);
+        }
+
+        $this->describeCommandList($description, $describedNamespace, $options);
+    }
+
+    protected function describeCommand(Command $command, array $options = []): void
+    {
+        if (!$this->styled) {
+            parent::describeCommand($command, $options);
+
+            return;
+        }
+
+        $command->mergeApplicationDefinition(false);
+
+        $description = $command->getDescription();
+        if ($description) {
+            $this->heading('Description', null, $options);
+            $this->writeRaw('  ' . $description . "\n", $options);
+        }
+
+        $this->heading('Usage', null, $options);
+        foreach (array_merge([$command->getSynopsis(true)], $command->getAliases(), $command->getUsages()) as $usage) {
+            $this->writeRaw('  ' . OutputFormatter::escape($usage) . "\n", $options);
+        }
+
+        $definition = $command->getDefinition();
+
+        if ($definition->getArguments()) {
+            $this->heading('Arguments', null, $options);
+            $this->describeArgumentList($definition, $options);
+        }
+
+        if ($definition->getOptions()) {
+            $this->heading('Options', null, $options);
+            $this->describeOptionList($definition, $options);
+        }
+
+        $help = $command->getProcessedHelp();
+        if ($help && $help !== $description) {
+            $this->heading('Help', null, $options);
+            $this->writeRaw('  ' . str_replace("\n", "\n  ", $help) . "\n", $options);
+        }
+    }
+
+    /**
+     * `list --raw`: one `name description` line per command and nothing else. Consumed by scripts
+     * and shell completion, so it must stay exactly as Symfony produces it.
+     */
+    private function describeApplicationRaw(ApplicationDescription $description, array $options): void
+    {
+        $commands = $description->getCommands();
+        $width = $this->columnWidth(array_keys($commands));
+
+        foreach ($commands as $command) {
+            $this->writeRaw(
+                sprintf("%-{$width}s %s\n", $command->getName(), $command->getDescription()),
+                $options
+            );
+        }
+    }
+
+    private function describeCommandList(
+        ApplicationDescription $description,
+        ?string $describedNamespace,
+        array $options
+    ): void {
+        $commands = $description->getCommands();
+        $namespaces = $description->getNamespaces();
+
+        if ($describedNamespace && $namespaces) {
+            // Alias-only entries are not in getCommands() but belong to the described namespace.
+            $describedNamespaceInfo = reset($namespaces);
+            foreach ($describedNamespaceInfo['commands'] as $name) {
+                $commands[$name] = $description->getCommand($name);
+            }
+        }
+
+        $listedNames = [];
+        foreach ($namespaces as $namespace) {
+            $listedNames[] = array_intersect($namespace['commands'], array_keys($commands));
+        }
+        $listedNames = $listedNames === [] ? [] : array_merge(...$listedNames);
+
+        // The name column is indented one level deeper inside a namespace group, so budget for it.
+        $width = $this->columnWidth($listedNames) + 2;
+
+        $heading = $describedNamespace === null
+            ? 'Commands'
+            : sprintf('Commands in "%s"', $describedNamespace);
+
+        $this->heading($heading, count($listedNames), $options);
+
+        foreach ($namespaces as $namespace) {
+            $namespace['commands'] = array_filter(
+                $namespace['commands'],
+                static fn ($name) => isset($commands[$name])
+            );
+
+            if (!$namespace['commands']) {
+                continue;
+            }
+
+            $isGrouped = !$describedNamespace && ApplicationDescription::GLOBAL_NAMESPACE !== $namespace['id'];
+
+            if ($isGrouped) {
+                $this->writeRaw(sprintf("\n  <subheading>%s</subheading>\n", $namespace['id']), $options);
+            }
+
+            foreach ($namespace['commands'] as $name) {
+                $command = $commands[$name];
+                $aliases = $name === $command->getName() ? $this->aliasesText($command) : '';
+                $indent = $isGrouped ? '    ' : '  ';
+                $padding = max(1, $width - Helper::width($name) - ($isGrouped ? 2 : 0));
+
+                $this->writeRaw(sprintf(
+                    "%s<accent>%s</accent>%s<muted>%s</muted>\n",
+                    $indent,
+                    $name,
+                    str_repeat(' ', $padding),
+                    $aliases . $command->getDescription()
+                ), $options);
+            }
+        }
+    }
+
+    private function describeArgumentList(InputDefinition $definition, array $options): void
+    {
+        $totalWidth = $this->totalWidth($definition);
+
+        foreach ($definition->getArguments() as $argument) {
+            $this->describeInputArgument($argument, array_merge($options, ['total_width' => $totalWidth]));
+            $this->writeRaw("\n", $options);
+        }
+    }
+
+    private function describeOptionList(InputDefinition $definition, array $options): void
+    {
+        $totalWidth = $this->totalWidth($definition);
+
+        // Symfony lists options with a multi-character shortcut last; keep that ordering.
+        $laterOptions = [];
+
+        foreach ($definition->getOptions() as $option) {
+            if (strlen($option->getShortcut() ?? '') > 1) {
+                $laterOptions[] = $option;
+                continue;
+            }
+
+            $this->describeInputOption($option, array_merge($options, ['total_width' => $totalWidth]));
+            $this->writeRaw("\n", $options);
+        }
+
+        foreach ($laterOptions as $option) {
+            $this->describeInputOption($option, array_merge($options, ['total_width' => $totalWidth]));
+            $this->writeRaw("\n", $options);
+        }
+    }
+
+    /**
+     * Unlike a command's own headings this one keeps an underlining rule: the help page is a wall of
+     * full-width text with no table borders to separate its sections.
+     */
+    private function heading(string $text, ?int $count, array $options): void
+    {
+        $this->writeRaw(sprintf(
+            "\n%s\n<border>%s</border>\n",
+            Theme::headingLine($text, $count),
+            Glyph::repeat(Glyph::LINE, Theme::width())
+        ), $options);
+    }
+
+    /**
+     * @param array<int, string> $names
+     */
+    private function columnWidth(array $names): int
+    {
+        $width = 0;
+
+        foreach ($names as $name) {
+            $width = max($width, Helper::width((string) $name));
+        }
+
+        return $width + self::COLUMN_GAP;
+    }
+
+    /**
+     * Width of the widest argument/option synopsis, which the parent's line renderers pad to.
+     */
+    private function totalWidth(InputDefinition $definition): int
+    {
+        $width = 0;
+
+        foreach ($definition->getArguments() as $argument) {
+            $width = max($width, Helper::width($argument->getName()));
+        }
+
+        foreach ($definition->getOptions() as $option) {
+            $shortcut = $option->getShortcut() ? sprintf('-%s, ', $option->getShortcut()) : '    ';
+            $value = '';
+
+            if ($option->acceptValue()) {
+                $valueName = strtoupper($option->getName());
+                $value = $option->isValueOptional() ? '[=' . $valueName . ']' : '=' . $valueName;
+            }
+
+            $width = max($width, Helper::width($shortcut . '--' . $option->getName() . $value));
+        }
+
+        return $width;
+    }
+
+    private function aliasesText(Command $command): string
+    {
+        $aliases = $command->getAliases();
+
+        return $aliases ? '[' . implode('|', $aliases) . '] ' : '';
+    }
+
+    /**
+     * Honours the same `raw_text` / `raw_output` semantics as the parent descriptor.
+     */
+    private function writeRaw(string $content, array $options = []): void
+    {
+        $this->write(
+            ($options['raw_text'] ?? false) ? strip_tags($content) : $content,
+            isset($options['raw_output']) ? !$options['raw_output'] : true
+        );
+    }
+}

--- a/src/N98/Magento/Application/Console/ErrorRenderer.php
+++ b/src/N98/Magento/Application/Console/ErrorRenderer.php
@@ -1,0 +1,280 @@
+<?php
+/**
+ * This file is part of the n98-magerun2 project.
+ *
+ * For the full copyright and license information, please view the MIT-LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace N98\Magento\Application\Console;
+
+use N98\Util\Console\Glyph;
+use N98\Util\Console\Theme;
+use Symfony\Component\Console\Exception\CommandNotFoundException;
+use Symfony\Component\Console\Exception\RuntimeException as ConsoleRuntimeException;
+use Symfony\Component\Console\Output\OutputInterface;
+use Throwable;
+
+/**
+ * Renders an uncaught throwable as a compact error report.
+ *
+ * Symfony's default renderer draws a full-width red block, which pushes the actual message off to
+ * the side and buries the one thing a user needs: what to do next. This renderer leads with the
+ * message, adds a hint for the failure modes magerun sees most often, and only shows the stack
+ * trace when the user asked for verbose output.
+ */
+final class ErrorRenderer
+{
+    /**
+     * How many alternatives to offer for a mistyped command.
+     */
+    private const MAX_ALTERNATIVES = 5;
+
+    /**
+     * Hints keyed by a pattern matched against the exception message.
+     *
+     * @var array<string, string>
+     */
+    private const HINTS = [
+        '/magento folder could not be detected/i' => 'Run magerun from inside a Magento directory, or point it at one with --root-dir=/path/to/magento',
+        '/must be run from a magento/i' => 'Run magerun from inside a Magento directory, or point it at one with --root-dir=/path/to/magento',
+        '/(app\/etc\/env\.php|env\.php).*(not|missing)/i' => 'This Magento installation has no app/etc/env.php yet - it looks like setup:install has not run.',
+        '/(access denied for user|connection refused|sqlstate\[hy000\] \[10\d\d\])/i' => 'Check the database credentials in app/etc/env.php, and that the database server is reachable.',
+        '/unknown database/i' => 'The database named in app/etc/env.php does not exist. Create it, or fix the db name.',
+        '/area code (is )?not set/i' => 'This command needs a Magento area. Report it if a core magerun command triggers this.',
+        '/is not available because/i' => 'This command is gated behind a capability check - the message above says which one.',
+        '/permission denied/i' => 'Check file ownership and permissions; magerun needs the same access as your web server user.',
+        '/allowed memory size|memory_limit/i' => 'Raise PHP\'s memory limit, e.g. php -d memory_limit=2G $(which n98-magerun2) ...',
+    ];
+
+    /**
+     * @param array<int, string> $allCommandNames used to suggest alternatives for typos
+     */
+    public function render(
+        Throwable $throwable,
+        OutputInterface $output,
+        ?string $commandName = null,
+        array $allCommandNames = []
+    ): void {
+        $width = Theme::width();
+        $decorated = $output->isDecorated() && !Theme::colorDisabledByEnvironment();
+
+        $output->writeln('');
+
+        if ($decorated) {
+            $output->writeln('<failure>ERROR</failure>');
+            $output->writeln(sprintf('<border>%s</border>', Glyph::repeat(Glyph::LINE, $width)));
+        } else {
+            // Keep the historic prefix so scripts grepping for it still match.
+            $output->writeln(sprintf('[%s]', $this->shortClassName($throwable)));
+        }
+
+        foreach ($this->messageLines($throwable, $decorated) as $line) {
+            $output->writeln($decorated ? '  ' . rtrim($line) : $line);
+        }
+
+        if ($decorated) {
+            $this->renderAlternatives($throwable, $output, $allCommandNames);
+        }
+        $this->renderFacts($throwable, $output, $commandName, $decorated);
+        $this->renderHint($throwable, $output, $decorated);
+        $this->renderTrace($throwable, $output, $decorated);
+
+        $output->writeln('');
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function messageLines(Throwable $throwable, bool $decorated): array
+    {
+        $message = trim($throwable->getMessage());
+
+        if ($message === '') {
+            $message = sprintf('%s was thrown with no message.', $this->shortClassName($throwable));
+        }
+
+        // Symfony already appends "Did you mean one of these?" and the list to this exception's
+        // message. Undecorated output keeps it verbatim; decorated output drops it in favour of the
+        // styled block below, which would otherwise repeat the same names twice.
+        if ($decorated && $throwable instanceof CommandNotFoundException) {
+            $message = trim(explode("\n", $message)[0]);
+        }
+
+        return explode("\n", $message);
+    }
+
+    /**
+     * @param array<int, string> $allCommandNames
+     */
+    private function renderAlternatives(
+        Throwable $throwable,
+        OutputInterface $output,
+        array $allCommandNames
+    ): void {
+        $alternatives = $this->findAlternatives($throwable, $allCommandNames);
+
+        if ($alternatives === []) {
+            return;
+        }
+
+        $output->writeln('');
+        $output->writeln('  <term>Did you mean</term>');
+
+        foreach ($alternatives as $alternative) {
+            $output->writeln(sprintf('    <accent>%s</accent>', $alternative));
+        }
+    }
+
+    /**
+     * Alternatives come from Symfony when it recognises a near-miss; otherwise fall back to our
+     * own similarity search so a mistyped namespace still gets suggestions.
+     *
+     * @param array<int, string> $allCommandNames
+     * @return array<int, string>
+     */
+    private function findAlternatives(Throwable $throwable, array $allCommandNames): array
+    {
+        if (!$throwable instanceof CommandNotFoundException) {
+            return [];
+        }
+
+        $alternatives = $throwable->getAlternatives();
+
+        if ($alternatives === [] && $allCommandNames !== []) {
+            $alternatives = $this->guessCommandNames($throwable->getMessage(), $allCommandNames);
+        }
+
+        return array_slice(array_values($alternatives), 0, self::MAX_ALTERNATIVES);
+    }
+
+    /**
+     * @param array<int, string> $allCommandNames
+     * @return array<int, string>
+     */
+    private function guessCommandNames(string $message, array $allCommandNames): array
+    {
+        if (preg_match('/"([^"]+)"/', $message, $matches) !== 1) {
+            return [];
+        }
+
+        $needle = $matches[1];
+        $scored = [];
+
+        foreach ($allCommandNames as $name) {
+            similar_text($needle, $name, $percent);
+
+            if ($percent >= 55.0 || str_contains($name, $needle)) {
+                $scored[$name] = $percent;
+            }
+        }
+
+        arsort($scored);
+
+        return array_keys($scored);
+    }
+
+    private function renderFacts(
+        Throwable $throwable,
+        OutputInterface $output,
+        ?string $commandName,
+        bool $decorated
+    ): void {
+        if (!$decorated) {
+            return;
+        }
+
+        $facts = [];
+
+        if ($commandName !== null && $commandName !== '') {
+            $facts['command'] = $commandName;
+        }
+
+        // A console RuntimeException is a usage error (bad option, missing argument); the class
+        // name adds nothing there. For anything else it tells the user what actually broke.
+        if (!$throwable instanceof ConsoleRuntimeException && !$throwable instanceof CommandNotFoundException) {
+            $facts['exception'] = $this->shortClassName($throwable);
+        }
+
+        if ($output->isVerbose()) {
+            $facts['at'] = sprintf('%s:%d', $throwable->getFile(), $throwable->getLine());
+        }
+
+        if ($facts === []) {
+            return;
+        }
+
+        $output->writeln('');
+
+        $labelWidth = max(array_map('strlen', array_keys($facts)));
+        foreach ($facts as $label => $value) {
+            $output->writeln(sprintf(
+                '  <term>%s</term>  %s',
+                str_pad($label, $labelWidth, ' ', STR_PAD_RIGHT),
+                $value
+            ));
+        }
+    }
+
+    private function renderHint(Throwable $throwable, OutputInterface $output, bool $decorated): void
+    {
+        $hint = $this->findHint($throwable);
+
+        if ($hint === null) {
+            return;
+        }
+
+        $output->writeln('');
+        $output->writeln($decorated ? sprintf('  <hint>%s</hint>', $hint) : $hint);
+    }
+
+    private function findHint(Throwable $throwable): ?string
+    {
+        $message = $throwable->getMessage();
+
+        foreach (self::HINTS as $pattern => $hint) {
+            if (preg_match($pattern, $message) === 1) {
+                return $hint;
+            }
+        }
+
+        return null;
+    }
+
+    private function renderTrace(Throwable $throwable, OutputInterface $output, bool $decorated): void
+    {
+        if (!$output->isVerbose()) {
+            if ($decorated) {
+                $output->writeln('');
+                $output->writeln('  <hint>Re-run with -v for the stack trace.</hint>');
+            }
+
+            return;
+        }
+
+        $current = $throwable;
+        while ($current !== null) {
+            $output->writeln('');
+            $output->writeln($decorated
+                ? sprintf('<border>%s</border>', Glyph::repeat(Glyph::LINE, Theme::width()))
+                : '');
+            $output->writeln(sprintf(
+                '%s: %s',
+                $this->shortClassName($current),
+                trim($current->getMessage())
+            ));
+            $output->writeln($current->getTraceAsString());
+
+            $current = $current->getPrevious();
+        }
+    }
+
+    private function shortClassName(Throwable $throwable): string
+    {
+        $parts = explode('\\', get_class($throwable));
+
+        return (string) end($parts);
+    }
+}

--- a/src/N98/Magento/Command/AbstractMagentoCommand.php
+++ b/src/N98/Magento/Command/AbstractMagentoCommand.php
@@ -16,13 +16,15 @@ use N98\Magento\Application;
 use N98\Magento\Command\SubCommand\ConfigBag;
 use N98\Magento\Command\SubCommand\SubCommandFactory;
 use N98\Util\Console\Helper\InjectionHelper;
+use N98\Util\Console\Helper\Table\Renderer\RendererFactory;
+use N98\Util\Console\MagerunStyle;
 use N98\Util\Console\Prompts\ConfiguresPromptFallbacks;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Exception\RuntimeException;
 use Symfony\Component\Console\Helper\FormatterHelper;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Console\Style\SymfonyStyle;
 
 /**
  * Class AbstractMagentoCommand
@@ -76,19 +78,54 @@ abstract class AbstractMagentoCommand extends Command
     protected $_objectManager = null;
 
     /**
+     * Shared output vocabulary - headings, status lines, tables, progress, prompts.
+     *
+     * Available from initialize() onwards. Prefer this over writing raw markup to $output so every
+     * command speaks the same visual language and gets the plain-output fallbacks for free.
+     *
+     * @var MagerunStyle|null
+     */
+    protected $io = null;
+
+    /**
      * Initializes the command just after the input has been validated.
      *
      * This is mainly useful when a lot of commands extends one main command
      * where some things need to be initialized based on the input arguments and options.
      *
      * @param InputInterface $input An InputInterface instance
-     * @param InputInterface $input An InputInterface instance
      * @param OutputInterface $output An OutputInterface instance
      */
     protected function initialize(InputInterface $input, OutputInterface $output): void
     {
+        $this->io = new MagerunStyle($input, $output);
+
         $this->checkDeprecatedAliases($input, $output);
-        $this->configurePrompts(new SymfonyStyle($input, $output));
+        $this->configurePrompts($this->io);
+    }
+
+    /**
+     * The shared output style, built on demand for the rare caller that runs before initialize()
+     * or that overrides it without chaining to the parent.
+     */
+    protected function io(InputInterface $input, OutputInterface $output): MagerunStyle
+    {
+        return $this->io ??= new MagerunStyle($input, $output);
+    }
+
+    /**
+     * Add the `--format` option every command that renders a table shares.
+     *
+     * @return $this
+     */
+    protected function addFormatOption()
+    {
+        return $this->addOption(
+            'format',
+            null,
+            InputOption::VALUE_OPTIONAL,
+            'Output Format. One of [' . implode(',', RendererFactory::getFormats()) . ']'
+        );
     }
 
     /**
@@ -117,12 +154,30 @@ abstract class AbstractMagentoCommand extends Command
     }
 
     /**
+     * Write the heading that introduces a command's output.
+     *
+     * Delegates to MagerunStyle::heading(), which draws the dense rule on a terminal and reproduces
+     * the historic blue block byte for byte everywhere else - so the ~16 commands calling this get
+     * the new look without a change of their own, and piped output is untouched.
+     *
      * @param OutputInterface $output
      * @param string $text
-     * @param string $style
+     * @param string $style only honoured for the legacy block, i.e. when a caller asked for a
+     *                      colour other than the default
+     * @param int|null $count number of items listed below the heading
      */
-    protected function writeSection(OutputInterface $output, $text, $style = 'bg=blue;fg=white'): void
-    {
+    protected function writeSection(
+        OutputInterface $output,
+        $text,
+        $style = 'bg=blue;fg=white',
+        ?int $count = null
+    ): void {
+        if ($style === 'bg=blue;fg=white' && $this->io !== null && $this->io->getOutput() === $output) {
+            $this->io->heading($text, $count);
+
+            return;
+        }
+
         /** @var $formatter FormatterHelper */
         $formatter = $this->getHelper('formatter');
 

--- a/src/N98/Magento/Command/Admin/User/ListCommand.php
+++ b/src/N98/Magento/Command/Admin/User/ListCommand.php
@@ -8,7 +8,6 @@
 
 namespace N98\Magento\Command\Admin\User;
 
-use N98\Util\Console\Helper\Table\Renderer\RendererFactory;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -21,12 +20,7 @@ class ListCommand extends AbstractAdminUserCommand
         $this
             ->setName('admin:user:list')
             ->setDescription('List admin users.')
-            ->addOption(
-                'format',
-                null,
-                InputOption::VALUE_OPTIONAL,
-                'Output Format. One of [' . implode(',', RendererFactory::getFormats()) . ']'
-            )
+            ->addFormatOption()
             ->addOption(
                 'sort',
                 null,
@@ -152,6 +146,7 @@ class ListCommand extends AbstractAdminUserCommand
         }
 
         $this->getHelper('table')
+            ->setTitle('Admin users')
             ->setHeaders($headers)
             ->renderByFormat($output, $table, $input->getOption('format'));
 

--- a/src/N98/Magento/Command/Cache/DisableCommand.php
+++ b/src/N98/Magento/Command/Cache/DisableCommand.php
@@ -8,9 +8,7 @@
 
 namespace N98\Magento\Command\Cache;
 
-use N98\Util\Console\Helper\Table\Renderer\RendererFactory;
 use Symfony\Component\Console\Input\InputArgument;
-use Symfony\Component\Console\Input\InputOption;
 
 class DisableCommand extends AbstractModifierCommand
 {
@@ -34,11 +32,6 @@ class DisableCommand extends AbstractModifierCommand
                 InputArgument::IS_ARRAY,
                 'Type of cache to disable (separate multiple types with a space)'
             )
-            ->addOption(
-                'format',
-                null,
-                InputOption::VALUE_OPTIONAL,
-                'Output Format. One of [' . implode(',', RendererFactory::getFormats()) . ']'
-            );
+            ->addFormatOption();
     }
 }

--- a/src/N98/Magento/Command/Cache/EnableCommand.php
+++ b/src/N98/Magento/Command/Cache/EnableCommand.php
@@ -8,9 +8,7 @@
 
 namespace N98\Magento\Command\Cache;
 
-use N98\Util\Console\Helper\Table\Renderer\RendererFactory;
 use Symfony\Component\Console\Input\InputArgument;
-use Symfony\Component\Console\Input\InputOption;
 
 class EnableCommand extends AbstractModifierCommand
 {
@@ -34,11 +32,6 @@ class EnableCommand extends AbstractModifierCommand
                 InputArgument::IS_ARRAY,
                 'Type of cache to enable (separate multiple types with a space)'
             )
-            ->addOption(
-                'format',
-                null,
-                InputOption::VALUE_OPTIONAL,
-                'Output Format. One of [' . implode(',', RendererFactory::getFormats()) . ']'
-            );
+            ->addFormatOption();
     }
 }

--- a/src/N98/Magento/Command/Cache/ListCommand.php
+++ b/src/N98/Magento/Command/Cache/ListCommand.php
@@ -10,7 +10,6 @@ namespace N98\Magento\Command\Cache;
 
 use Magento\Framework\App\Cache\TypeList;
 use N98\Magento\Command\AbstractMagentoCommand;
-use N98\Util\Console\Helper\Table\Renderer\RendererFactory;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -42,12 +41,7 @@ class ListCommand extends AbstractMagentoCommand
                 InputOption::VALUE_OPTIONAL,
                 'Filter the list to display only enabled [1] or disabled [0] cache types'
             )
-            ->addOption(
-                'format',
-                null,
-                InputOption::VALUE_OPTIONAL,
-                'Output Format. One of [' . implode(',', RendererFactory::getFormats()) . ']'
-            );
+            ->addFormatOption();
     }
 
     /**

--- a/src/N98/Magento/Command/Cache/ReportCommand.php
+++ b/src/N98/Magento/Command/Cache/ReportCommand.php
@@ -11,7 +11,6 @@ namespace N98\Magento\Command\Cache;
 use Magento\Framework\App\CacheInterface;
 use Magento\PageCache\Model\Cache\Type as FullPageCache;
 use N98\Magento\Command\AbstractMagentoCommand;
-use N98\Util\Console\Helper\Table\Renderer\RendererFactory;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -79,12 +78,7 @@ class ReportCommand extends AbstractMagentoCommand
                 InputOption::VALUE_OPTIONAL,
                 'Filter output by TAG (separate multiple tags by comma)'
             )
-            ->addOption(
-                'format',
-                null,
-                InputOption::VALUE_OPTIONAL,
-                'Output Format. One of [' . implode(', ', RendererFactory::getFormats()) . ']'
-            )
+            ->addFormatOption()
             ->setDescription('View inside the cache');
     }
 

--- a/src/N98/Magento/Command/Config/Data/IndexerCommand.php
+++ b/src/N98/Magento/Command/Config/Data/IndexerCommand.php
@@ -9,7 +9,6 @@
 namespace N98\Magento\Command\Config\Data;
 
 use N98\Magento\Command\AbstractMagentoCommand;
-use N98\Util\Console\Helper\Table\Renderer\RendererFactory;
 use N98\Util\Console\Helper\TreeHelper;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -35,12 +34,7 @@ class IndexerCommand extends AbstractMagentoCommand
                 'global'
             )
             ->addOption('tree', 't', InputOption::VALUE_NONE, 'Show data as tree')
-            ->addOption(
-                'format',
-                null,
-                InputOption::VALUE_OPTIONAL,
-                'Output Format. One of [' . implode(',', RendererFactory::getFormats()) . ']'
-            )
+            ->addFormatOption()
             ->setDescription('Dump merged data of indexer.xml files');
     }
 

--- a/src/N98/Magento/Command/Config/Data/MViewCommand.php
+++ b/src/N98/Magento/Command/Config/Data/MViewCommand.php
@@ -9,7 +9,6 @@
 namespace N98\Magento\Command\Config\Data;
 
 use N98\Magento\Command\AbstractMagentoCommand;
-use N98\Util\Console\Helper\Table\Renderer\RendererFactory;
 use N98\Util\Console\Helper\TreeHelper;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -35,12 +34,7 @@ class MViewCommand extends AbstractMagentoCommand
                 'global'
             )
             ->addOption('tree', 't', InputOption::VALUE_NONE, 'Show data as tree')
-            ->addOption(
-                'format',
-                null,
-                InputOption::VALUE_OPTIONAL,
-                'Output Format. One of [' . implode(',', RendererFactory::getFormats()) . ']'
-            )
+            ->addFormatOption()
             ->setDescription('Dump merged data of mview.xml files');
     }
 

--- a/src/N98/Magento/Command/Config/Env/ShowCommand.php
+++ b/src/N98/Magento/Command/Config/Env/ShowCommand.php
@@ -11,12 +11,10 @@ namespace N98\Magento\Command\Config\Env;
 use Dflydev\DotAccessData\Data;
 use InvalidArgumentException;
 use N98\Magento\Command\AbstractMagentoCommand;
-use N98\Util\Console\Helper\Table\Renderer\RendererFactory;
 use RuntimeException;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\VarDumper\Cloner\VarCloner;
 use Symfony\Component\VarDumper\Dumper\CliDumper;
@@ -33,12 +31,7 @@ class ShowCommand extends AbstractMagentoCommand
             ->setName('config:env:show')
             ->setDescription('List env.php file')
             ->addArgument('key', InputArgument::OPTIONAL, 'Key to show.')
-            ->addOption(
-                'format',
-                null,
-                InputOption::VALUE_OPTIONAL,
-                'Output Format. One of [' . implode(',', RendererFactory::getFormats()) . ']'
-            );
+            ->addFormatOption();
     }
 
     /**
@@ -94,6 +87,7 @@ class ShowCommand extends AbstractMagentoCommand
             }
 
             $this->getHelper('table')
+                ->setTitle('env.php')
                 ->setHeaders(['key', 'value'])
                 ->renderByFormat($output, $table, $input->getOption('format'));
         }

--- a/src/N98/Magento/Command/Config/SearchCommand.php
+++ b/src/N98/Magento/Command/Config/SearchCommand.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 
 namespace N98\Magento\Command\Config;
 
+use function Laravel\Prompts\search;
 use Magento\Config\Model\Config\Structure as ConfigStructure;
 use Magento\Config\Model\Config\Structure\Data as ConfigStructureData;
 use Magento\Config\Model\Config\Structure\Element\AbstractComposite;
@@ -17,15 +18,22 @@ use Magento\Framework\App\Area;
 use Magento\Framework\App\AreaList;
 use Magento\Framework\App\State;
 use Magento\Framework\ObjectManager\ConfigLoaderInterface;
+use N98\Magento\Application\Console\CommandPalette;
 use N98\Magento\Command\AbstractMagentoCommand;
-use N98\Util\Console\Helper\Table\Renderer\RendererFactory;
+use N98\Util\Console\Interaction;
+use Symfony\Component\Console\Exception\RuntimeException;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Throwable;
 
 class SearchCommand extends AbstractMagentoCommand
 {
+    /**
+     * Rows of the result list to keep on screen.
+     */
+    private const SCROLL = 12;
+
     private ConfigStructure $configStructure;
     private ConfigStructureData $configStructureData;
     private array $results = [];
@@ -42,13 +50,8 @@ class SearchCommand extends AbstractMagentoCommand
                 Searches the merged system.xml configuration tree <labels/> and <comments/> for the indicated text.
 EOT
             )
-            ->addOption(
-                'format',
-                null,
-                InputOption::VALUE_OPTIONAL,
-                'Output Format. One of [' . implode(',', RendererFactory::getFormats()) . ']'
-            )
-            ->addArgument('text', InputArgument::REQUIRED, 'The text to search for');
+            ->addFormatOption()
+            ->addArgument('text', InputArgument::OPTIONAL, 'The text to search for');
 
         parent::configure();
     }
@@ -78,10 +81,20 @@ EOT
 
         $this->tabMap = $configData['tabs'];
 
+        $searchTerm = $input->getArgument('text');
+        $interactive = $searchTerm === null;
+
+        if ($interactive && !$this->canBrowse($input, $output)) {
+            // Same message Symfony produced while the argument was still REQUIRED, so scripts that
+            // relied on the failure keep seeing it rather than hanging on a prompt they cannot answer.
+            throw new RuntimeException('Not enough arguments (missing: "text").');
+        }
+
         if (isset($configData['sections'])) {
+            // A null term collects the whole tree, which is what the picker searches through.
             $this->findInStructure(
                 $configData['sections'],
-                $input->getArgument('text'),
+                $searchTerm,
                 ''
             );
         }
@@ -91,7 +104,12 @@ EOT
             return self::SUCCESS;
         }
 
+        if ($interactive) {
+            return $this->browse($output);
+        }
+
         $this->getHelper('table')
+            ->setTitle('Config matches')
             ->setHeaders(array_keys($this->results[0]))
             ->renderByFormat($output, $this->results, $input->getOption('format'));
 
@@ -99,13 +117,133 @@ EOT
     }
 
     /**
+     * Whether the interactive picker can be offered for this invocation.
+     */
+    private function canBrowse(InputInterface $input, OutputInterface $output): bool
+    {
+        // A caller that asked for json/csv/xml wants data, not a prompt.
+        if ($input->getOption('format')) {
+            return false;
+        }
+
+        return Interaction::isPromptable($input, $output);
+    }
+
+    /**
+     * Let the user search the configuration tree as they type and pick a single entry.
+     *
+     * `config:search` exists to answer "where does this setting live?", and a term good enough to
+     * narrow 3000-odd entries to a readable table is usually found by trial and error. Doing that
+     * against a live list is faster than re-running the command with a different word each time.
+     */
+    private function browse(OutputInterface $output): int
+    {
+        // Keyed by config path, which is what search() hands back. It has to be a *non-numeric*
+        // key: PHP turns numeric string keys back into integers, and laravel/prompts returns the
+        // label rather than the key once the option array looks like a plain list.
+        $byPath = [];
+        foreach ($this->results as $result) {
+            if ($result['id'] !== '') {
+                $byPath[$result['id']] = $result;
+            }
+        }
+
+        if ($byPath === []) {
+            $output->writeln('<info>No results found.</info>');
+
+            return self::SUCCESS;
+        }
+
+        try {
+            $chosen = search(
+                label: 'Which setting are you looking for?',
+                options: fn (string $value): array => $this->match($byPath, $value),
+                placeholder: 'Start typing, e.g. base url, robots, cache',
+                scroll: self::SCROLL,
+                hint: sprintf('%d settings available. Ctrl+C to quit.', count($byPath))
+            );
+        } catch (Throwable $e) {
+            // Ctrl+C, and a terminal that turns out not to support raw input, both land here.
+            CommandPalette::restoreTerminal();
+
+            return self::SUCCESS;
+        }
+
+        CommandPalette::restoreTerminal();
+
+        if (!is_string($chosen) || !isset($byPath[$chosen])) {
+            return self::SUCCESS;
+        }
+
+        $result = $byPath[$chosen];
+
+        $this->io->heading('Config match');
+        $this->io->keyValue([
+            'path' => $result['id'],
+            'type' => $result['type'],
+            'name' => self::plainLabel($result['name']),
+        ]);
+        $this->io->hint(sprintf('Read the current value with: config:store:get %s', $result['id']));
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * Rank collected settings against what the user has typed.
+     *
+     * A path match outranks a label match, so typing "base_url" offers `web/unsecure/base_url`
+     * before the settings that merely mention base URLs in their breadcrumb.
+     *
+     * @param array<string, array<string, string>> $byPath
+     * @return array<string, string> config path => label shown in the list
+     */
+    private function match(array $byPath, string $value): array
+    {
+        $needle = trim(mb_strtolower($value));
+
+        $pathMatches = [];
+        $nameMatches = [];
+
+        foreach ($byPath as $path => $result) {
+            if ($needle === '' || str_contains(mb_strtolower($path), $needle)) {
+                $pathMatches[$path] = self::optionLabel($path, $result);
+                continue;
+            }
+
+            if (str_contains(mb_strtolower($result['name']), $needle)) {
+                $nameMatches[$path] = self::optionLabel($path, $result);
+            }
+        }
+
+        return $pathMatches + $nameMatches;
+    }
+
+    /**
+     * @param array<string, string> $result
+     */
+    private static function optionLabel(string $path, array $result): string
+    {
+        return sprintf('%s  —  %s', self::plainLabel($result['name']), $path);
+    }
+
+    /**
+     * Magento's system.xml labels are HTML fragments - "<strong>Get more insights</strong>" and
+     * the like. laravel/prompts writes to the terminal directly rather than through Symfony's
+     * formatter, so the markup would show up as-is in the picker.
+     */
+    private static function plainLabel(string $name): string
+    {
+        return trim(preg_replace('/\s+/u', ' ', strip_tags($name)));
+    }
+
+    /**
      * @param array $elements
-     * @param string $searchTerm
+     * @param string|null $searchTerm null collects every element, for the interactive picker
      * @param string $pathLabel
      */
     private function findInStructure($elements, $searchTerm, $pathLabel = '')
     {
-        if (empty($searchTerm)) {
+        if ($searchTerm !== null && empty($searchTerm)) {
             return;
         }
 
@@ -119,7 +257,8 @@ EOT
                 $structureElement = $this->configStructure->getElement($structureElement['id']);
             }
 
-            if (mb_stripos((string)$structureElement->getLabel(), $searchTerm) !== false
+            if ($searchTerm === null
+                || mb_stripos((string)$structureElement->getLabel(), $searchTerm) !== false
                 || mb_stripos((string)$structureElement->getComment(), $searchTerm) !== false
             ) {
                 $elementData = $structureElement->getData();

--- a/src/N98/Magento/Command/Config/Store/GetCommand.php
+++ b/src/N98/Magento/Command/Config/Store/GetCommand.php
@@ -10,7 +10,6 @@ namespace N98\Magento\Command\Config\Store;
 
 use Magento\Config\Model\ResourceModel\Config\Data\Collection;
 use N98\Magento\Command\Config\AbstractConfigCommand;
-use N98\Util\Console\Helper\Table\Renderer\RendererFactory;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -66,12 +65,7 @@ EOT
             )
             ->addOption('update-script', null, InputOption::VALUE_NONE, 'Output as update script lines')
             ->addOption('magerun-script', null, InputOption::VALUE_NONE, 'Output for usage with config:store:set')
-            ->addOption(
-                'format',
-                null,
-                InputOption::VALUE_OPTIONAL,
-                'Output Format. One of [' . implode(',', RendererFactory::getFormats()) . ']'
-            );
+            ->addFormatOption();
 
         $help = <<<HELP
 If path is not set, all available config items will be listed. path may contain wildcards (*)
@@ -185,6 +179,7 @@ HELP;
         /* @var $tableHelper \N98\Util\Console\Helper\TableHelper */
         $tableHelper = $this->getHelper('table');
         $tableHelper
+            ->setTitle('Config values')
             ->setHeaders(['Path', 'Scope', 'Scope-ID', 'Value', 'Updated At'])
             ->setRows($formattedTable)
             ->renderByFormat($output, $formattedTable, $format);

--- a/src/N98/Magento/Command/Customer/CreateCommand.php
+++ b/src/N98/Magento/Command/Customer/CreateCommand.php
@@ -15,12 +15,10 @@ use Magento\Customer\Api\AccountManagementInterface;
 use Magento\Framework\App\State as AppState;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Theme\Model\View\Design;
-use N98\Util\Console\Helper\Table\Renderer\RendererFactory;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
@@ -49,12 +47,7 @@ class CreateCommand extends AbstractCustomerCommand
             ->addArgument('lastname', InputArgument::OPTIONAL, 'Lastname')
             ->addArgument('website', InputArgument::OPTIONAL, 'Website')
             ->addArgument('additionalFields', InputArgument::IS_ARRAY, 'Additional fields, specifiy as field_name1 value2 field_name2 value2')
-            ->addOption(
-                'format',
-                null,
-                InputOption::VALUE_OPTIONAL,
-                'Output Format. One of [' . implode(',', RendererFactory::getFormats()) . ']'
-            )
+            ->addFormatOption()
             ->setDescription('Creates a new customer/user for shop frontend.');
     }
 

--- a/src/N98/Magento/Command/Customer/ListCommand.php
+++ b/src/N98/Magento/Command/Customer/ListCommand.php
@@ -8,11 +8,9 @@
 
 namespace N98\Magento\Command\Customer;
 
-use N98\Util\Console\Helper\Table\Renderer\RendererFactory;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
@@ -27,12 +25,7 @@ class ListCommand extends AbstractCustomerCommand
             ->setName('customer:list')
             ->setDescription('Lists all magento customers')
             ->addArgument('search', InputArgument::OPTIONAL, 'Search query')
-            ->addOption(
-                'format',
-                null,
-                InputOption::VALUE_OPTIONAL,
-                'Output Format. One of [' . implode(',', RendererFactory::getFormats()) . ']'
-            );
+            ->addFormatOption();
 
         $help = <<<HELP
 Lists all Magento Customers of current installation.
@@ -73,6 +66,7 @@ HELP;
 
         if (count($table) > 0) {
             $helper = $this->getHelper('table');
+            $helper->setTitle('Customers');
             $helper->setHeaders(['id', 'firstname', 'lastname', 'email', 'website', 'created_at']);
             $helper->renderByFormat($output, $table, $input->getOption('format'));
         } else {

--- a/src/N98/Magento/Command/Database/AbstractShowCommand.php
+++ b/src/N98/Magento/Command/Database/AbstractShowCommand.php
@@ -8,7 +8,6 @@
 
 namespace N98\Magento\Command\Database;
 
-use N98\Util\Console\Helper\Table\Renderer\RendererFactory;
 use N98\Util\Filesystem;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
@@ -62,12 +61,7 @@ abstract class AbstractShowCommand extends AbstractDatabaseCommand
                 InputArgument::OPTIONAL,
                 'Only output variables of specified name. The wildcard % is supported!'
             )
-            ->addOption(
-                'format',
-                null,
-                InputOption::VALUE_OPTIONAL,
-                'Output Format. One of [' . implode(',', RendererFactory::getFormats()) . ']'
-            )
+            ->addFormatOption()
             ->addOption(
                 'rounding',
                 null,

--- a/src/N98/Magento/Command/Database/InfoCommand.php
+++ b/src/N98/Magento/Command/Database/InfoCommand.php
@@ -10,11 +10,9 @@ namespace N98\Magento\Command\Database;
 
 use InvalidArgumentException;
 use N98\Util\Console\Helper\DatabaseHelper;
-use N98\Util\Console\Helper\Table\Renderer\RendererFactory;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
@@ -30,12 +28,7 @@ class InfoCommand extends AbstractDatabaseCommand
             ->setName('db:info')
             ->addArgument('setting', InputArgument::OPTIONAL, 'Only output value of named setting')
             ->setDescription('Dumps database informations')
-            ->addOption(
-                'format',
-                null,
-                InputOption::VALUE_OPTIONAL,
-                'Output Format. One of [' . implode(',', RendererFactory::getFormats()) . ']'
-            );
+            ->addFormatOption();
         $this->addDeprecatedAlias('database:info', 'Please use db:info');
 
         $help = <<<HELP
@@ -121,6 +114,7 @@ HELP;
             $output->writeln((string) $settings[$settingArgument]);
         } else {
             $this->getHelper('table')
+                ->setTitle('Database')
                 ->setHeaders(['Name', 'Value'])
                 ->renderByFormat($output, $rows, $input->getOption('format'));
         }

--- a/src/N98/Magento/Command/Database/Maintain/CheckTablesCommand.php
+++ b/src/N98/Magento/Command/Database/Maintain/CheckTablesCommand.php
@@ -8,10 +8,8 @@
 
 namespace N98\Magento\Command\Database\Maintain;
 
-use function Laravel\Prompts\progress;
-use Laravel\Prompts\Progress;
 use N98\Magento\Command\AbstractMagentoCommand;
-use N98\Util\Console\Helper\Table\Renderer\RendererFactory;
+use N98\Util\Console\ProgressFactory;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Input\InputInterface;
@@ -105,12 +103,7 @@ HELP;
                 InputOption::VALUE_OPTIONAL,
                 'Process only given table (wildcards are supported)'
             )
-            ->addOption(
-                'format',
-                null,
-                InputOption::VALUE_OPTIONAL,
-                'Output Format. One of [' . implode(',', RendererFactory::getFormats()) . ']'
-            )
+            ->addFormatOption()
             ->setHelp($help);
     }
 
@@ -128,11 +121,11 @@ HELP;
     }
 
     /**
-     * @param ProgressBar|Progress $progress
+     * @param ProgressBar|null $progress null when progress output is suppressed
      */
-    protected function progressAdvance(ProgressBar|Progress $progress)
+    protected function progressAdvance(?ProgressBar $progress)
     {
-        if ($this->showProgress) {
+        if ($progress !== null) {
             $progress->advance();
         }
     }
@@ -173,14 +166,12 @@ HELP;
 
         $tableOutput = [];
 
-        if ($this->showProgress && $output->isDecorated() && count($tables) > 0) {
-            $progress = progress(label: 'Checking tables', steps: count($tables));
+        // No bar at all when a machine-readable --format was requested; even the label line would
+        // end up in the csv/json the caller is parsing.
+        $progress = null;
+        if ($this->showProgress) {
+            $progress = ProgressFactory::create($output, count($tables), 'Checking tables');
             $progress->start();
-        } else {
-            $progress = new ProgressBar($output, 50);
-            if ($this->showProgress) {
-                $progress->start(count($tables));
-            }
         }
 
         $methods = [
@@ -204,8 +195,9 @@ HELP;
             $this->progressAdvance($progress);
         }
 
-        if ($this->showProgress) {
+        if ($progress !== null) {
             $progress->finish();
+            $output->writeln('');
         }
 
         $this->getHelper('table')

--- a/src/N98/Magento/Command/Developer/Console/ModulesCommand.php
+++ b/src/N98/Magento/Command/Developer/Console/ModulesCommand.php
@@ -48,7 +48,7 @@ class ModulesCommand extends AbstractConsoleCommand
             });
         }
 
-        $output->writeln('<strong>' . implode(PHP_EOL, $modules) . '</strong>');
+        $output->writeln('<emphasis>' . implode(PHP_EOL, $modules) . '</emphasis>');
 
         return Command::SUCCESS;
     }

--- a/src/N98/Magento/Command/Developer/Di/Preference/ListCommand.php
+++ b/src/N98/Magento/Command/Developer/Di/Preference/ListCommand.php
@@ -12,11 +12,9 @@ use Exception;
 use function Laravel\Prompts\select;
 use Magento\Framework\ObjectManager\ConfigLoaderInterface;
 use N98\Magento\Command\AbstractMagentoCommand;
-use N98\Util\Console\Helper\Table\Renderer\RendererFactory;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
@@ -50,12 +48,7 @@ class ListCommand extends AbstractMagentoCommand
                 InputArgument::OPTIONAL,
                 'Filter observers in specific area. One of [' . implode(',', $this->areas) . ']'
             )
-            ->addOption(
-                'format',
-                null,
-                InputOption::VALUE_OPTIONAL,
-                'Output Format. One of [' . implode(',', RendererFactory::getFormats()) . ']'
-            );
+            ->addFormatOption();
     }
 
     protected function interact(InputInterface $input, OutputInterface $output)

--- a/src/N98/Magento/Command/Developer/Log/SizeCommand.php
+++ b/src/N98/Magento/Command/Developer/Log/SizeCommand.php
@@ -11,9 +11,7 @@ namespace N98\Magento\Command\Developer\Log;
 use Magento\Framework\App\Filesystem\DirectoryList;
 use Magento\Framework\Filesystem;
 use N98\Magento\Command\AbstractMagentoCommand;
-use N98\Util\Console\Helper\Table\Renderer\RendererFactory;
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -58,12 +56,7 @@ class SizeCommand extends AbstractMagentoCommand
                 InputOption::VALUE_NONE,
                 'Show file sizes in human readable format'
             )
-            ->addOption(
-                'format',
-                null,
-                InputOption::VALUE_OPTIONAL,
-                'Output Format. One of [' . implode(',', RendererFactory::getFormats()) . ']'
-            )
+            ->addFormatOption()
             ->setHelp(
                 'This command displays the size of all log files in the var/log directory. ' .
                 'Magento 2 has various log files like system.log, debug.log, exception.log, etc.'
@@ -175,24 +168,16 @@ class SizeCommand extends AbstractMagentoCommand
         }
 
         $headers = ['Log File', 'Size', 'Last Modified'];
-        if ($format) {
+        if ($format && empty($rows)) {
             // Ensure header is rendered even if there are no rows
             // (e.g., CSV renderer prints headers only on first row)
-            if (empty($rows)) {
-                $rows[] = array_fill(0, count($headers), '');
-            }
-
-            $this->getHelper('table')
-                ->setHeaders($headers)
-                ->renderByFormat($output, $rows, $format);
-        } else {
-            $table = new Table($output);
-            $table->setHeaders($headers);
-            foreach ($rows as $row) {
-                $table->addRow($row);
-            }
-            $table->render();
+            $rows[] = array_fill(0, count($headers), '');
         }
+
+        $this->getHelper('table')
+            ->setTitle('Log sizes')
+            ->setHeaders($headers)
+            ->renderByFormat($output, $rows, $format);
 
         // Display summary
         $fileCount = count($logFiles);

--- a/src/N98/Magento/Command/Developer/Module/ListCommand.php
+++ b/src/N98/Magento/Command/Developer/Module/ListCommand.php
@@ -11,7 +11,6 @@ namespace N98\Magento\Command\Developer\Module;
 use Magento\Framework\Module\FullModuleList;
 use Magento\Framework\Module\Manager;
 use N98\Magento\Command\AbstractMagentoCommand;
-use N98\Util\Console\Helper\Table\Renderer\RendererFactory;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -69,12 +68,7 @@ class ListCommand extends AbstractMagentoCommand
             ->setDescription('List all installed modules')
             ->addOption('only-enabled', 'e', InputOption::VALUE_NONE, 'Show only enabled modules')
             ->addOption('only-disabled', 'd', InputOption::VALUE_NONE, 'Show only disabled modules')
-            ->addOption(
-                'format',
-                null,
-                InputOption::VALUE_OPTIONAL,
-                'Output Format. One of [' . implode(',', RendererFactory::getFormats()) . ']'
-            );
+            ->addFormatOption();
     }
 
     /**

--- a/src/N98/Magento/Command/Developer/Module/Observer/ListCommand.php
+++ b/src/N98/Magento/Command/Developer/Module/Observer/ListCommand.php
@@ -11,7 +11,6 @@ namespace N98\Magento\Command\Developer\Module\Observer;
 use Exception;
 use function Laravel\Prompts\select;
 use N98\Magento\Command\AbstractMagentoCommand;
-use N98\Util\Console\Helper\Table\Renderer\RendererFactory;
 use Symfony\Component\Console\Helper\TableSeparator;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -56,12 +55,7 @@ class ListCommand extends AbstractMagentoCommand
                 InputArgument::OPTIONAL,
                 'Filter observers in specific area. One of [' . implode(',', $this->areas) . ']'
             )
-            ->addOption(
-                'format',
-                null,
-                InputOption::VALUE_OPTIONAL,
-                'Output Format. One of [' . implode(',', RendererFactory::getFormats()) . ']'
-            )
+            ->addFormatOption()
             ->addOption(
                 'sort',
                 null,

--- a/src/N98/Magento/Command/Developer/Theme/ListCommand.php
+++ b/src/N98/Magento/Command/Developer/Theme/ListCommand.php
@@ -10,10 +10,8 @@ namespace N98\Magento\Command\Developer\Theme;
 
 use Magento\Theme\Model\ResourceModel\Theme\Collection as ThemeCollection;
 use N98\Magento\Command\AbstractMagentoCommand;
-use N98\Util\Console\Helper\Table\Renderer\RendererFactory;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
@@ -32,12 +30,7 @@ class ListCommand extends AbstractMagentoCommand
         $this
             ->setName('dev:theme:list')
             ->setDescription('Lists all available themes')
-            ->addOption(
-                'format',
-                null,
-                InputOption::VALUE_OPTIONAL,
-                'Output Format. One of [' . implode(',', RendererFactory::getFormats()) . ']'
-            );
+            ->addFormatOption();
     }
 
     /**
@@ -74,6 +67,7 @@ class ListCommand extends AbstractMagentoCommand
         }
 
         $this->getHelper('table')
+            ->setTitle('Themes')
             ->setHeaders(['id', 'path', 'title', 'area', 'code'])
             ->renderByFormat($output, $rows, $input->getOption('format'));
 

--- a/src/N98/Magento/Command/Eav/Attribute/ListCommand.php
+++ b/src/N98/Magento/Command/Eav/Attribute/ListCommand.php
@@ -13,7 +13,6 @@ use Magento\Eav\Model\Entity\Type as EntityType;
 use Magento\Eav\Model\ResourceModel\Entity\Attribute\Collection as AttributeCollection;
 use Magento\Eav\Model\ResourceModel\Entity\Type\CollectionFactory as EntityTypeCollectionFactory;
 use N98\Magento\Command\AbstractMagentoCommand;
-use N98\Util\Console\Helper\Table\Renderer\RendererFactory;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -73,12 +72,7 @@ class ListCommand extends AbstractMagentoCommand
                 InputOption::VALUE_OPTIONAL,
                 'Filter attributes by entity type'
             )
-            ->addOption(
-                'format',
-                null,
-                InputOption::VALUE_OPTIONAL,
-                'Output Format. One of [' . implode(',', RendererFactory::getFormats()) . ']'
-            )
+            ->addFormatOption()
             ->setDescription('List EAV attributes');
     }
 
@@ -162,6 +156,7 @@ class ListCommand extends AbstractMagentoCommand
         }
 
         $this->getHelper('table')
+            ->setTitle('EAV attributes')
             ->setHeaders($headers)
             ->renderByFormat($output, $table, $input->getOption('format'));
 

--- a/src/N98/Magento/Command/Eav/Attribute/ViewCommand.php
+++ b/src/N98/Magento/Command/Eav/Attribute/ViewCommand.php
@@ -9,11 +9,9 @@
 namespace N98\Magento\Command\Eav\Attribute;
 
 use InvalidArgumentException;
-use N98\Util\Console\Helper\Table\Renderer\RendererFactory;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
@@ -31,12 +29,7 @@ class ViewCommand extends AbstractAttributeCommand
             ->setName('eav:attribute:view')
             ->addArgument('entityType', InputArgument::REQUIRED, 'Entity Type Code like catalog_product')
             ->addArgument('attributeCode', InputArgument::REQUIRED, 'Attribute Code')
-            ->addOption(
-                'format',
-                null,
-                InputOption::VALUE_OPTIONAL,
-                'Output Format. One of [' . implode(',', RendererFactory::getFormats()) . ']'
-            )
+            ->addFormatOption()
             ->setDescription('View information about an EAV attribute')
             ->setHelp('Enter an entity type code and an attribute code to see information about an EAV attribute.');
     }

--- a/src/N98/Magento/Command/GiftCard/InfoCommand.php
+++ b/src/N98/Magento/Command/GiftCard/InfoCommand.php
@@ -9,10 +9,8 @@
 namespace N98\Magento\Command\GiftCard;
 
 use Magento\GiftCardAccount\Model\Giftcardaccount;
-use N98\Util\Console\Helper\Table\Renderer\RendererFactory;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
@@ -31,12 +29,7 @@ class InfoCommand extends AbstractGiftCardCommand
         $this
             ->setName('giftcard:info')
             ->addArgument('code', \Symfony\Component\Console\Input\InputArgument::REQUIRED, 'Gift card code')
-            ->addOption(
-                'format',
-                null,
-                InputOption::VALUE_OPTIONAL,
-                'Output Format. One of [' . implode(',', RendererFactory::getFormats()) . ']'
-            )
+            ->addFormatOption()
             ->setDescription('Get gift card account information by code');
 
         $help = <<<HELP

--- a/src/N98/Magento/Command/Indexer/ListCommand.php
+++ b/src/N98/Magento/Command/Indexer/ListCommand.php
@@ -8,10 +8,8 @@
 
 namespace N98\Magento\Command\Indexer;
 
-use N98\Util\Console\Helper\Table\Renderer\RendererFactory;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
@@ -25,12 +23,7 @@ class ListCommand extends AbstractIndexerCommand
         $this
             ->setName('index:list')
             ->setDescription('Lists all magento indexes')
-            ->addOption(
-                'format',
-                null,
-                InputOption::VALUE_OPTIONAL,
-                'Output Format. One of [' . implode(',', RendererFactory::getFormats()) . ']'
-            );
+            ->addFormatOption();
 
         $help = <<<HELP
 Lists all Magento indexers of current installation.
@@ -62,6 +55,7 @@ HELP;
         }
 
         $this->getHelper('table')
+            ->setTitle('Indexers')
             ->setHeaders(['code', 'title', 'status', 'last_updated'])
             ->renderByFormat($output, $table, $input->getOption('format'));
 

--- a/src/N98/Magento/Command/Integration/CreateCommand.php
+++ b/src/N98/Magento/Command/Integration/CreateCommand.php
@@ -23,7 +23,6 @@ use Magento\Integration\Model\Oauth\TokenFactory;
 use Magento\Integration\Model\OauthService;
 use Magento\Integration\Model\ResourceModel\Oauth\Consumer;
 use N98\Magento\Command\AbstractMagentoCommand;
-use N98\Util\Console\Helper\Table\Renderer\RendererFactory;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Exception\RuntimeException;
 use Symfony\Component\Console\Input\InputArgument;
@@ -86,12 +85,7 @@ class CreateCommand extends AbstractMagentoCommand
             ->addOption('access-token', '', InputOption::VALUE_REQUIRED, 'Access-Token (length 32 chars)')
             ->addOption('access-token-secret', '', InputOption::VALUE_REQUIRED, 'Access-Token Secret (length 32 chars)')
             ->addOption('resource', 'r', InputOption::VALUE_IS_ARRAY|InputOption::VALUE_REQUIRED, 'Defines a granted ACL resource', [])
-            ->addOption(
-                'format',
-                null,
-                InputOption::VALUE_OPTIONAL,
-                'Output Format. One of [' . implode(',', RendererFactory::getFormats()) . ']'
-            )
+            ->addFormatOption()
             ->setDescription('Create a new integration');
 
         $help = <<<HELP

--- a/src/N98/Magento/Command/Integration/ListCommand.php
+++ b/src/N98/Magento/Command/Integration/ListCommand.php
@@ -11,10 +11,8 @@ namespace N98\Magento\Command\Integration;
 use Magento\Integration\Model\Integration;
 use Magento\Integration\Model\ResourceModel\Integration\Collection;
 use N98\Magento\Command\AbstractMagentoCommand;
-use N98\Util\Console\Helper\Table\Renderer\RendererFactory;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
@@ -48,12 +46,7 @@ class ListCommand extends AbstractMagentoCommand
         $this
             ->setName('integration:list')
             ->setDescription('List all existing integrations.')
-            ->addOption(
-                'format',
-                null,
-                InputOption::VALUE_OPTIONAL,
-                'Output Format. One of [' . implode(',', RendererFactory::getFormats()) . ']'
-            );
+            ->addFormatOption();
     }
 
     public function inject(
@@ -103,6 +96,7 @@ class ListCommand extends AbstractMagentoCommand
         }
 
         $this->getHelper('table')
+            ->setTitle('Integrations')
             ->setHeaders(['id', 'name', 'email', 'endpoint', 'type', 'status'])
             ->renderByFormat($output, $table, $input->getOption('format'));
 

--- a/src/N98/Magento/Command/Integration/ShowCommand.php
+++ b/src/N98/Magento/Command/Integration/ShowCommand.php
@@ -13,12 +13,10 @@ use Magento\Integration\Model\IntegrationService;
 use Magento\Integration\Model\Oauth\TokenFactory;
 use Magento\Integration\Model\OauthService;
 use N98\Magento\Command\AbstractMagentoCommand;
-use N98\Util\Console\Helper\Table\Renderer\RendererFactory;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Exception\RuntimeException;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
@@ -60,12 +58,7 @@ class ShowCommand extends AbstractMagentoCommand
                 InputArgument::OPTIONAL,
                 'Only output value of named param like "Access Token". Key is case insensitive.'
             )
-            ->addOption(
-                'format',
-                null,
-                InputOption::VALUE_OPTIONAL,
-                'Output Format. One of [' . implode(',', RendererFactory::getFormats()) . ']'
-            );
+            ->addFormatOption();
     }
 
     public function inject(

--- a/src/N98/Magento/Command/Magerun/ConfigInfoCommand.php
+++ b/src/N98/Magento/Command/Magerun/ConfigInfoCommand.php
@@ -12,10 +12,8 @@ namespace N98\Magento\Command\Magerun;
 
 use N98\Magento\Application\ConfigInfo;
 use N98\Magento\Command\AbstractMagentoCommand;
-use N98\Util\Console\Helper\Table\Renderer\RendererFactory;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class ConfigInfoCommand extends AbstractMagentoCommand
@@ -25,12 +23,7 @@ class ConfigInfoCommand extends AbstractMagentoCommand
         $this
             ->setName('magerun:config:info')
             ->setDescription('Prints infos about the loaded config files')
-            ->addOption(
-                'format',
-                null,
-                InputOption::VALUE_OPTIONAL,
-                'Output Format. One of [' . implode(',', RendererFactory::getFormats()) . ']'
-            );
+            ->addFormatOption();
     }
 
     public function execute(InputInterface $input, OutputInterface $output)
@@ -47,6 +40,7 @@ class ConfigInfoCommand extends AbstractMagentoCommand
         }
 
         $this->getHelper('table')
+            ->setTitle('Magerun config')
             ->setHeaders(['type', 'path', 'note'])
             ->renderByFormat($output, $table, $input->getOption('format'));
 

--- a/src/N98/Magento/Command/Route/ListCommand.php
+++ b/src/N98/Magento/Command/Route/ListCommand.php
@@ -22,7 +22,6 @@ use Magento\Framework\App\AreaList;
 use Magento\Framework\App\Route\Config;
 use Magento\Framework\Module\Dir\Reader;
 use N98\Magento\Command\AbstractMagentoCommand;
-use N98\Util\Console\Helper\Table\Renderer\RendererFactory;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -65,12 +64,7 @@ class ListCommand extends AbstractMagentoCommand
                 'm',
                 InputOption::VALUE_OPTIONAL,
                 'Show registered routes of a module'
-            )->addOption(
-                'format',
-                null,
-                InputOption::VALUE_OPTIONAL,
-                'Output Format. One of [' . implode(',', RendererFactory::getFormats()) . ']'
-            );
+            )->addFormatOption();
     }
 
     /**
@@ -154,6 +148,7 @@ class ListCommand extends AbstractMagentoCommand
         }
 
         $this->getHelper('table')
+            ->setTitle('Routes')
             ->setHeaders(
                 [
                     'Area',

--- a/src/N98/Magento/Command/Script/Repository/ListCommand.php
+++ b/src/N98/Magento/Command/Script/Repository/ListCommand.php
@@ -8,10 +8,8 @@
 
 namespace N98\Magento\Command\Script\Repository;
 
-use N98\Util\Console\Helper\Table\Renderer\RendererFactory;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
@@ -25,12 +23,7 @@ class ListCommand extends AbstractRepositoryCommand
         $this
             ->setName('script:repo:list')
             ->setDescription('Lists all scripts in repository')
-            ->addOption(
-                'format',
-                null,
-                InputOption::VALUE_OPTIONAL,
-                'Output Format. One of [' . implode(',', RendererFactory::getFormats()) . ']'
-            );
+            ->addFormatOption();
 
         $help = <<<HELP
 You can organize your scripts in a repository.
@@ -74,6 +67,7 @@ HELP;
         }
 
         $this->getHelper('table')
+            ->setTitle('Scripts')
             ->setHeaders(['Script', 'Location', 'Description'])
             ->renderByFormat($output, $table, $input->getOption('format'));
 

--- a/src/N98/Magento/Command/SearchEngine/ListCommand.php
+++ b/src/N98/Magento/Command/SearchEngine/ListCommand.php
@@ -9,10 +9,8 @@
 namespace N98\Magento\Command\SearchEngine;
 
 use N98\Magento\Command\AbstractMagentoCommand;
-use N98\Util\Console\Helper\Table\Renderer\RendererFactory;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
@@ -31,12 +29,7 @@ class ListCommand extends AbstractMagentoCommand
         $this
             ->setName('search:engine:list')
             ->setDescription('Lists all registered search engines')
-            ->addOption(
-                'format',
-                null,
-                InputOption::VALUE_OPTIONAL,
-                'Output Format. One of [' . implode(',', RendererFactory::getFormats()) . ']'
-            );
+            ->addFormatOption();
     }
 
     /**
@@ -76,6 +69,7 @@ class ListCommand extends AbstractMagentoCommand
         }
 
         $this->getHelper('table')
+            ->setTitle('Search engines')
             ->setHeaders(['code', 'label'])
             ->renderByFormat($output, $table, $input->getOption('format'));
 

--- a/src/N98/Magento/Command/SelfUpdateCommand.php
+++ b/src/N98/Magento/Command/SelfUpdateCommand.php
@@ -9,8 +9,7 @@
 namespace N98\Magento\Command;
 
 use Exception;
-use function Laravel\Prompts\progress;
-use Laravel\Prompts\Progress;
+use N98\Util\Console\ProgressFactory;
 use N98\Util\Markdown\VersionFilePrinter;
 use Phar;
 use PharException;
@@ -359,23 +358,10 @@ EOT
     /**
      * Create a progress bar for the download.
      */
-    private function createProgressBar(OutputInterface $output, int $filesize): ProgressBar|Progress
+    private function createProgressBar(OutputInterface $output, int $filesize): ProgressBar
     {
-        if ($output->isDecorated() && $filesize > 0) {
-            $progress = progress(label: 'Downloading', steps: $filesize);
-            $progress->start();
-
-            return $progress;
-        }
-
-        $progress = new ProgressBar($output);
-        if ($filesize > 0) {
-            $progress->setFormat('[%bar%] %current%/%max% bytes %percent:3s%% %elapsed:6s%/%estimated:-6s%');
-            $progress->start($filesize);
-        } else {
-            $progress->setFormat('[%bar%] %current% bytes downloaded');
-            $progress->start(0);
-        }
+        $progress = ProgressFactory::create($output, $filesize, 'Downloading');
+        $progress->start();
 
         return $progress;
     }
@@ -397,18 +383,15 @@ EOT
     /**
      * Perform the download using the prepared options.
      */
-    private function performDownload(string $remoteUrl, string $tempFilename, ProgressBar|Progress $progress, array $requestOpts)
+    private function performDownload(string $remoteUrl, string $tempFilename, ProgressBar $progress, array $requestOpts)
     {
         // Create a hooks instance for progress reporting
         $hooks = new Hooks();
 
         // Register a progress callback
+        // Bytes, not steps: the bar was created with the content-length as its maximum.
         $hooks->register('request.progress', function ($data, $bytes_so_far, $bytes_limit) use ($progress) {
-            if ($progress instanceof Progress) {
-                $progress->advance($bytes_so_far - $progress->progress);
-            } elseif ($progress->getMaxSteps() > 0) {
-                $progress->setProgress($bytes_so_far);
-            }
+            $progress->setProgress($bytes_so_far);
         });
 
         // Prepare options for the request
@@ -449,7 +432,7 @@ EOT
         int $maxRetries,
         int $retryDelaySeconds,
         string $tempFilename,
-        ProgressBar|Progress $progress
+        ProgressBar $progress
     ) {
         $progress->finish();
         $output->writeln('');

--- a/src/N98/Magento/Command/System/CheckCommand.php
+++ b/src/N98/Magento/Command/System/CheckCommand.php
@@ -18,11 +18,9 @@ use N98\Magento\Command\System\Check\Result;
 use N98\Magento\Command\System\Check\ResultCollection;
 use N98\Magento\Framework\AreaAware;
 use N98\Util\Console\Helper\InjectionHelper;
-use N98\Util\Console\Helper\Table\Renderer\RendererFactory;
 use N98\Util\Unicode\Charset;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
@@ -59,12 +57,7 @@ class CheckCommand extends AbstractMagentoCommand
         $this
             ->setName('sys:check')
             ->setDescription('Checks Magento System')
-            ->addOption(
-                'format',
-                null,
-                InputOption::VALUE_OPTIONAL,
-                'Output Format. One of [' . implode(',', RendererFactory::getFormats()) . ']'
-            );
+            ->addFormatOption();
 
         $help = <<<HELP
 - Checks missing files and folders

--- a/src/N98/Magento/Command/System/Cron/HistoryCommand.php
+++ b/src/N98/Magento/Command/System/Cron/HistoryCommand.php
@@ -9,7 +9,6 @@
 namespace N98\Magento\Command\System\Cron;
 
 use Magento\Cron\Model\Schedule;
-use N98\Util\Console\Helper\Table\Renderer\RendererFactory;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -32,12 +31,7 @@ class HistoryCommand extends AbstractCronCommand
                 InputOption::VALUE_OPTIONAL,
                 'Timezone to show finished at in'
             )
-            ->addOption(
-                'format',
-                null,
-                InputOption::VALUE_OPTIONAL,
-                'Output Format. One of [' . implode(',', RendererFactory::getFormats()) . ']'
-            );
+            ->addFormatOption();
     }
 
     /**

--- a/src/N98/Magento/Command/System/Cron/ListCommand.php
+++ b/src/N98/Magento/Command/System/Cron/ListCommand.php
@@ -10,11 +10,9 @@ namespace N98\Magento\Command\System\Cron;
 
 use Magento\Framework\App\Area;
 use Magento\Framework\App\AreaList;
-use N98\Util\Console\Helper\Table\Renderer\RendererFactory;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
@@ -33,12 +31,7 @@ class ListCommand extends AbstractCronCommand
                 InputArgument::OPTIONAL,
                 'Filter by job name. Wildcards with * are allowed.'
             )
-            ->addOption(
-                'format',
-                null,
-                InputOption::VALUE_OPTIONAL,
-                'Output Format. One of [' . implode(',', RendererFactory::getFormats()) . ']'
-            );
+            ->addFormatOption();
     }
 
     /**

--- a/src/N98/Magento/Command/System/InfoCommand.php
+++ b/src/N98/Magento/Command/System/InfoCommand.php
@@ -23,7 +23,6 @@ use Magento\Framework\App\State as AppState;
 use Magento\Framework\Module\ModuleListInterface;
 use Magento\User\Model\ResourceModel\User\CollectionFactory;
 use N98\Magento\Command\AbstractMagentoCommand;
-use N98\Util\Console\Helper\Table\Renderer\RendererFactory;
 use N98\Util\ProjectComposer;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
@@ -103,12 +102,7 @@ class InfoCommand extends AbstractMagentoCommand
                 'Only output value of named param like "version". Key is case insensitive.'
             )
             ->addOption('sort', '', InputOption::VALUE_NONE, 'Sort by name')
-            ->addOption(
-                'format',
-                null,
-                InputOption::VALUE_OPTIONAL,
-                'Output Format. One of [' . implode(',', RendererFactory::getFormats()) . ']'
-            );
+            ->addFormatOption();
     }
 
     /**

--- a/src/N98/Magento/Command/System/Setup/CompareVersionsCommand.php
+++ b/src/N98/Magento/Command/System/Setup/CompareVersionsCommand.php
@@ -15,7 +15,6 @@
 namespace N98\Magento\Command\System\Setup;
 
 use N98\Util\ArrayFunctions;
-use N98\Util\Console\Helper\Table\Renderer\RendererFactory;
 use N98\Util\Console\Helper\TableHelper;
 use N98\Util\JUnitSession;
 use Symfony\Component\Console\Input\InputInterface;
@@ -37,12 +36,7 @@ class CompareVersionsCommand extends AbstractSetupCommand
             ->setName('sys:setup:compare-versions')
             ->addOption('ignore-data', null, InputOption::VALUE_NONE, 'Ignore data updates')
             ->addOption('log-junit', null, InputOption::VALUE_REQUIRED, 'Log output to a JUnit xml file.')
-            ->addOption(
-                'format',
-                null,
-                InputOption::VALUE_OPTIONAL,
-                'Output Format. One of [' . implode(',', RendererFactory::getFormats()) . ']'
-            )
+            ->addFormatOption()
             ->setDescription('Compare module version with setup_module table.');
         $help = <<<HELP
 Compares module version with saved setup version in `setup_module` table and displays version mismatch.

--- a/src/N98/Magento/Command/System/Store/Config/BaseUrlListCommand.php
+++ b/src/N98/Magento/Command/System/Store/Config/BaseUrlListCommand.php
@@ -15,7 +15,6 @@ use Magento\Framework\UrlInterface;
 use Magento\Store\Model\Store;
 use Magento\Store\Model\StoreManagerInterface;
 use N98\Magento\Command\AbstractMagentoCommand;
-use N98\Util\Console\Helper\Table\Renderer\RendererFactory;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -44,12 +43,7 @@ class BaseUrlListCommand extends AbstractMagentoCommand
             ->setDescription('Lists all base urls')
             ->addOption('with-admin-store', null, InputOption::VALUE_NONE, 'Include admin store')
             ->addOption('with-admin-login-url', null, InputOption::VALUE_NONE, 'Include admin login url')
-            ->addOption(
-                'format',
-                null,
-                InputOption::VALUE_OPTIONAL,
-                'Output Format. One of [' . implode(',', RendererFactory::getFormats()) . ']'
-            );
+            ->addFormatOption();
     }
 
     /**

--- a/src/N98/Magento/Command/System/Store/ListCommand.php
+++ b/src/N98/Magento/Command/System/Store/ListCommand.php
@@ -9,10 +9,8 @@
 namespace N98\Magento\Command\System\Store;
 
 use N98\Magento\Command\AbstractMagentoCommand;
-use N98\Util\Console\Helper\Table\Renderer\RendererFactory;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
@@ -31,12 +29,7 @@ class ListCommand extends AbstractMagentoCommand
         $this
             ->setName('sys:store:list')
             ->setDescription('Lists all installed store-views')
-            ->addOption(
-                'format',
-                null,
-                InputOption::VALUE_OPTIONAL,
-                'Output Format. One of [' . implode(',', RendererFactory::getFormats()) . ']'
-            );
+            ->addFormatOption();
     }
 
     /**
@@ -74,6 +67,7 @@ class ListCommand extends AbstractMagentoCommand
         $format = $input->getOption('format');
 
         $this->getHelper('table')
+            ->setTitle('Stores')
             ->setHeaders(['id', 'website_id', 'group_id', 'name', 'code', 'sort_order', 'is_active'])
             ->renderByFormat($output, $table, $format);
 

--- a/src/N98/Magento/Command/System/Url/Generator/AbstractGenerator.php
+++ b/src/N98/Magento/Command/System/Url/Generator/AbstractGenerator.php
@@ -8,10 +8,9 @@
 
 namespace N98\Magento\Command\System\Url\Generator;
 
-use function Laravel\Prompts\progress;
-use Laravel\Prompts\Progress;
 use Magento\Store\Model\StoreManagerInterface;
 use Magento\UrlRewrite\Model\UrlPersistInterface;
+use N98\Util\Console\ProgressFactory;
 use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -33,7 +32,7 @@ abstract class AbstractGenerator implements GeneratorInterface
     protected $batchSize = 100;
 
     /**
-     * @var ProgressBar|Progress
+     * @var ProgressBar
      */
     protected $progressBar;
 
@@ -90,19 +89,12 @@ abstract class AbstractGenerator implements GeneratorInterface
      * @param OutputInterface $output
      * @param int $max
      * @param string $label
-     * @return ProgressBar|Progress
+     * @return ProgressBar
      */
-    protected function createProgressBar(OutputInterface $output, int $max, string $label = ''): ProgressBar|Progress
+    protected function createProgressBar(OutputInterface $output, int $max, string $label = ''): ProgressBar
     {
-        if ($output->isDecorated() && $max > 0) {
-            $this->progressBar = progress(label: $label, steps: $max);
-            return $this->progressBar;
-        }
+        $this->progressBar = ProgressFactory::create($output, $max, $label);
 
-        $this->progressBar = new ProgressBar($output, $max);
-        $this->progressBar->setFormat(
-            '%current%/%max% [%bar%] %percent:3s%% %elapsed:6s%/%estimated:-6s% %memory:6s%'
-        );
         return $this->progressBar;
     }
 

--- a/src/N98/Magento/Command/System/Website/ListCommand.php
+++ b/src/N98/Magento/Command/System/Website/ListCommand.php
@@ -9,10 +9,8 @@
 namespace N98\Magento\Command\System\Website;
 
 use N98\Magento\Command\AbstractMagentoCommand;
-use N98\Util\Console\Helper\Table\Renderer\RendererFactory;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
@@ -31,12 +29,7 @@ class ListCommand extends AbstractMagentoCommand
         $this
             ->setName('sys:website:list')
             ->setDescription('Lists all websites')
-            ->addOption(
-                'format',
-                null,
-                InputOption::VALUE_OPTIONAL,
-                'Output Format. One of [' . implode(',', RendererFactory::getFormats()) . ']'
-            );
+            ->addFormatOption();
     }
 
     /**

--- a/src/N98/Util/Console/Glyph.php
+++ b/src/N98/Util/Console/Glyph.php
@@ -1,0 +1,152 @@
+<?php
+/**
+ * This file is part of the n98-magerun2 project.
+ *
+ * For the full copyright and license information, please view the MIT-LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace N98\Util\Console;
+
+use N98\Util\OperatingSystem;
+
+/**
+ * Terminal glyphs with an ASCII fallback.
+ *
+ * Every symbol the UI draws goes through here so a terminal that cannot render the
+ * box-drawing and symbol blocks (legacy Windows consoles, non-UTF-8 locales, TERM=dumb)
+ * still produces readable output instead of mojibake.
+ */
+final class Glyph
+{
+    public const OK = 'ok';
+    public const ERROR = 'error';
+    public const WARNING = 'warning';
+    public const INFO = 'info';
+    public const PENDING = 'pending';
+    public const BULLET = 'bullet';
+    public const ARROW = 'arrow';
+    public const POINTER = 'pointer';
+    public const ELLIPSIS = 'ellipsis';
+
+    public const LINE = 'line';
+    public const LINE_HEAVY = 'line-heavy';
+    public const VERTICAL = 'vertical';
+    public const TOP_LEFT = 'top-left';
+    public const TOP_MID = 'top-mid';
+    public const TOP_RIGHT = 'top-right';
+    public const MID_LEFT = 'mid-left';
+    public const CROSS = 'cross';
+    public const MID_RIGHT = 'mid-right';
+    public const BOTTOM_LEFT = 'bottom-left';
+    public const BOTTOM_MID = 'bottom-mid';
+    public const BOTTOM_RIGHT = 'bottom-right';
+
+    /**
+     * @var array<string, array{0: string, 1: string}> glyph name => [unicode, ascii]
+     */
+    private const GLYPHS = [
+        self::OK => ["\u{2713}", '+'],
+        self::ERROR => ["\u{2717}", 'x'],
+        self::WARNING => ["\u{25B2}", '!'],
+        self::INFO => ["\u{2022}", '-'],
+        self::PENDING => ["\u{25CB}", 'o'],
+        self::BULLET => ["\u{2022}", '*'],
+        self::ARROW => ["\u{2192}", '->'],
+        self::POINTER => ["\u{276F}", '>'],
+        self::ELLIPSIS => ["\u{2026}", '...'],
+
+        self::LINE => ["\u{2500}", '-'],
+        self::LINE_HEAVY => ["\u{2501}", '='],
+        self::VERTICAL => ["\u{2502}", '|'],
+        self::TOP_LEFT => ["\u{250C}", '+'],
+        self::TOP_MID => ["\u{252C}", '+'],
+        self::TOP_RIGHT => ["\u{2510}", '+'],
+        self::MID_LEFT => ["\u{251C}", '+'],
+        self::CROSS => ["\u{253C}", '+'],
+        self::MID_RIGHT => ["\u{2524}", '+'],
+        self::BOTTOM_LEFT => ["\u{2514}", '+'],
+        self::BOTTOM_MID => ["\u{2534}", '+'],
+        self::BOTTOM_RIGHT => ["\u{2518}", '+'],
+    ];
+
+    /**
+     * @var bool|null cached capability, null until first probe
+     */
+    private static $unicodeSupported = null;
+
+    /**
+     * Resolve a glyph for the current terminal.
+     */
+    public static function get(string $name): string
+    {
+        if (!isset(self::GLYPHS[$name])) {
+            return '';
+        }
+
+        return self::GLYPHS[$name][self::supportsUnicode() ? 0 : 1];
+    }
+
+    /**
+     * Repeat a glyph, e.g. to draw a horizontal rule.
+     */
+    public static function repeat(string $name, int $times): string
+    {
+        return $times > 0 ? str_repeat(self::get($name), $times) : '';
+    }
+
+    /**
+     * True when the terminal can render the box-drawing and symbol blocks.
+     *
+     * Windows Terminal and ConEmu handle UTF-8 fine; the legacy conhost cannot, and there is no
+     * reliable probe for which one is attached, so Windows only opts in when it advertises itself.
+     */
+    public static function supportsUnicode(): bool
+    {
+        if (self::$unicodeSupported !== null) {
+            return self::$unicodeSupported;
+        }
+
+        return self::$unicodeSupported = self::probeUnicodeSupport();
+    }
+
+    /**
+     * Force the capability, or pass null to re-probe. Intended for tests.
+     */
+    public static function setUnicodeSupported(?bool $supported): void
+    {
+        self::$unicodeSupported = $supported;
+    }
+
+    private static function probeUnicodeSupport(): bool
+    {
+        if (getenv('MAGERUN_ASCII') !== false) {
+            return false;
+        }
+
+        if (getenv('TERM') === 'dumb') {
+            return false;
+        }
+
+        if (OperatingSystem::isWindows()) {
+            return getenv('WT_SESSION') !== false
+                || getenv('ConEmuANSI') === 'ON'
+                || getenv('TERM_PROGRAM') === 'vscode';
+        }
+
+        foreach (['LC_ALL', 'LC_CTYPE', 'LANG'] as $variable) {
+            $value = getenv($variable);
+            if ($value === false || $value === '') {
+                continue;
+            }
+
+            return stripos($value, 'utf-8') !== false || stripos($value, 'utf8') !== false;
+        }
+
+        // No locale advertised at all. Modern terminals are UTF-8 by default and macOS ships
+        // without LANG set in non-login shells, so assume support rather than degrading everyone.
+        return true;
+    }
+}

--- a/src/N98/Util/Console/Helper/Table/Renderer/JsonArrayRenderer.php
+++ b/src/N98/Util/Console/Helper/Table/Renderer/JsonArrayRenderer.php
@@ -23,6 +23,11 @@ class JsonArrayRenderer implements RendererInterface
     public function render(OutputInterface $output, array $rows)
     {
         $rows = array_values($rows);
-        $output->writeln(\json_encode($rows, JSON_THROW_ON_ERROR | \JSON_PRETTY_PRINT));
+        // Raw, so a cell value that looks like markup keeps its angle brackets instead of being
+        // run through the output formatter and having "tags" stripped out of the document.
+        $output->writeln(
+            \json_encode($rows, JSON_THROW_ON_ERROR | \JSON_PRETTY_PRINT),
+            OutputInterface::OUTPUT_RAW
+        );
     }
 }

--- a/src/N98/Util/Console/Helper/Table/Renderer/JsonRenderer.php
+++ b/src/N98/Util/Console/Helper/Table/Renderer/JsonRenderer.php
@@ -27,6 +27,8 @@ class JsonRenderer implements RendererInterface
             $options |= \JSON_PRETTY_PRINT;
         }
 
-        $output->writeln(\json_encode($rows, $options));
+        // Raw, so a cell value that looks like markup keeps its angle brackets instead of being
+        // run through the output formatter and having "tags" stripped out of the document.
+        $output->writeln(\json_encode($rows, $options), OutputInterface::OUTPUT_RAW);
     }
 }

--- a/src/N98/Util/Console/Helper/Table/Renderer/XmlRenderer.php
+++ b/src/N98/Util/Console/Helper/Table/Renderer/XmlRenderer.php
@@ -8,6 +8,7 @@
 
 namespace N98\Util\Console\Helper\Table\Renderer;
 
+use DOMDocument;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
@@ -22,7 +23,7 @@ class XmlRenderer implements RendererInterface
      */
     public function render(OutputInterface $output, array $rows)
     {
-        $dom = new \DOMDocument('1.0', 'UTF-8');
+        $dom = new DOMDocument('1.0', 'UTF-8');
         $dom->formatOutput = true;
         $rootXml = $dom->createElement('table');
         $dom->appendChild($rootXml);
@@ -30,12 +31,42 @@ class XmlRenderer implements RendererInterface
         foreach ($rows as $row) {
             $rowXml = $dom->createElement('row');
             foreach ($row as $key => $value) {
-                $key = preg_replace('/[^A-Za-z0-9]/u', '_', $key);
-                $rowXml->appendChild($dom->createElement($key, @iconv('UTF-8', 'UTF-8//IGNORE', $value)));
+                $cellXml = $dom->createElement($this->elementName($key));
+                // Not createElement()'s second argument: that one is inserted unescaped, so a
+                // value containing "&" or "<" - a label like "Terms & Conditions" - would either
+                // be truncated at the ampersand or break the document.
+                $cellXml->appendChild(
+                    $dom->createTextNode((string) @iconv('UTF-8', 'UTF-8//IGNORE', (string) $value))
+                );
+                $rowXml->appendChild($cellXml);
             }
             $rootXml->appendChild($rowXml);
         }
 
-        $output->writeln($dom->saveXML());
+        // Written raw: writeln() would otherwise run the document through Symfony's output
+        // formatter, which treats any element whose name happens to match a registered style tag
+        // - <info>, <comment>, <error>, <key>, <term>, ... - as markup and drops the tag,
+        // leaving the cell's text unwrapped and the XML no longer well formed.
+        $output->writeln($dom->saveXML(), OutputInterface::OUTPUT_RAW);
+    }
+
+    /**
+     * Turn a column header into a usable XML element name.
+     *
+     * Headers are free-form English ("Updated At", "Scope-ID") and are occasionally numeric, so
+     * beyond replacing the characters XML forbids we also have to guarantee the name does not
+     * start with a digit - createElement() would throw for those.
+     *
+     * @param int|string $key
+     */
+    private function elementName($key): string
+    {
+        $name = preg_replace('/[^A-Za-z0-9]/u', '_', (string) $key);
+
+        if ($name === '' || preg_match('/^[A-Za-z_]/', $name) !== 1) {
+            $name = '_' . $name;
+        }
+
+        return $name;
     }
 }

--- a/src/N98/Util/Console/Helper/Table/Renderer/YamlRenderer.php
+++ b/src/N98/Util/Console/Helper/Table/Renderer/YamlRenderer.php
@@ -23,6 +23,8 @@ class YamlRenderer implements RendererInterface
      */
     public function render(OutputInterface $output, array $rows)
     {
-        $output->writeln(Yaml::dump($rows));
+        // Raw, so a cell value that looks like markup keeps its angle brackets instead of being
+        // run through the output formatter and having "tags" stripped out of the document.
+        $output->writeln(Yaml::dump($rows), OutputInterface::OUTPUT_RAW);
     }
 }

--- a/src/N98/Util/Console/Helper/Table/TableStyleFactory.php
+++ b/src/N98/Util/Console/Helper/Table/TableStyleFactory.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * This file is part of the n98-magerun2 project.
+ *
+ * For the full copyright and license information, please view the MIT-LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace N98\Util\Console\Helper\Table;
+
+use N98\Util\Console\Glyph;
+use Symfony\Component\Console\Helper\TableStyle;
+
+/**
+ * Builds the table styles used across magerun.
+ *
+ * The dense style drops the outer frame and keeps only the column separators plus three
+ * horizontal rules, which reads better than a fully boxed table once a listing has more than a
+ * handful of rows - the eye follows the columns instead of the frame.
+ */
+final class TableStyleFactory
+{
+    /**
+     * Number of characters a column separator occupies including its surrounding padding.
+     */
+    public const SEPARATOR_WIDTH = 3;
+
+    /**
+     * The modern, frameless style used on interactive terminals.
+     */
+    public static function dense(): TableStyle
+    {
+        $horizontal = Glyph::get(Glyph::LINE);
+
+        return (new TableStyle())
+            ->setHorizontalBorderChars($horizontal)
+            // A space, not an empty string, for the outer edge: Symfony budgets one character for
+            // it when drawing the horizontal rules, so an empty one leaves every rule a character
+            // wider than the rows it separates.
+            ->setVerticalBorderChars(' ', Glyph::get(Glyph::VERTICAL))
+            ->setCrossingChars(
+                Glyph::get(Glyph::CROSS),
+                $horizontal,
+                Glyph::get(Glyph::TOP_MID),
+                $horizontal,
+                $horizontal,
+                $horizontal,
+                Glyph::get(Glyph::BOTTOM_MID),
+                $horizontal,
+                $horizontal
+            )
+            ->setBorderFormat('<border>%s</border>')
+            ->setCellHeaderFormat('<subheading>%s</subheading>');
+    }
+
+    /**
+     * A right-aligned variant of the dense style, applied to numeric columns.
+     */
+    public static function denseNumeric(): TableStyle
+    {
+        return self::dense()->setPadType(STR_PAD_LEFT);
+    }
+
+    /**
+     * Symfony's stock style, used verbatim for non-decorated output.
+     *
+     * Piped, redirected and `--no-ansi` output must stay byte-identical to previous releases so
+     * scripts, cron jobs and CI parsing magerun output keep working.
+     */
+    public static function plain(): TableStyle
+    {
+        return new TableStyle();
+    }
+}

--- a/src/N98/Util/Console/Helper/TableHelper.php
+++ b/src/N98/Util/Console/Helper/TableHelper.php
@@ -8,12 +8,16 @@
 
 namespace N98\Util\Console\Helper;
 
-use function Laravel\Prompts\table;
 use N98\Magento\Command\CommandAware;
 use N98\Util\Console\Helper\Table\Renderer\RendererFactory;
 use N98\Util\Console\Helper\Table\Renderer\RendererInterface;
+use N98\Util\Console\Helper\Table\TableStyleFactory;
+use N98\Util\Console\Theme;
+use Symfony\Component\Console\Formatter\OutputFormatterInterface;
 use Symfony\Component\Console\Helper\Helper as AbstractHelper;
 use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Helper\TableCell;
+use Symfony\Component\Console\Helper\TableSeparator;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
@@ -26,6 +30,13 @@ use Symfony\Component\Console\Output\OutputInterface;
 class TableHelper extends AbstractHelper implements CommandAware
 {
     use CommandTrait;
+
+    /**
+     * Narrowest a column may be squeezed to when fitting a wide table into the terminal.
+     *
+     * @var int
+     */
+    private const MIN_COLUMN_WIDTH = 8;
 
     /**
      * @var string
@@ -41,6 +52,27 @@ class TableHelper extends AbstractHelper implements CommandAware
      * @var array
      */
     protected $rows = [];
+
+    /**
+     * @var string|null heading drawn above the table on a terminal
+     */
+    protected $title;
+
+    /**
+     * Label the table, e.g. `STORES (2)`.
+     *
+     * Only drawn on a decorated terminal: the machine-readable `--format` renderers never see it,
+     * and plain text output stays byte-identical to previous releases.
+     *
+     * @param string|null $title
+     * @return $this
+     */
+    public function setTitle($title)
+    {
+        $this->title = $title;
+
+        return $this;
+    }
 
     /**
      * @param string $format
@@ -110,18 +142,173 @@ class TableHelper extends AbstractHelper implements CommandAware
             $rows = $this->rows;
         }
 
+        $table = new Table($output);
+        $table->setHeaders($this->headers);
+        $table->setRows($rows);
+
         if (!$output->isDecorated()) {
-            // Laravel Prompts' table() has no piped/redirected-output safety net (unlike
-            // Symfony's Table), so keep the old renderer for non-tty/scripted/cron usage.
-            $baseTable = new Table($output);
-            $baseTable->setRows($rows);
-            $baseTable->setHeaders($this->headers);
-            $baseTable->render();
+            // Piped, redirected and --no-ansi output keeps Symfony's stock rendering so scripts,
+            // cron jobs and CI that parse magerun output are unaffected by the visual redesign.
+            $table->setStyle(TableStyleFactory::plain());
+            $table->render();
 
             return;
         }
 
-        table($this->headers, $rows);
+        $this->renderTitle($output, count($rows));
+        $table->setStyle(TableStyleFactory::dense());
+
+        $widths = $this->naturalColumnWidths($rows, $output->getFormatter());
+        $this->alignNumericColumns($table, $rows, array_keys($widths));
+        $this->constrainToTerminalWidth($table, $widths);
+
+        $table->render();
+    }
+
+    /**
+     * Draw the table's heading and row count above it.
+     */
+    private function renderTitle(OutputInterface $output, int $rowCount): void
+    {
+        if ($this->title === null || $this->title === '' || Theme::colorDisabledByEnvironment()) {
+            return;
+        }
+
+        // See MagerunStyle::__construct(): the heading's tags have to be registered on whatever
+        // output we were handed, or the formatter would print them verbatim.
+        Theme::apply($output);
+
+        $output->writeln(Theme::headingLine($this->title, $rowCount));
+    }
+
+    /**
+     * Right-align columns whose every populated cell is numeric, so digits line up by magnitude.
+     *
+     * @param array<int, int> $columns
+     */
+    private function alignNumericColumns(Table $table, array $rows, array $columns): void
+    {
+        foreach ($columns as $column) {
+            if ($this->isNumericColumn($rows, $column)) {
+                $table->setColumnStyle($column, TableStyleFactory::denseNumeric());
+            }
+        }
+    }
+
+    /**
+     * Cap column widths so a wide table wraps inside the terminal instead of being chopped up by
+     * the terminal's own line wrapping, which would destroy the column alignment entirely.
+     *
+     * Width is reclaimed from the widest column first and Symfony wraps rather than truncates,
+     * so no data is lost.
+     *
+     * @param array<int, int> $widths natural width per column index
+     */
+    private function constrainToTerminalWidth(Table $table, array $widths): void
+    {
+        if ($widths === []) {
+            return;
+        }
+
+        $natural = $widths;
+        $budget = Theme::width() - (count($widths) * TableStyleFactory::SEPARATOR_WIDTH);
+
+        if ($budget < count($widths) * self::MIN_COLUMN_WIDTH || array_sum($widths) <= $budget) {
+            // Either the table already fits, or the terminal is too narrow for every column to
+            // keep its floor - in which case shrinking would mangle the layout for no gain.
+            return;
+        }
+
+        while (array_sum($widths) > $budget) {
+            $widest = (int) array_search(max($widths), $widths, true);
+            if ($widths[$widest] <= self::MIN_COLUMN_WIDTH) {
+                break;
+            }
+
+            --$widths[$widest];
+        }
+
+        foreach ($widths as $column => $width) {
+            if ($width < $natural[$column]) {
+                $table->setColumnMaxWidth($column, $width);
+            }
+        }
+    }
+
+    /**
+     * Visible width of the widest cell in each column, ignoring style tags and counting multibyte
+     * characters as one.
+     *
+     * @return array<int, int> column index => width
+     */
+    private function naturalColumnWidths(array $rows, OutputFormatterInterface $formatter): array
+    {
+        $widths = [];
+
+        foreach ($this->headers as $column => $header) {
+            $widths[$column] = self::cellWidth($header, $formatter);
+        }
+
+        foreach ($rows as $row) {
+            if (!is_array($row)) {
+                continue;
+            }
+
+            foreach ($row as $column => $cell) {
+                if (!is_int($column)) {
+                    continue;
+                }
+
+                $widths[$column] = max($widths[$column] ?? 0, self::cellWidth($cell, $formatter));
+            }
+        }
+
+        ksort($widths);
+
+        return $widths;
+    }
+
+    private function isNumericColumn(array $rows, int $column): bool
+    {
+        $seenValue = false;
+
+        foreach ($rows as $row) {
+            if (!is_array($row) || !isset($row[$column])) {
+                continue;
+            }
+
+            $value = trim((string) $row[$column]);
+            if ($value === '') {
+                continue;
+            }
+
+            if (!is_numeric($value)) {
+                return false;
+            }
+
+            $seenValue = true;
+        }
+
+        return $seenValue;
+    }
+
+    /**
+     * @param mixed $value
+     */
+    private static function cellWidth($value, OutputFormatterInterface $formatter): int
+    {
+        if ($value instanceof TableCell || $value instanceof TableSeparator) {
+            // Spanning cells and separators do not map onto a single column width.
+            return 0;
+        }
+
+        $width = 0;
+
+        foreach (explode("\n", (string) $value) as $line) {
+            $width = max($width, self::width(self::removeDecoration($formatter, $line)));
+        }
+
+        return $width;
     }
 
     /**

--- a/src/N98/Util/Console/Interaction.php
+++ b/src/N98/Util/Console/Interaction.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * This file is part of the n98-magerun2 project.
+ *
+ * For the full copyright and license information, please view the MIT-LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace N98\Util\Console;
+
+use N98\Util\OperatingSystem;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Whether this invocation may take over the terminal to ask the user something.
+ *
+ * Interactive prompts are an enhancement, never a requirement: a command that would block waiting
+ * for input it can never receive is worse than one that simply reports the argument it is missing.
+ * Every caller that cannot answer - cron, CI, a pipeline, `--no-interaction` - has to be filtered
+ * out before a prompt is drawn.
+ */
+final class Interaction
+{
+    /**
+     * True when a laravel/prompts prompt can be drawn and answered.
+     */
+    public static function isPromptable(InputInterface $input, OutputInterface $output): bool
+    {
+        if (!$input->isInteractive() || !$output->isDecorated()) {
+            return false;
+        }
+
+        if (Theme::colorDisabledByEnvironment()) {
+            return false;
+        }
+
+        // laravel/prompts reads the terminal directly, so it needs a real tty and a platform it
+        // supports. This mirrors ConfiguresPromptFallbacks::shouldFallbackToPlainPrompts().
+        return !OperatingSystem::isWindows() && defined('STDIN') && stream_isatty(STDIN);
+    }
+}

--- a/src/N98/Util/Console/MagerunStyle.php
+++ b/src/N98/Util/Console/MagerunStyle.php
@@ -1,0 +1,379 @@
+<?php
+/**
+ * This file is part of the n98-magerun2 project.
+ *
+ * For the full copyright and license information, please view the MIT-LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace N98\Util\Console;
+
+use function Laravel\Prompts\spin;
+use Symfony\Component\Console\Formatter\OutputFormatter;
+use Symfony\Component\Console\Helper\FormatterHelper;
+use Symfony\Component\Console\Helper\Helper;
+use Symfony\Component\Console\Helper\ProgressBar;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\ConsoleOutputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Throwable;
+
+/**
+ * The shared output vocabulary for magerun commands.
+ *
+ * Every method has two renderings:
+ *
+ *  - decorated (interactive terminal): the dense visual language - uppercase headings with a
+ *    row count, thin rules, glyph-prefixed status lines, de-emphasised secondary text.
+ *  - undecorated (pipe, redirect, cron, CI, `--no-ansi`): the exact text previous releases
+ *    produced, with no glyphs, rules or extra blank lines. Downstream scripts that grep magerun
+ *    output must not break because the interactive UI was redesigned.
+ *
+ * `heading()` in particular reproduces AbstractMagentoCommand::writeSection()'s block byte for
+ * byte when undecorated, so migrating a command from one to the other is invisible to scripts.
+ */
+class MagerunStyle extends SymfonyStyle
+{
+    /**
+     * @var OutputInterface
+     */
+    private $output;
+
+    /**
+     * @var FormatterHelper
+     */
+    private $formatterHelper;
+
+    public function __construct(InputInterface $input, OutputInterface $output)
+    {
+        parent::__construct($input, $output);
+
+        // Idempotent, and cheap. Guarantees the semantic tags this class writes are known to the
+        // formatter even when the output was not built by Application::run(): Symfony passes
+        // unregistered tags through verbatim, so a missed registration leaks markup to the user.
+        Theme::apply($output);
+
+        $this->output = $output;
+        $this->formatterHelper = new FormatterHelper();
+    }
+
+    /**
+     * The primary heading of a command's output, optionally with the number of items below it.
+     *
+     *     STORES (3)
+     */
+    public function heading(string $text, ?int $count = null): void
+    {
+        if (!$this->isStyled()) {
+            // Identical to the historic writeSection() block so piped output is unchanged.
+            $this->output->writeln([
+                '',
+                $this->formatterHelper->formatBlock($text, 'bg=blue;fg=white', true),
+                '',
+            ]);
+
+            return;
+        }
+
+        $this->output->writeln('');
+        $this->output->writeln(Theme::headingLine($text, $count));
+    }
+
+    /**
+     * A lighter heading for a subdivision of a command's output.
+     */
+    public function subheading(string $text): void
+    {
+        if (!$this->isStyled()) {
+            $this->output->writeln(['', $text, '']);
+
+            return;
+        }
+
+        $this->output->writeln('');
+        $this->output->writeln(sprintf('<subheading>%s</subheading>', $text));
+    }
+
+    /**
+     * A horizontal rule, optionally labelled.
+     */
+    public function rule(?string $label = null): void
+    {
+        if (!$this->isStyled()) {
+            if ($label !== null) {
+                $this->output->writeln($label);
+            }
+
+            return;
+        }
+
+        $width = Theme::width();
+
+        if ($label === null) {
+            $this->output->writeln(sprintf('<border>%s</border>', Glyph::repeat(Glyph::LINE, $width)));
+
+            return;
+        }
+
+        $visible = self::visibleWidth($label) + 2;
+        $this->output->writeln(sprintf(
+            '<border>%s</border> %s <border>%s</border>',
+            Glyph::repeat(Glyph::LINE, 3),
+            $label,
+            Glyph::repeat(Glyph::LINE, max(0, $width - $visible - 3))
+        ));
+    }
+
+    /**
+     * An aligned key/value block - the shape most `sys:*` and `*:info` commands need.
+     *
+     * @param array<string, mixed> $pairs
+     */
+    public function keyValue(array $pairs): void
+    {
+        if ($pairs === []) {
+            return;
+        }
+
+        if (!$this->isStyled()) {
+            foreach ($pairs as $key => $value) {
+                $this->output->writeln(sprintf('%s: %s', $key, self::stringify($value)));
+            }
+
+            return;
+        }
+
+        $width = 0;
+        foreach (array_keys($pairs) as $key) {
+            $width = max($width, self::visibleWidth((string) $key));
+        }
+
+        foreach ($pairs as $key => $value) {
+            $this->output->writeln(sprintf(
+                '  <term>%s</term>  %s',
+                str_pad((string) $key, $width, ' ', STR_PAD_RIGHT),
+                self::stringify($value)
+            ));
+        }
+    }
+
+    /**
+     * A successful outcome.
+     */
+    public function ok(string $message): void
+    {
+        $this->status(Glyph::OK, 'success', $message);
+    }
+
+    /**
+     * A failed outcome. Written to stderr so `magerun ... > file` keeps errors on the terminal.
+     */
+    public function fail(string $message): void
+    {
+        $this->status(Glyph::ERROR, 'failure', $message, true);
+    }
+
+    /**
+     * Something the user should know about but which did not stop the command.
+     */
+    public function warn(string $message): void
+    {
+        $this->status(Glyph::WARNING, 'warning', $message, true);
+    }
+
+    /**
+     * A neutral progress or outcome line.
+     */
+    public function item(string $message): void
+    {
+        $this->status(Glyph::INFO, 'accent', $message);
+    }
+
+    /**
+     * Work that was deliberately not done.
+     */
+    public function skipped(string $message): void
+    {
+        $this->status(Glyph::PENDING, 'skipped', $message);
+    }
+
+    /**
+     * Secondary guidance - what to run next, why something was chosen.
+     */
+    public function hint(string $message): void
+    {
+        if (!$this->isStyled()) {
+            $this->output->writeln($message);
+
+            return;
+        }
+
+        $this->output->writeln(sprintf('  <hint>%s</hint>', $message));
+    }
+
+    /**
+     * Detail that only matters when the user asked for more verbosity.
+     */
+    public function detail(string $message): void
+    {
+        if (!$this->output->isVerbose()) {
+            return;
+        }
+
+        $this->hint($message);
+    }
+
+    /**
+     * Run a callback behind a spinner, returning whatever the callback returns.
+     *
+     * Falls back to simply announcing the work and running it when there is no terminal to
+     * animate, so cron and CI logs stay clean.
+     *
+     * @template T
+     * @param callable(): T $callback
+     * @return T
+     */
+    public function spin(callable $callback, string $label = '')
+    {
+        if (!$this->isStyled()) {
+            if ($label !== '') {
+                $this->output->writeln($label);
+            }
+
+            return $callback();
+        }
+
+        return spin($callback, $label);
+    }
+
+    /**
+     * A progress bar in the dense visual language.
+     *
+     * @see ProgressFactory for why this is a Symfony ProgressBar and not a laravel/prompts one
+     */
+    public function createProgress(int $max = 0, string $label = ''): ProgressBar
+    {
+        return ProgressFactory::create($this->output, $max, $label);
+    }
+
+    /**
+     * Iterate a collection while showing progress.
+     *
+     * @template TKey
+     * @template TValue
+     * @param iterable<TKey, TValue> $items
+     * @return iterable<TKey, TValue>
+     */
+    public function trackProgress(iterable $items, string $label = '', ?int $max = null): iterable
+    {
+        if ($max === null && is_countable($items)) {
+            $max = count($items);
+        }
+
+        $progress = $this->createProgress($max ?? 0, $label);
+        $progress->start();
+
+        try {
+            foreach ($items as $key => $value) {
+                yield $key => $value;
+
+                $progress->advance();
+            }
+        } finally {
+            $progress->finish();
+            $this->output->writeln('');
+        }
+    }
+
+    /**
+     * Announce a unit of work, run it, and report the outcome on a single line.
+     *
+     * @template T
+     * @param callable(): T $callback
+     * @return T
+     * @throws Throwable rethrown after the failure is reported
+     */
+    public function task(string $label, callable $callback)
+    {
+        try {
+            $result = $this->spin($callback, $label);
+        } catch (Throwable $exception) {
+            $this->fail(sprintf('%s: %s', $label, $exception->getMessage()));
+
+            throw $exception;
+        }
+
+        $this->ok($label);
+
+        return $result;
+    }
+
+    /**
+     * The raw output this style writes to, for the rare case a command needs it directly.
+     */
+    public function getOutput(): OutputInterface
+    {
+        return $this->output;
+    }
+
+    /**
+     * Whether to draw the modern visual language.
+     *
+     * Colour alone is not enough: a `NO_COLOR` user has asked for plain output, so the glyphs and
+     * rules go away too rather than being emitted uncoloured.
+     */
+    private function isStyled(): bool
+    {
+        return $this->output->isDecorated() && !Theme::colorDisabledByEnvironment();
+    }
+
+    private function status(string $glyph, string $style, string $message, bool $toErrorStream = false): void
+    {
+        $target = $toErrorStream ? $this->getErrorStyleOutput() : $this->output;
+
+        if (!$this->isStyled()) {
+            $target->writeln($message);
+
+            return;
+        }
+
+        $target->writeln(sprintf('  <%s>%s</%s> %s', $style, Glyph::get($glyph), $style, $message));
+    }
+
+    private function getErrorStyleOutput(): OutputInterface
+    {
+        if ($this->output instanceof ConsoleOutputInterface) {
+            return $this->output->getErrorOutput();
+        }
+
+        return $this->output;
+    }
+
+    /**
+     * @param mixed $value
+     */
+    private static function stringify($value): string
+    {
+        if (is_bool($value)) {
+            return $value ? 'yes' : 'no';
+        }
+
+        if ($value === null) {
+            return '';
+        }
+
+        if (is_array($value)) {
+            return implode(', ', array_map([self::class, 'stringify'], $value));
+        }
+
+        return (string) $value;
+    }
+
+    private static function visibleWidth(string $value): int
+    {
+        return Helper::width(Helper::removeDecoration(new OutputFormatter(), $value));
+    }
+}

--- a/src/N98/Util/Console/ProgressFactory.php
+++ b/src/N98/Util/Console/ProgressFactory.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * This file is part of the n98-magerun2 project.
+ *
+ * For the full copyright and license information, please view the MIT-LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace N98\Util\Console;
+
+use Symfony\Component\Console\Helper\ProgressBar;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Builds every progress bar magerun shows, so long-running commands all look the same.
+ *
+ * Symfony's ProgressBar is used rather than laravel/prompts because it writes to the
+ * OutputInterface it is handed - laravel/prompts renders to its own global stream - it throttles
+ * and degrades on its own when the output is not decorated, and it can be driven by CommandTester.
+ *
+ * Undecorated output gets none of the styling: Symfony's own default format is left in place, which
+ * emits one plain line per redraw instead of rewriting a single one - what cron mails and CI logs
+ * want. The three hand-rolled bars this replaced each had their own plain format, so there was no
+ * single previous rendering to preserve; Symfony's default is the one we can keep in step.
+ */
+final class ProgressFactory
+{
+    /**
+     * Redraw at most this often on a terminal. Without it a fast loop spends its time on ANSI.
+     */
+    private const REDRAW_INTERVAL_SECONDS = 0.1;
+
+    public static function create(OutputInterface $output, int $max = 0, string $label = ''): ProgressBar
+    {
+        $progress = new ProgressBar($output, $max);
+
+        if (!self::isStyled($output)) {
+            if ($label !== '') {
+                $output->writeln($label);
+            }
+
+            return $progress;
+        }
+
+        $progress->setBarCharacter('<accent>' . Glyph::get(Glyph::LINE_HEAVY) . '</accent>');
+        $progress->setProgressCharacter('<accent>' . Glyph::get(Glyph::LINE_HEAVY) . '</accent>');
+        $progress->setEmptyBarCharacter('<border>' . Glyph::get(Glyph::LINE) . '</border>');
+        $progress->setFormat(self::format($max > 0, $label !== ''));
+        $progress->setMessage($label);
+        $progress->minSecondsBetweenRedraws(self::REDRAW_INTERVAL_SECONDS);
+
+        return $progress;
+    }
+
+    /**
+     * Without a known total there is no bar, no percentage and no estimate to show - only how far
+     * we have got and how long it has taken.
+     */
+    private static function format(bool $hasMax, bool $hasLabel): string
+    {
+        $bar = $hasMax
+            ? ' %bar% <emphasis>%percent:3s%%</emphasis> <muted>%current%/%max%</muted>' .
+              ' <muted>%elapsed:6s% / %estimated:-6s%</muted>'
+            : ' <muted>%current%</muted> <muted>%elapsed:6s%</muted>';
+
+        return $hasLabel ? $bar . '  <term>%message%</term>' : $bar;
+    }
+
+    /**
+     * A NO_COLOR user asked for plain output, so the bar goes away rather than being drawn
+     * uncoloured with box-drawing characters.
+     */
+    private static function isStyled(OutputInterface $output): bool
+    {
+        return $output->isDecorated() && !Theme::colorDisabledByEnvironment();
+    }
+}

--- a/src/N98/Util/Console/Theme.php
+++ b/src/N98/Util/Console/Theme.php
@@ -1,0 +1,170 @@
+<?php
+/**
+ * This file is part of the n98-magerun2 project.
+ *
+ * For the full copyright and license information, please view the MIT-LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace N98\Util\Console;
+
+use Symfony\Component\Console\Formatter\OutputFormatterStyle;
+use Symfony\Component\Console\Output\AnsiColorMode;
+use Symfony\Component\Console\Output\ConsoleOutputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Terminal;
+
+/**
+ * Central definition of every semantic output style used by magerun.
+ *
+ * Colours are deliberately taken from the terminal's own 16-colour palette (plus `gray`, i.e.
+ * bright black, for de-emphasis) instead of fixed hex values, so output stays legible on light
+ * and dark backgrounds and respects whatever theme the user has configured.
+ *
+ * Symfony strips every style tag when the output is not decorated, so registering styles here
+ * has no effect on piped, redirected or `--no-ansi` output.
+ *
+ * Tag names deliberately avoid HTML element names - hence `term` and `emphasis` rather than the
+ * more obvious `label` and `strong`. Symfony emits an *unregistered* tag verbatim but consumes a
+ * registered one, so naming a style after an HTML element silently eats that element out of any
+ * data magerun renders. Magento's system.xml labels are HTML fragments, so `config:search` would
+ * otherwise lose the markup its previous releases printed.
+ */
+final class Theme
+{
+    /**
+     * Fallback width when the terminal size cannot be determined (pipes, cron, CI).
+     */
+    public const DEFAULT_WIDTH = 80;
+
+    /**
+     * Never draw wider than this, even on a maximised 4K terminal - long rules are hard to scan.
+     */
+    public const MAX_WIDTH = 120;
+
+    /**
+     * @var array<string, array{0: string, 1: string, 2: array<int, string>}>
+     *      tag => [foreground, background, options]
+     */
+    private const STYLES = [
+        // Structure
+        'heading' => ['cyan', '', ['bold']],
+        'subheading' => ['default', '', ['bold']],
+        'border' => ['gray', '', []],
+        'muted' => ['gray', '', []],
+        'hint' => ['gray', '', []],
+        'count' => ['gray', '', []],
+        'term' => ['gray', '', []],
+        'accent' => ['cyan', '', []],
+        'emphasis' => ['default', '', ['bold']],
+
+        // Status
+        'success' => ['green', '', []],
+        'failure' => ['red', '', []],
+        'skipped' => ['gray', '', []],
+
+        // Value types, promoted from Magerun\ConfigDumpCommand so any command can highlight data
+        'key' => ['cyan', '', ['bold']],
+        'string' => ['green', '', []],
+        'number' => ['magenta', '', []],
+        'bool' => ['yellow', '', []],
+        'null' => ['gray', '', []],
+
+        // Overrides of pre-existing tags. `warning` used to be bold red-on-yellow and `debug`
+        // magenta-on-white; both were close to unreadable on a dark background.
+        'warning' => ['yellow', '', ['bold']],
+        'debug' => ['magenta', '', []],
+    ];
+
+    /**
+     * Register every semantic style on an output's formatter.
+     *
+     * Applies to the error stream too, so `<hint>` and friends work in messages written to stderr.
+     */
+    public static function apply(OutputInterface $output): void
+    {
+        self::applyToSingleOutput($output);
+
+        if ($output instanceof ConsoleOutputInterface) {
+            self::applyToSingleOutput($output->getErrorOutput());
+        }
+    }
+
+    /**
+     * Usable width for rules, headings and tables, clamped to something readable.
+     */
+    public static function width(): int
+    {
+        $width = (new Terminal())->getWidth();
+
+        if ($width <= 0) {
+            return self::DEFAULT_WIDTH;
+        }
+
+        return (int) max(40, min($width, self::MAX_WIDTH));
+    }
+
+    /**
+     * The one definition of a section heading: an upper-case label with an optional item count.
+     *
+     * Deliberately without an underlining rule. Nearly every heading in magerun introduces a table,
+     * and a table already draws its own top border directly underneath - a second rule of a
+     * different width above it just looks broken.
+     *
+     * @param string $label
+     * @param int|null $count
+     */
+    public static function headingLine(string $label, ?int $count = null): string
+    {
+        // Trimmed because some headings were padded to centre them inside the old blue block.
+        $label = trim($label);
+
+        // Upper-casing a path or a version would just shout, so those are left as they are.
+        if (preg_match('/[\/\\\\@]|\d\.\d/', $label) !== 1) {
+            $label = mb_strtoupper($label);
+        }
+
+        return sprintf(
+            '<heading>%s</heading>%s',
+            $label,
+            $count === null ? '' : sprintf(' <count>(%d)</count>', $count)
+        );
+    }
+
+    /**
+     * True when the terminal advertises 24-bit colour support.
+     *
+     * Only needed for gradients; ordinary styles let Symfony degrade colours on its own.
+     */
+    public static function supportsTrueColor(): bool
+    {
+        return Terminal::getColorMode() === AnsiColorMode::Ansi24;
+    }
+
+    /**
+     * True when the user has asked for colourless output via the NO_COLOR convention or a dumb
+     * terminal. Callers should treat this as "also skip decorative structure", not just colour.
+     *
+     * @see https://no-color.org
+     */
+    public static function colorDisabledByEnvironment(): bool
+    {
+        $noColor = getenv('NO_COLOR');
+        if ($noColor !== false && $noColor !== '') {
+            return true;
+        }
+
+        return getenv('TERM') === 'dumb';
+    }
+
+    private static function applyToSingleOutput(OutputInterface $output): void
+    {
+        $formatter = $output->getFormatter();
+
+        foreach (self::STYLES as $tag => [$foreground, $background, $options]) {
+            $formatter->setStyle($tag, new OutputFormatterStyle($foreground, $background, $options));
+        }
+    }
+}

--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -11,14 +11,30 @@ if (!class_exists(N98\MagerunBootstrap::class)) {
 }
 
 try {
-    if (version_compare(PHP_VERSION, '7.4.0', '<')) {
-        throw new \ErrorException('PHP Version is lower than 7.4.0. Please upgrade your runtime.');
+    // Keep in sync with the "php" constraint in composer.json.
+    if (version_compare(PHP_VERSION, '8.0.0', '<')) {
+        throw new \ErrorException('PHP Version is lower than 8.0.0. Please upgrade your runtime.');
     }
     return N98\MagerunBootstrap::createApplication();
-} catch (Exception $e) {
-    printf("%s: %s\n", get_class($e), $e->getMessage());
-    if (array_intersect(['-vvv', '-vv', '-v', '--verbose'], $argv)) {
-        printf("%s\n", $e->getTraceAsString());
+} catch (Throwable $e) {
+    $verbose = (bool) array_intersect(['-vvv', '-vv', '-v', '--verbose'], $argv);
+
+    // Bootstrapping is where the autoloader itself can be broken, so the styled renderer is only
+    // used when its classes are actually loadable; otherwise fall back to unformatted output.
+    if (class_exists(N98\Magento\Application\Console\ErrorRenderer::class)) {
+        $output = new Symfony\Component\Console\Output\ConsoleOutput(
+            $verbose
+                ? Symfony\Component\Console\Output\OutputInterface::VERBOSITY_VERBOSE
+                : Symfony\Component\Console\Output\OutputInterface::VERBOSITY_NORMAL
+        );
+
+        (new N98\Magento\Application\Console\ErrorRenderer())->render($e, $output->getErrorOutput());
+    } else {
+        fprintf(STDERR, "%s: %s\n", get_class($e), $e->getMessage());
+        if ($verbose) {
+            fprintf(STDERR, "%s\n", $e->getTraceAsString());
+        }
     }
+
     exit(1);
 }

--- a/tests/N98/Util/Console/Helper/Table/Renderer/XmlRendererTest.php
+++ b/tests/N98/Util/Console/Helper/Table/Renderer/XmlRendererTest.php
@@ -8,6 +8,7 @@
 
 namespace N98\Util\Console\Helper\Table\Renderer;
 
+use N98\Util\Console\Theme;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Output\StreamOutput;
 
@@ -89,6 +90,102 @@ XML;
     <col_1>val1</col_1>
     <col_2>val2</col_2>
     <col_3>val3</col_3>
+  </row>
+</table>
+XML;
+        $this->assertXmlStringEqualsXmlString($expectedXml, $xmlOutput);
+    }
+
+    /**
+     * A column whose name collides with a style tag registered on the formatter - `label` is one of
+     * magerun's own, `info` one of Symfony's - must still be written as an element. Rendering
+     * through the formatter used to swallow those tags and leave the cell's text bare, which is how
+     * `eav:attribute:list --format=xml` came to emit an unwrapped "Weight".
+     */
+    public function testRenderKeysThatCollideWithStyleTags()
+    {
+        $renderer = new XmlRenderer();
+        $stream = fopen('php://memory', 'r+');
+        $output = new StreamOutput($stream);
+        Theme::apply($output);
+
+        $rows = [
+            ['code' => 'weight_type', 'label' => 'Dynamic Weight', 'info' => 'decimal'],
+        ];
+
+        $renderer->render($output, $rows);
+
+        rewind($stream);
+        $xmlOutput = stream_get_contents($stream);
+        fclose($stream);
+
+        $expectedXml = <<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<table>
+  <row>
+    <code>weight_type</code>
+    <label>Dynamic Weight</label>
+    <info>decimal</info>
+  </row>
+</table>
+XML;
+        $this->assertXmlStringEqualsXmlString($expectedXml, $xmlOutput);
+    }
+
+    /**
+     * Values are text, not markup: the characters XML reserves have to survive as data.
+     */
+    public function testRenderEscapesReservedCharactersInValues()
+    {
+        $renderer = new XmlRenderer();
+        $stream = fopen('php://memory', 'r+');
+        $output = new StreamOutput($stream);
+
+        $rows = [
+            ['col1' => 'Terms & Conditions', 'col2' => 'a < b > c', 'col3' => 'say "hi"'],
+        ];
+
+        $renderer->render($output, $rows);
+
+        rewind($stream);
+        $xmlOutput = stream_get_contents($stream);
+        fclose($stream);
+
+        $document = new \DOMDocument();
+        $this->assertTrue($document->loadXML($xmlOutput), 'renderer produced malformed XML');
+
+        $row = $document->getElementsByTagName('row')->item(0);
+        $this->assertSame('Terms & Conditions', $row->getElementsByTagName('col1')->item(0)->textContent);
+        $this->assertSame('a < b > c', $row->getElementsByTagName('col2')->item(0)->textContent);
+        $this->assertSame('say "hi"', $row->getElementsByTagName('col3')->item(0)->textContent);
+    }
+
+    /**
+     * XML names may not start with a digit, so a numeric column header needs a prefix rather than
+     * an exception out of createElement().
+     */
+    public function testRenderNumericKeys()
+    {
+        $renderer = new XmlRenderer();
+        $stream = fopen('php://memory', 'r+');
+        $output = new StreamOutput($stream);
+
+        $rows = [
+            ['val1', 'val2'],
+        ];
+
+        $renderer->render($output, $rows);
+
+        rewind($stream);
+        $xmlOutput = stream_get_contents($stream);
+        fclose($stream);
+
+        $expectedXml = <<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<table>
+  <row>
+    <_0>val1</_0>
+    <_1>val2</_1>
   </row>
 </table>
 XML;

--- a/tests/bats/functional_magerun_commands.bats
+++ b/tests/bats/functional_magerun_commands.bats
@@ -391,6 +391,8 @@ function cleanup_files_in_magento() {
 # ============================================
 
 @test "Command: customer:create" {
+  $BIN "customer:delete" --email=foo@example.com --force >/dev/null 2>&1 || true
+
   run $BIN "customer:create" "foo@example.com" "Password123" "Firstname" "Lastname"
   assert_output --partial "Customer foo@example.com successfully created"
 }
@@ -633,9 +635,11 @@ function cleanup_files_in_magento() {
 # ============================================
 
 @test "Command: dev:module:create" {
+  cleanup_files_in_magento "app/code/Magerun123/TestModule"
+
   run $BIN "dev:module:create" Magerun123 TestModule
   assert_output --partial "Created directory"
-  cleanup_files_in_magento "app/code/N98/Magerun123"
+  cleanup_files_in_magento "app/code/Magerun123/TestModule"
 }
 
 # ============================================
@@ -883,6 +887,9 @@ function cleanup_files_in_magento() {
 # ============================================
 
 @test "Command: Integration:create" {
+  $BIN "integration:delete" magerun-test >/dev/null 2>&1 || true
+  $BIN "integration:delete" magerun-test1 >/dev/null 2>&1 || true
+
   # Create with all arguments
   run $BIN "integration:create" magerun-test magerun@example.com https://localhost
   assert_output --partial "Integration ID"
@@ -927,6 +934,8 @@ function cleanup_files_in_magento() {
 @test "Command: integration:delete" {
   run $BIN "integration:delete" magerun-test
   assert_output --partial "Successfully deleted integration"
+
+  $BIN "integration:delete" magerun-test1 >/dev/null 2>&1 || true
 }
 
 # ============================================


### PR DESCRIPTION
## Summary
- overhaul the CLI look and feel with dedicated console styling, themed tables, glyphs, progress helpers, and improved interaction helpers
- add custom list/help command rendering, command palette support, and a dedicated error renderer for a more polished command experience
- update command table output usage across existing commands and extend XML renderer coverage
- make selected functional BATS fixtures idempotent so repeated test runs do not fail on stale customers, modules, or integrations

## Testing
- vendor/bin/phpunit tests/N98/Util/Console/Helper/Table/Renderer/XmlRendererTest.php
- ddev exec bats --filter 'Command: (customer:create|customer:info|customer:list|customer:change-password|customer:add-address|customer:delete|dev:module:create|Integration:create|integration:list|integration:show|integration:delete)' tests/bats/functional_magerun_commands.bats
- ddev exec bats tests/bats/functional_magerun_commands.bats tests/bats/functional_core_commands.bats