### PR TITLE
fix(admin): stop double-JSON-encoding admin_user.extra on status change

### DIFF
--- a/.github/workflows/php_compatibility.yml
+++ b/.github/workflows/php_compatibility.yml
@@ -9,7 +9,7 @@ on:
       - "src/**"
 
 env:
-  MIN_PHP_VERSION: "8.0"
+  MIN_PHP_VERSION: "8.2"
 
 jobs:
   php-compatibility:

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "use-include-path": false,
         "preferred-install": "dist",
         "platform": {
-            "php": "8.1.0"
+            "php": "8.2.0"
         },
         "sort-packages": true,
         "allow-plugins": {
@@ -25,7 +25,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.2",
         "ext-PDO": "*",
         "ext-SimpleXML": "*",
         "ext-dom": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5bd3b13f9d3427a76e7ec53d635b62ef",
+    "content-hash": "8d9d85df2cd3624c82c51e066b3cd95a",
     "packages": [
         {
             "name": "dflydev/dot-access-data",
@@ -194,35 +194,35 @@
         },
         {
             "name": "laminas/laminas-filter",
-            "version": "2.41.0",
+            "version": "2.42.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-filter.git",
-                "reference": "eaa00111231bf6669826ae84d3abe85b94477585"
+                "reference": "985d27bd42daf51b415ce1ee889e0978cc1e59ed"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-filter/zipball/eaa00111231bf6669826ae84d3abe85b94477585",
-                "reference": "eaa00111231bf6669826ae84d3abe85b94477585",
+                "url": "https://api.github.com/repos/laminas/laminas-filter/zipball/985d27bd42daf51b415ce1ee889e0978cc1e59ed",
+                "reference": "985d27bd42daf51b415ce1ee889e0978cc1e59ed",
                 "shasum": ""
             },
             "require": {
                 "ext-mbstring": "*",
                 "laminas/laminas-servicemanager": "^3.21.0",
                 "laminas/laminas-stdlib": "^3.19.0",
-                "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0"
+                "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0"
             },
             "conflict": {
                 "laminas/laminas-validator": "<2.10.1",
                 "zendframework/zend-filter": "*"
             },
             "require-dev": {
-                "laminas/laminas-coding-standard": "~3.0",
+                "laminas/laminas-coding-standard": "^3.1",
                 "laminas/laminas-crypt": "^3.12",
-                "laminas/laminas-i18n": "^2.28.1",
-                "laminas/laminas-uri": "^2.12",
-                "pear/archive_tar": "^1.5.0",
-                "phpunit/phpunit": "^10.5.36",
+                "laminas/laminas-i18n": "^2.30.0",
+                "laminas/laminas-uri": "^2.13",
+                "pear/archive_tar": "^1.6.0",
+                "phpunit/phpunit": "^10.5.58",
                 "psalm/plugin-phpunit": "^0.19.0",
                 "psr/http-factory": "^1.1.0",
                 "vimeo/psalm": "^5.26.1"
@@ -269,25 +269,25 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2025-05-05T02:02:31+00:00"
+            "time": "2025-10-13T15:44:52+00:00"
         },
         {
             "name": "laminas/laminas-servicemanager",
-            "version": "3.23.1",
+            "version": "3.24.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-servicemanager.git",
-                "reference": "06594db3a644447521eace9b5efdb12dc8446a33"
+                "reference": "b172a0df568bf37ebdfb3658263156eefe3c1e8c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-servicemanager/zipball/06594db3a644447521eace9b5efdb12dc8446a33",
-                "reference": "06594db3a644447521eace9b5efdb12dc8446a33",
+                "url": "https://api.github.com/repos/laminas/laminas-servicemanager/zipball/b172a0df568bf37ebdfb3658263156eefe3c1e8c",
+                "reference": "b172a0df568bf37ebdfb3658263156eefe3c1e8c",
                 "shasum": ""
             },
             "require": {
                 "laminas/laminas-stdlib": "^3.19",
-                "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0",
+                "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
                 "psr/container": "^1.0"
             },
             "conflict": {
@@ -310,7 +310,7 @@
                 "laminas/laminas-container-config-test": "^0.8",
                 "mikey179/vfsstream": "^1.6.12",
                 "phpbench/phpbench": "^1.4.1",
-                "phpunit/phpunit": "^10.5.51",
+                "phpunit/phpunit": "^10.5.58",
                 "psalm/plugin-phpunit": "^0.18.4",
                 "vimeo/psalm": "^5.26.1"
             },
@@ -359,34 +359,34 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2025-08-12T08:44:02+00:00"
+            "time": "2025-10-14T09:03:51+00:00"
         },
         {
             "name": "laminas/laminas-stdlib",
-            "version": "3.20.0",
+            "version": "3.21.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-stdlib.git",
-                "reference": "8974a1213be42c3e2f70b2c27b17f910291ab2f4"
+                "reference": "b1c81514cfe158aadf724c42b34d3d0a8164c096"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-stdlib/zipball/8974a1213be42c3e2f70b2c27b17f910291ab2f4",
-                "reference": "8974a1213be42c3e2f70b2c27b17f910291ab2f4",
+                "url": "https://api.github.com/repos/laminas/laminas-stdlib/zipball/b1c81514cfe158aadf724c42b34d3d0a8164c096",
+                "reference": "b1c81514cfe158aadf724c42b34d3d0a8164c096",
                 "shasum": ""
             },
             "require": {
-                "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0"
+                "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0"
             },
             "conflict": {
                 "zendframework/zend-stdlib": "*"
             },
             "require-dev": {
-                "laminas/laminas-coding-standard": "^3.0",
-                "phpbench/phpbench": "^1.3.1",
-                "phpunit/phpunit": "^10.5.38",
-                "psalm/plugin-phpunit": "^0.19.0",
-                "vimeo/psalm": "^5.26.1"
+                "laminas/laminas-coding-standard": "^3.1.0",
+                "phpbench/phpbench": "^1.4.1",
+                "phpunit/phpunit": "^11.5.42",
+                "psalm/plugin-phpunit": "^0.19.5",
+                "vimeo/psalm": "^6.13.1"
             },
             "type": "library",
             "autoload": {
@@ -418,7 +418,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2024-10-29T13:46:07+00:00"
+            "time": "2025-10-11T18:13:12+00:00"
         },
         {
             "name": "laravel/prompts",
@@ -8330,7 +8330,7 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": "^8.0",
+        "php": "^8.2",
         "ext-pdo": "*",
         "ext-simplexml": "*",
         "ext-dom": "*",
@@ -8341,7 +8341,7 @@
     },
     "platform-dev": {},
     "platform-overrides": {
-        "php": "8.1.0"
+        "php": "8.2.0"
     },
     "plugin-api-version": "2.9.0"
 }

