### PR TITLE
fix: db:query produces no output via mcp:server:start

### DIFF
--- a/src/N98/Magento/Command/Database/QueryCommand.php
+++ b/src/N98/Magento/Command/Database/QueryCommand.php
@@ -9,10 +9,12 @@
 namespace N98\Magento\Command\Database;
 
 use function Laravel\Prompts\text;
+use RuntimeException;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Process\Process;
 
 /**
  * Class QueryCommand
@@ -83,6 +85,9 @@ HELP;
         $this->detectDbSettings($output);
 
         if (($query = $input->getArgument('query')) === null) {
+            if (!$input->isInteractive()) {
+                throw new RuntimeException('No SQL query provided. Please pass the query as a command argument.');
+            }
             $query = text('SQL Query:');
         }
 
@@ -92,32 +97,44 @@ HELP;
 
         if ($input->getOption('only-command')) {
             $output->writeln($exec);
-            $returnValue = 0;
-        } else {
-            $format = $input->getOption('format');
-            if ($format === 'csv') {
-                // Prepend -B for batch mode (tab-separated output)
-                $exec = str_replace('mysql ', 'mysql -B ', $exec);
-                exec($exec, $commandOutput, $returnValue);
-
-                if ($returnValue === 0) {
-                    foreach ($commandOutput as $line) {
-                        $parts = explode("\t", $line);
-                        $csvLine = '"' . implode('","', $parts) . '"';
-                        $output->writeln($csvLine);
-                    }
-                } else {
-                    $output->writeln('<error>' . implode(PHP_EOL, $commandOutput) . '</error>');
-                }
-            } else {
-                exec($exec, $commandOutput, $returnValue);
-                $output->writeln($commandOutput);
-                if ($returnValue > 0) {
-                    $output->writeln('<error>' . implode(PHP_EOL, $commandOutput) . '</error>');
-                }
-            }
+            return 0;
         }
 
-        return $returnValue;
+        $format = $input->getOption('format');
+        if ($format === 'csv') {
+            // Prepend -B for batch mode (tab-separated output)
+            $exec = str_replace('mysql ', 'mysql -B ', $exec);
+        }
+
+        $process = Process::fromShellCommandline($exec);
+        $process->setTimeout(null);
+        $process->run();
+
+        if (!$process->isSuccessful()) {
+            $errorOutput = trim($process->getErrorOutput());
+            if ($errorOutput === '') {
+                $errorOutput = trim($process->getOutput());
+            }
+            $output->writeln('<error>' . $errorOutput . '</error>');
+
+            return $process->getExitCode() ?: 1;
+        }
+
+        $commandOutput = rtrim($process->getOutput(), "\r\n");
+        if ($commandOutput === '') {
+            return 0;
+        }
+
+        if ($format === 'csv') {
+            foreach (explode("\n", $commandOutput) as $line) {
+                $parts = explode("\t", rtrim($line, "\r"));
+                $csvLine = '"' . implode('","', $parts) . '"';
+                $output->writeln($csvLine);
+            }
+        } else {
+            $output->writeln($commandOutput);
+        }
+
+        return 0;
     }
 }

--- a/src/N98/Magento/Mcp/CommandToolHandler.php
+++ b/src/N98/Magento/Mcp/CommandToolHandler.php
@@ -10,8 +10,10 @@ namespace N98\Magento\Mcp;
 
 use Mcp\Exception\ToolCallException;
 use N98\Magento\Application;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Exception\CommandNotFoundException;
-use Symfony\Component\Console\Input\StringInput;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 use Throwable;
@@ -42,15 +44,7 @@ class CommandToolHandler
             throw new ToolCallException($exception->getMessage(), previous: $exception);
         }
 
-        $argumentString = trim($arguments);
-        if ($argumentString === '') {
-            $argumentString = '--no-interaction';
-        } elseif (!preg_match('/(^|\\s)(--no-interaction|-n)(\\s|$)/', $argumentString)) {
-            $argumentString = '--no-interaction ' . $argumentString;
-        }
-
-        $input = new StringInput($this->commandName . ' ' . $argumentString);
-        $input->setInteractive(false);
+        $input = $this->buildInput($command, $arguments);
 
         $output = new BufferedOutput(OutputInterface::VERBOSITY_NORMAL, false);
 
@@ -84,5 +78,174 @@ class CommandToolHandler
         }
 
         return $content;
+    }
+
+    /**
+     * Builds the command Input directly from an argument/option map instead of relying on
+     * StringInput's shell-style tokenizer. This guarantees that a free-form, multi-word value
+     * (e.g. a SQL query passed to db:query) reaches the command's single scalar argument
+     * completely verbatim, quotes and all, instead of requiring the MCP caller to shell-quote
+     * it correctly (which is not a reliable contract for an LLM client, and still can't
+     * survive quote characters embedded in the value itself).
+     */
+    private function buildInput(Command $command, string $arguments): ArrayInput
+    {
+        $definition = $command->getDefinition();
+
+        [$parameters, $remainder] = $this->consumeOptions($definition, $arguments);
+
+        $parameters['--no-interaction'] = true;
+
+        $argumentNames = array_keys($definition->getArguments());
+        $remainder = trim($remainder);
+
+        if ($remainder !== '') {
+            if ($argumentNames === []) {
+                throw new ToolCallException(sprintf(
+                    'Command "%s" does not accept any arguments, got "%s".',
+                    $this->commandName,
+                    $remainder
+                ));
+            }
+
+            $argumentName = $argumentNames[0];
+            $argument = $definition->getArgument($argumentName);
+
+            $parameters[$argumentName] = $argument->isArray()
+                ? $this->tokenizeWords($remainder)
+                : $remainder;
+        }
+
+        $input = new ArrayInput($parameters);
+        $input->setInteractive(false);
+
+        return $input;
+    }
+
+    /**
+     * Scans the front of the raw argument string for recognized `--option`, `--option=value`,
+     * `-x` and `-x value` tokens (including the globally available `--no-interaction`/`-n`
+     * flag, which lives on the Application definition rather than the command's own
+     * definition). Returns the collected ArrayInput parameters plus the untouched remainder
+     * of the original string (everything after the last recognized option).
+     *
+     * @return array{0: array<string, mixed>, 1: string}
+     */
+    private function consumeOptions(InputDefinition $definition, string $arguments): array
+    {
+        $parameters = [];
+        $offset = 0;
+        $length = strlen($arguments);
+
+        while ($offset < $length) {
+            $skipped = strspn($arguments, " \t\n\r\0\x0B", $offset);
+            $offset += $skipped;
+
+            if ($offset >= $length) {
+                break;
+            }
+
+            $rest = substr($arguments, $offset);
+
+            if (!preg_match('/^(--[A-Za-z0-9][A-Za-z0-9\-]*|-[A-Za-z])/', $rest, $match)) {
+                break;
+            }
+
+            $name = $match[1];
+            $consumed = strlen($name);
+
+            $isLongOption = str_starts_with($name, '--');
+            $optionName = $isLongOption ? substr($name, 2) : substr($name, 1);
+
+            if ($optionName === 'no-interaction' || $optionName === 'n') {
+                $offset += $consumed;
+                continue;
+            }
+
+            $isKnownOption = $isLongOption
+                ? $definition->hasOption($optionName)
+                : $definition->hasShortcut($optionName);
+
+            if (!$isKnownOption) {
+                // Unknown option-looking token: stop parsing options, treat the rest as the argument value.
+                break;
+            }
+
+            $option = $isLongOption ? $definition->getOption($optionName) : $definition->getOptionForShortcut($optionName);
+
+            $value = null;
+            if (substr($rest, $consumed, 1) === '=') {
+                $consumed++;
+                [$value, $valueLength] = $this->readWord(substr($rest, $consumed));
+                $consumed += $valueLength;
+            } elseif ($option->acceptValue()) {
+                $afterName = substr($rest, $consumed);
+                $skippedBeforeValue = strspn($afterName, " \t\n\r\0\x0B");
+                [$value, $valueLength] = $this->readWord(substr($afterName, $skippedBeforeValue));
+                $consumed += $skippedBeforeValue + $valueLength;
+            }
+
+            $parameters['--' . $option->getName()] = $value ?? true;
+            $offset += $consumed;
+        }
+
+        return [$parameters, substr($arguments, $offset)];
+    }
+
+    /**
+     * Reads a single word from the start of $str: either a quoted string (single or double
+     * quotes, matching the opposite quote type not requiring escaping) or an unquoted run of
+     * non-whitespace characters.
+     *
+     * @return array{0: string, 1: int} the word value and the number of characters consumed
+     */
+    private function readWord(string $str): array
+    {
+        if ($str === '') {
+            return ['', 0];
+        }
+
+        $quote = $str[0];
+        if ($quote === '"' || $quote === "'") {
+            $end = strpos($str, $quote, 1);
+            if ($end !== false) {
+                return [substr($str, 1, $end - 1), $end + 1];
+            }
+        }
+
+        $unquotedLength = strcspn($str, " \t\n\r\0\x0B");
+
+        return [substr($str, 0, $unquotedLength), $unquotedLength];
+    }
+
+    /**
+     * Splits a string into words for IS_ARRAY arguments, respecting simple quoting.
+     *
+     * @return string[]
+     */
+    private function tokenizeWords(string $str): array
+    {
+        $words = [];
+        $offset = 0;
+        $length = strlen($str);
+
+        while ($offset < $length) {
+            $skipped = strspn($str, " \t\n\r\0\x0B", $offset);
+            $offset += $skipped;
+
+            if ($offset >= $length) {
+                break;
+            }
+
+            [$word, $consumed] = $this->readWord(substr($str, $offset));
+            if ($consumed === 0) {
+                break;
+            }
+
+            $words[] = $word;
+            $offset += $consumed;
+        }
+
+        return $words;
     }
 }

