### PR TITLE
fix(console): prevent nested style errors in list output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ super-linter.log
 /*.sql.gz
 
 .tokensave
+.serena
 
 # Claude Code
 .claude/.headroom_wrap_marker.json

--- a/src/N98/Magento/Application/Console/Descriptor/MagerunTextDescriptor.php
+++ b/src/N98/Magento/Application/Console/Descriptor/MagerunTextDescriptor.php
@@ -202,21 +202,26 @@ final class MagerunTextDescriptor extends TextDescriptor
             $isGrouped = !$describedNamespace && ApplicationDescription::GLOBAL_NAMESPACE !== $namespace['id'];
 
             if ($isGrouped) {
-                $this->writeRaw(sprintf("\n  <subheading>%s</subheading>\n", $namespace['id']), $options);
+                $this->writeRaw(sprintf(
+                    "\n  <subheading>%s</subheading>\n",
+                    OutputFormatter::escape($namespace['id'])
+                ), $options);
             }
 
             foreach ($namespace['commands'] as $name) {
                 $command = $commands[$name];
-                $aliases = $name === $command->getName() ? $this->aliasesText($command) : '';
+                $aliases = $name === $command->getName()
+                    ? OutputFormatter::escape($this->aliasesText($command))
+                    : '';
                 $indent = $isGrouped ? '    ' : '  ';
                 $padding = max(1, $width - Helper::width($name) - ($isGrouped ? 2 : 0));
 
                 $this->writeRaw(sprintf(
                     "%s<accent>%s</accent>%s<muted>%s</muted>\n",
                     $indent,
-                    $name,
+                    OutputFormatter::escape($name),
                     str_repeat(' ', $padding),
-                    $aliases . $command->getDescription()
+                    $aliases . OutputFormatter::escape($command->getDescription())
                 ), $options);
             }
         }

--- a/tests/N98/Magento/Application/Console/Descriptor/MagerunTextDescriptorTest.php
+++ b/tests/N98/Magento/Application/Console/Descriptor/MagerunTextDescriptorTest.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * This file is part of the n98-magerun2 project.
+ *
+ * For the full copyright and license information, please view the MIT-LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace N98\Magento\Application\Console\Descriptor;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class MagerunTextDescriptorTest extends TestCase
+{
+    public function testCommandMetadataCannotBreakDecoratedListFormatting(): void
+    {
+        $application = new Application('test');
+        $application->add(new Command('broken-command'));
+        $application->get('broken-command')->setDescription('Broken </muted><accent>command metadata');
+
+        $output = new BufferedOutput(OutputInterface::VERBOSITY_NORMAL, true);
+
+        (new MagerunTextDescriptor())->describe($output, $application);
+
+        $this->assertStringContainsString('Broken </muted><accent>command metadata', $output->fetch());
+    }
+}

--- a/tests/bats/functional_magerun_commands.bats
+++ b/tests/bats/functional_magerun_commands.bats
@@ -56,6 +56,13 @@ function cleanup_files_in_magento() {
   assert_output --partial "n98-magerun2"
 }
 
+@test "Test Application - list with ANSI output" {
+  run $BIN --ansi "list"
+  assert_success
+  assert_output --partial "COMMANDS"
+  refute_output --partial "Incorrectly nested style tag found"
+}
+
 @test "Test Application - help" {
   run $BIN "list"
   assert_output --partial "Display help for a command"


### PR DESCRIPTION
## Summary
- escape dynamic command metadata in styled `list` output
- add PHPUnit and BATS regression coverage for malformed formatter tags
- ignore Serena project metadata in `.gitignore`

## Testing
- `bats tests/bats/functional_magerun_commands.bats --filter "list with ANSI"`
- `vendor/bin/phpunit tests/N98/Magento/Application/Console/Descriptor/MagerunTextDescriptorTest.php`
- `php bin/n98-magerun2 list --ansi`
- PHP-CS-Fixer dry-run passed for changed PHP files

The focused existing `ListCommandTest` requires a configured Magento test root and could not run in this environment.