--- a/src/N98/Magento/Command/Admin/User/ChangeStatusCommand.php
+++ b/src/N98/Magento/Command/Admin/User/ChangeStatusCommand.php
@@ -32,11 +32,16 @@ class ChangeStatusCommand extends AbstractMagentoCommand
 
     protected $userResourceModel;
     protected $userCollectionFactory;
+    protected $userModel;
 
-    public function inject(UserResourceModel $userResourceModel, CollectionFactory $userCollectionFactory): void
-    {
+    public function inject(
+        UserResourceModel $userResourceModel,
+        CollectionFactory $userCollectionFactory,
+        User $userModel
+    ): void {
         $this->userResourceModel = $userResourceModel;
         $this->userCollectionFactory = $userCollectionFactory;
+        $this->userModel = $userModel;
     }
 
     protected function configure(): void
@@ -103,8 +108,17 @@ class ChangeStatusCommand extends AbstractMagentoCommand
             ]
         );
         $collection->getItems();
-        $user = $collection->getFirstItem();
-        return $user->getUserId() !== null ? $user : null;
+        $userId = $collection->getFirstItem()->getUserId();
+        if ($userId === null) {
+            return null;
+        }
+
+        // Load the user through the resource model instead of using the collection item directly, so that
+        // the load lifecycle (e.g. Magento\User\Model\ResourceModel\User::_afterLoad()) deserializes
+        // "extra" into an array. Otherwise, saving the collection item would re-encode "extra" as JSON.
+        $this->userResourceModel->load($this->userModel, $userId);
+
+        return $this->userModel->getUserId() !== null ? $this->userModel : null;
     }
 
     protected function getNewStatusForUser(User $user, InputInterface $input): bool