--- a/tests/N98/Magento/Command/Database/QueryCommandTest.php
+++ b/tests/N98/Magento/Command/Database/QueryCommandTest.php
@@ -8,49 +8,58 @@
 
 namespace N98\Magento\Command\Database;
 
-use N98\Magento\MagerunCommandTester;
+use N98\Magento\Command\TestCase;
 use N98\Util\Console\Helper\DatabaseHelper;
+use RuntimeException;
+use Symfony\Component\Console\Tester\CommandTester;
 
-class QueryCommandTest extends MagerunCommandTester
+class QueryCommandTest extends TestCase
 {
     public function testDbQueryCsvOutput()
     {
         $application = $this->getApplication();
-        // Ensure the command is registered
         $this->assertTrue($application->has('db:query'), 'Command db:query should be registered.');
-        $command = $application->find('db:query');
 
-        // Mock DatabaseHelper
+        $this->mockDatabaseHelper('--host=localhost --user=test --password=test test_db');
+
+        $this->assertExecute(['command' => 'db:query', 'query' => 'SELECT 1', '--format' => 'csv']);
+    }
+
+    public function testThrowsWhenNoQueryGivenNonInteractively()
+    {
+        $this->mockDatabaseHelper('--host=localhost --user=test --password=test test_db');
+
+        $command = $this->getApplication()->find('db:query');
+        $tester = new CommandTester($command);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('No SQL query provided');
+
+        $tester->execute(['command' => 'db:query'], ['interactive' => false]);
+    }
+
+    public function testFailingQuerySurfacesMysqlErrorInOutput()
+    {
+        // Use a bogus mysql CLI option so the client fails synchronously and
+        // deterministically, without depending on a real database connection.
+        $this->mockDatabaseHelper('--this-option-does-not-exist');
+
+        $this->assertDisplayContains(
+            ['command' => 'db:query', 'query' => 'SELECT 1'],
+            'unknown option'
+        );
+    }
+
+    private function mockDatabaseHelper(string $connectionString): void
+    {
         $dbHelperMock = $this->getMockBuilder(DatabaseHelper::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getMysqlClientToolConnectionString', 'detectDbSettings']) // Specify methods to mock
+            ->setMethods(['getMysqlClientToolConnectionString', 'detectDbSettings'])
             ->getMock();
 
-        $dbHelperMock->method('getMysqlClientToolConnectionString')->willReturn('mysql_connection_string --host=localhost --user=test --password=test test_db');
-        $dbHelperMock->method('detectDbSettings'); // Mock this method to do nothing
+        $dbHelperMock->method('getMysqlClientToolConnectionString')->willReturn($connectionString);
+        $dbHelperMock->method('detectDbSettings');
 
-        // Replace the original helper with the mock in the application's helper set
-        $application->getHelperSet()->set($dbHelperMock, 'database');
-        // It's also important to set it on the command itself if it fetches it directly
-        // However, n98-magerun2 commands typically get helpers from the application.
-
-        // Execute the command
-        // We pass a dummy query. Since exec is not mocked, it might try to run mysql.
-        // The goal is to ensure the command infrastructure handles the --format=csv.
-        // We expect it to fail gracefully or produce no output if mysql is not configured or the query is bad.
-        $this->executeCommand(
-            $command,
-            ['query' => 'SELECT 1', '--format' => 'csv'],
-            ['interactive' => false] // Disable interaction for QuestionHelper
-        );
-
-        // Basic assertion: Check that the command didn't throw an unhandled exception
-        // and produced some output (even if it's an error message from mysql client,
-        // it means our command part worked).
-        // If exec fails because mysql is not found, QueryCommand writes to error output.
-        // The important part is that our CSV logic path was taken.
-        // A more robust test would mock `exec` or check for specific CSV formatted output if `exec` could be controlled.
-        $this->assertStringContainsString('', $this->getDisplay());
-        // Optionally, check for absence of fatal errors in stderr if your test runner captures that.
+        $this->getApplication()->getHelperSet()->set($dbHelperMock, 'database');
     }
 }

--- a/tests/N98/Magento/Command/Database/QueryCommandTest.php
+++ b/tests/N98/Magento/Command/Database/QueryCommandTest.php
@@ -20,9 +20,11 @@ class QueryCommandTest extends TestCase
         $application = $this->getApplication();
         $this->assertTrue($application->has('db:query'), 'Command db:query should be registered.');
 
-        $this->mockDatabaseHelper('--host=localhost --user=test --password=test test_db');
-
-        $this->assertExecute(['command' => 'db:query', 'query' => 'SELECT 1', '--format' => 'csv']);
+        // Uses the real DatabaseHelper (configured against the test Magento install's
+        // actual database) so the query genuinely succeeds and exercises the CSV
+        // formatting path end to end.
+        $tester = $this->assertExecute(['command' => 'db:query', 'query' => 'SELECT 1', '--format' => 'csv']);
+        $this->assertStringContainsString('"1"', $tester->getDisplay());
     }
 
     public function testThrowsWhenNoQueryGivenNonInteractively()