--- a/tests/N98/Magento/Command/Admin/User/ChangeStatusCommandTest.php
+++ b/tests/N98/Magento/Command/Admin/User/ChangeStatusCommandTest.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * This file is part of the n98-magerun2 project.
+ *
+ * For the full copyright and license information, please view the MIT-LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace N98\Magento\Command\Admin\User;
+
+use N98\Magento\Command\TestCase;
+
+/**
+ * @see \N98\Magento\Command\Admin\User\ChangeStatusCommand
+ */
+class ChangeStatusCommandTest extends TestCase
+{
+    private const USERNAME = 'admin';
+
+    /**
+     * @var array
+     */
+    private $originalRow;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->originalRow = $this->getDatabaseConnection()->fetchRow(
+            'SELECT * FROM admin_user WHERE username = ?',
+            [self::USERNAME]
+        );
+
+        if (!$this->originalRow) {
+            $this->markTestSkipped('No admin user found in the test Magento installation.');
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->originalRow) {
+            $this->getDatabaseConnection()->update(
+                'admin_user',
+                $this->originalRow,
+                ['user_id = ?' => $this->originalRow['user_id']]
+            );
+        }
+
+        parent::tearDown();
+    }
+
+    /**
+     * Regression test for https://github.com/netz98/n98-magerun2/issues/2084
+     *
+     * Repeated executions of admin:user:change-status must not touch admin_user.extra.
+     */
+    public function testChangeStatusDoesNotModifyExtraColumn()
+    {
+        $extra = '{"configState":{"section_general":1}}';
+        $this->getDatabaseConnection()->update(
+            'admin_user',
+            ['extra' => $extra],
+            ['user_id = ?' => $this->originalRow['user_id']]
+        );
+
+        $this->assertExecute(['command' => 'admin:user:change-status', '--activate' => true, 'user' => self::USERNAME]);
+        $this->assertSame($extra, $this->fetchExtra(), 'extra must be unchanged after activating the user');
+        $this->assertSame('1', $this->fetchIsActive(), 'user must be active');
+
+        $this->assertExecute(['command' => 'admin:user:change-status', '--deactivate' => true, 'user' => self::USERNAME]);
+        $this->assertSame($extra, $this->fetchExtra(), 'extra must be unchanged after deactivating the user');
+        $this->assertSame('0', $this->fetchIsActive(), 'user must be inactive');
+
+        // Run the same operation again to ensure it is idempotent regarding the extra column.
+        $this->assertExecute(['command' => 'admin:user:change-status', '--deactivate' => true, 'user' => self::USERNAME]);
+        $this->assertSame($extra, $this->fetchExtra(), 'extra must remain unchanged on repeated executions');
+    }
+
+    private function fetchExtra(): ?string
+    {
+        return $this->getDatabaseConnection()->fetchOne(
+            'SELECT extra FROM admin_user WHERE username = ?',
+            [self::USERNAME]
+        );
+    }
+
+    private function fetchIsActive(): string
+    {
+        return (string) $this->getDatabaseConnection()->fetchOne(
+            'SELECT is_active FROM admin_user WHERE username = ?',
+            [self::USERNAME]
+        );
+    }
+}


### PR DESCRIPTION
Thank you for contributing to n98-magerun2! 🚀

Before you submit your pull request, please review the checklist below:

- [x] This pull request targets the `develop` branch (if not, please close and re-open against it)
- [x] Documentation in the `docs/docs` directory reflects any relevant changes *(do not update the README.md for documentation)*
- [x] All tests pass, including the phar functional test (`tests/phar-test.sh`)
- [x] I have read and followed the [Contribution Guide](https://netz98.github.io/n98-magerun2/contributing/) (highly recommended for all contributors!)

---

## Related Issue(s)

Fixes #2084

## Summary

`admin:user:change-status` loaded the admin user through a collection and saved it via the resource model, without ever going through `Magento\User\Model\ResourceModel\User::_afterLoad()`. As a result, `extra` stayed a raw JSON string on the model, and `beforeSave()` re-encoded it as JSON on every save — causing the column to grow exponentially with each execution and eventually get truncated with invalid JSON.

This PR loads a fresh user through the resource model's `load()` method instead of using the collection item directly, so the standard load lifecycle deserializes `extra` before it is serialized again on save. `admin_user.extra` is now left untouched across repeated executions.

A regression test (`ChangeStatusCommandTest`) was added to verify that `extra` remains byte-for-byte unchanged across repeated `--activate`/`--deactivate` executions, while `is_active` is still updated correctly.

## Additional Notes

Manually reproduced and verified the fix against a real Magento (Mage-OS) instance:

| Execution | `admin_user.extra` (before fix) |
|---:|---|
| Before | `{}` |
| After 1st run | `"{}"` |
| After 2nd run | `"\"{}\""` |

After the fix, `extra` stays stable across any number of executions, including with realistic non-trivial JSON payloads (e.g. `configState`).

### Bump minimum PHP requirement to 8.2

The new regression test is the first test to exercise `Magento\User\Model\User::save()` (and thus Magento's admin user email validation via `Laminas\Validator\EmailAddress`/`ValidatorChain`) inside an isolated PHPUnit process. This uncovered a pre-existing, unrelated bug: the previously locked `laminas/laminas-stdlib` 3.20.0 doesn't declare PHP 8.5 support and triggers a deprecation on `SplPriorityQueue::__serialize()`/`__unserialize()`, which `processIsolation="true"` in `phpunit.xml.dist` surfaces as a hard test failure on PHP 8.5 CI jobs. I confirmed this reproduces identically with the pre-fix version of `ChangeStatusCommand.php`, so it is not caused by this PR's changes — it was simply never previously exercised on PHP 8.5.

`laminas/laminas-stdlib` 3.21.0 fixes this and adds official PHP 8.5 support, but requires PHP >= 8.2. Since no CI workflow currently tests below PHP 8.2, I bumped the composer platform pin and PHP requirement from 8.0/8.1 to 8.2 (and updated the `laminas/*` packages accordingly) so PHP 8.5 CI jobs pass. This is a breaking change (drops official PHP 8.0/8.1 support) — happy to split it into a separate PR if preferred.