--- a/tests/N98/Magento/Mcp/CommandToolHandlerTest.php
+++ b/tests/N98/Magento/Mcp/CommandToolHandlerTest.php
@@ -2,16 +2,18 @@
 
 namespace N98\Magento\Mcp;
 
+use Mcp\Exception\ToolCallException;
 use N98\Magento\Application;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class CommandToolHandlerTest extends TestCase
 {
-    public function testInvokePassesCommandNameToInput()
+    public function testInvokePassesSingleWordArgumentToInput()
     {
         $command = new class('proxy:command') extends Command {
             /** @var InputInterface|null */
@@ -40,6 +42,117 @@ class CommandToolHandlerTest extends TestCase
 
         $this->assertSame('bar', $result);
         $this->assertNotNull($command->capturedInput);
-        $this->assertSame("'proxy:command' --no-interaction bar", (string) $command->capturedInput);
+        $this->assertSame('bar', $command->capturedInput->getArgument('foo'));
+    }
+
+    public function testInvokePassesMultiWordArgumentVerbatim()
+    {
+        $command = new class('proxy:query') extends Command {
+            protected function configure(): void
+            {
+                $this->addArgument('query', InputArgument::OPTIONAL);
+            }
+
+            protected function execute(InputInterface $input, OutputInterface $output): int
+            {
+                $output->writeln((string) $input->getArgument('query'));
+
+                return 0;
+            }
+        };
+
+        $application = new Application();
+        $application->setAutoExit(false);
+        $application->add($command);
+
+        $handler = new CommandToolHandler($application, 'proxy:query');
+        $result = $handler("SELECT sku FROM catalog_product_entity WHERE sku = 'ABC-123' LIMIT 5;");
+
+        $this->assertSame(
+            "SELECT sku FROM catalog_product_entity WHERE sku = 'ABC-123' LIMIT 5;",
+            $result
+        );
+    }
+
+    public function testInvokeParsesLeadingOptionsBeforeArgument()
+    {
+        $command = new class('proxy:query') extends Command {
+            public $capturedInput;
+
+            protected function configure(): void
+            {
+                $this
+                    ->addArgument('query', InputArgument::OPTIONAL)
+                    ->addOption('format', null, InputOption::VALUE_OPTIONAL);
+            }
+
+            protected function execute(InputInterface $input, OutputInterface $output): int
+            {
+                $this->capturedInput = $input;
+                $output->writeln((string) $input->getArgument('query'));
+
+                return 0;
+            }
+        };
+
+        $application = new Application();
+        $application->setAutoExit(false);
+        $application->add($command);
+
+        $handler = new CommandToolHandler($application, 'proxy:query');
+        $handler("--format=csv SELECT sku FROM catalog_product_entity LIMIT 5;");
+
+        $this->assertSame('csv', $command->capturedInput->getOption('format'));
+        $this->assertSame(
+            'SELECT sku FROM catalog_product_entity LIMIT 5;',
+            $command->capturedInput->getArgument('query')
+        );
+    }
+
+    public function testInvokeSplitsWordsForArrayArgument()
+    {
+        $command = new class('proxy:array') extends Command {
+            public $capturedInput;
+
+            protected function configure(): void
+            {
+                $this->addArgument('type', InputArgument::IS_ARRAY | InputArgument::OPTIONAL);
+            }
+
+            protected function execute(InputInterface $input, OutputInterface $output): int
+            {
+                $this->capturedInput = $input;
+
+                return 0;
+            }
+        };
+
+        $application = new Application();
+        $application->setAutoExit(false);
+        $application->add($command);
+
+        $handler = new CommandToolHandler($application, 'proxy:array');
+        $handler('config layout');
+
+        $this->assertSame(['config', 'layout'], $command->capturedInput->getArgument('type'));
+    }
+
+    public function testInvokeThrowsWhenCommandAcceptsNoArgumentsButExtraTextGiven()
+    {
+        $command = new class('proxy:noargs') extends Command {
+            protected function execute(InputInterface $input, OutputInterface $output): int
+            {
+                return 0;
+            }
+        };
+
+        $application = new Application();
+        $application->setAutoExit(false);
+        $application->add($command);
+
+        $handler = new CommandToolHandler($application, 'proxy:noargs');
+
+        $this->expectException(ToolCallException::class);
+        $handler('unexpected extra text');
     }
 }


### PR DESCRIPTION
## Summary

Fixes #2072 — `db:query` silently returned no output (neither result rows nor an error) when invoked as an MCP tool through the persistent `mcp:server:start` process, for both successful and failing queries, while the same query worked fine via direct CLI.

Root cause was three compounding issues:

- `CommandToolHandler` built the command's `Input` from a `StringInput`, which shell-tokenizes the raw argument string. A free-form, multi-word SQL query either failed to bind ("Too many arguments") or had embedded quotes corrupted — there was no reliable way to pass such a value through the MCP bridge.
- `QueryCommand` fell back to a Laravel Prompts `text()` prompt when no query argument was given. In the non-interactive MCP daemon (STDIN isn't a TTY), this silently returns `''` instead of prompting, so the command ran `mysql -e ''` and exited `0` with no output — masking both the "no query given" and "query failed" cases behind the same symptom.
- `QueryCommand` used `exec()`, which only ever captures STDOUT, never STDERR, so real MySQL error text was never visible through the command's own output layer.

## Changes

- `CommandToolHandler`: replaced the `StringInput`-based bridge with an option-aware scanner that recognizes leading `--option`/`-x` tokens and passes the remainder verbatim into the target command's scalar argument via `ArrayInput` (still word-splitting for `IS_ARRAY` arguments).
- `QueryCommand`: throws a clear `RuntimeException` when no query is given non-interactively instead of silently querying with an empty string, and switched from `exec()` to `Symfony\Process` to reliably capture and surface stdout/stderr separately.
- Fixed `QueryCommandTest`, which extended `MagerunCommandTester` (a helper class meant to be composed via a `TestCase`, not subclassed) and therefore never actually executed under PHPUnit — it now extends the project's `TestCase` base class like every other command test, with added coverage for the new exception and stderr surfacing on failure.
- Rewrote `CommandToolHandlerTest` with coverage for multi-word/quoted arguments, leading options, `IS_ARRAY` arguments, and rejection of stray extra input for zero-argument commands.

## Test plan

- [x] `vendor/bin/phpunit tests/N98/Magento/Mcp/CommandToolHandlerTest.php` — 5 tests, all passing
- [x] `vendor/bin/phpunit tests/N98/Magento/Command/Database/QueryCommandTest.php` — runs correctly now (skips without a real Magento install, consistent with the rest of the command test suite)
- [x] Full suite (`vendor/bin/phpunit`) — no new failures; pre-existing failures (`mydumper` binary missing, a `which`-based security test quirk) reproduce identically on `develop`
- [x] `php-cs-fixer` dry-run — clean on all changed files