### PR TITLE
feat(console): add table export formats

### DIFF
--- a/docs/docs/command-docs/cache/cache-disable.md
+++ b/docs/docs/command-docs/cache/cache-disable.md
@@ -14,6 +14,6 @@ n98-magerun2.phar cache:disable [--format[=FORMAT]] [type...]
 
 | Option              | Description                                         |
 |---------------------|-----------------------------------------------------|
-| `--format[=FORMAT]` | Output Format. One of [csv,json,json_array,yaml,xml] |
+| `--format[=FORMAT]` | Output Format. One of [csv,tsv,json,json_array,jsonl,yaml,markdown,xml]. Aliases: yml,md,ndjson |
 
 If no code is specified, all cache types will be disabled. Run `cache:list` command to see all codes.

--- a/docs/docs/command-docs/cache/cache-enable.md
+++ b/docs/docs/command-docs/cache/cache-enable.md
@@ -14,6 +14,6 @@ n98-magerun2.phar cache:enable [--format[=FORMAT]] [type...]
 
 | Option              | Description                                         |
 |---------------------|-----------------------------------------------------|
-| `--format[=FORMAT]` | Output Format. One of [csv,json,json_array,yaml,xml] |
+| `--format[=FORMAT]` | Output Format. One of [csv,tsv,json,json_array,jsonl,yaml,markdown,xml]. Aliases: yml,md,ndjson |
 
 If no code is specified, all cache types will be enabled. Run `cache:list` command to see all codes.

--- a/docs/docs/command-docs/cache/cache-list.md
+++ b/docs/docs/command-docs/cache/cache-list.md
@@ -15,4 +15,4 @@ n98-magerun2.phar cache:list [--enabled[=ENABLED]] [--format[=FORMAT]]
 | Option                | Description                                                              |
 |-----------------------|--------------------------------------------------------------------------|
 | `--enabled[=ENABLED]` | Filter the list to display only enabled [1] or disabled [0] cache types  |
-| `--format[=FORMAT]`   | Output Format. One of [csv,json,json_array,yaml,xml]                     |
+| `--format[=FORMAT]`   | Output Format. One of [csv,tsv,json,json_array,jsonl,yaml,markdown,xml]. Aliases: yml,md,ndjson                     |

--- a/docs/docs/command-docs/cache/cache-report.md
+++ b/docs/docs/command-docs/cache/cache-report.md
@@ -21,4 +21,4 @@ n98-magerun2.phar cache:report [options]
 | `-m, --mtime`               | Output last modification time                                  |
 | `--filter-id[=FILTER-ID]`   | Filter output by ID (substring)                                |
 | `--filter-tag[=FILTER-TAG]` | Filter output by TAG (separate multiple tags by comma)         |
-| `--format[=FORMAT]`         | Output Format. One of [csv, json, json_array, yaml, xml]       |
+| `--format[=FORMAT]`         | Output Format. One of [csv, tsv, json, json_array, jsonl, yaml, markdown, xml]. Aliases: yml, md, ndjson       |

--- a/docs/docs/command-docs/config/config-data-indexer.md
+++ b/docs/docs/command-docs/config/config-data-indexer.md
@@ -16,7 +16,7 @@ n98-magerun2.phar config:data:indexer [options]
 |---------------------|---------------------------------------------------------------------------------------------------------|
 | `--scope` `-s`      | Config scope (`global`, `adminhtml`, `frontend`, `webapi_rest`, `webapi_soap`, ...) (default: `global`) |
 | `--tree` `-t`       | Print data as tree                                                                                      |
-| `--format[=FORMAT]` | Output Format. One of [csv,json,json_array,yaml,xml]                                                    |
+| `--format[=FORMAT]` | Output Format. One of [csv,tsv,json,json_array,jsonl,yaml,markdown,xml]. Aliases: yml,md,ndjson                                                    |
 
 
 ---

--- a/docs/docs/command-docs/config/config-data-mview.md
+++ b/docs/docs/command-docs/config/config-data-mview.md
@@ -16,7 +16,7 @@ n98-magerun2.phar config:data:mview [options]
 |---------------------|---------------------------------------------------------------------------------------------------------|
 | `--scope` `-s`      | Config scope (`global`, `adminhtml`, `frontend`, `webapi_rest`, `webapi_soap`, ...) (default: `global`) |
 | `--tree` `-t`       | Print data as tree                                                                                      |
-| `--format[=FORMAT]` | Output Format. One of [csv,json,json_array,yaml,xml]                                                    |
+| `--format[=FORMAT]` | Output Format. One of [csv,tsv,json,json_array,jsonl,yaml,markdown,xml]. Aliases: yml,md,ndjson                                                    |
 
 
 ---

--- a/docs/docs/command-docs/config/config-store-get.md
+++ b/docs/docs/command-docs/config/config-store-get.md
@@ -25,7 +25,7 @@ n98-magerun2.phar config:store:get [--scope="..."] [--scope-id="..."] [--decrypt
 | `--decrypt`        | Decrypt the config value using crypt key defined in `env.php`.               |
 | `--update-script`  | Output as update script lines.                                               |
 | `--magerun-script` | Output for usage with `config:store:set`.                                    |
-| `--format[=FORMAT]`| Output Format. One of [csv,json,json_array,yaml,xml].                        |
+| `--format[=FORMAT]`| Output Format. One of [csv,tsv,json,json_array,jsonl,yaml,markdown,xml]. Aliases: yml,md,ndjson                        |
 
 **Help:**
 
@@ -36,4 +36,3 @@ If path is not set, all available config items will be listed. path may contain 
 ```sh
 n98-magerun2.phar config:store:get web/* --magerun-script
 ```
-

--- a/docs/docs/command-docs/customer/customer-create.md
+++ b/docs/docs/command-docs/customer/customer-create.md
@@ -25,7 +25,7 @@ n98-magerun2.phar customer:create foo@example.com passworD123 John Doe base taxv
 
 | Option              | Description                                          |
 |---------------------|------------------------------------------------------|
-| `--format[=FORMAT]` | Output Format. One of [csv,json,json_array,yaml,xml] |
+| `--format[=FORMAT]` | Output Format. One of [csv,tsv,json,json_array,jsonl,yaml,markdown,xml]. Aliases: yml,md,ndjson |
 
 ---
 

--- a/docs/docs/command-docs/db/db-info.md
+++ b/docs/docs/command-docs/db/db-info.md
@@ -25,7 +25,7 @@ n98-magerun2.phar db:info [options] [--] [<setting>]
 | Option                   | Description                                                                 |
 |--------------------------|-----------------------------------------------------------------------------|
 | `--connection=CONNECTION`| Select DB connection type for Magento configurations with several databases |
-| `--format[=FORMAT]`      | Output Format. One of [csv,json,json_array,yaml,xml]                        |
+| `--format[=FORMAT]`      | Output Format. One of [csv,tsv,json,json_array,jsonl,yaml,markdown,xml]. Aliases: yml,md,ndjson                        |
 
 **Help:**
 

--- a/docs/docs/command-docs/db/db-maintain-check-tables.md
+++ b/docs/docs/command-docs/db/db-maintain-check-tables.md
@@ -21,4 +21,4 @@ n98-magerun2.phar db:maintain:check-tables [options]
 | `--type[=TYPE]`    | Check type (one of QUICK, FAST, MEDIUM, EXTENDED, CHANGED) [default: "MEDIUM"] |
 | `--repair`         | Repair tables (only MyISAM)                                                 |
 | `--table[=TABLE]`  | Process only given table (wildcards are supported)                          |
-| `--format[=FORMAT]`| Output Format. One of [csv,json,json_array,yaml,xml]                        |
+| `--format[=FORMAT]`| Output Format. One of [csv,tsv,json,json_array,jsonl,yaml,markdown,xml]. Aliases: yml,md,ndjson                        |

--- a/docs/docs/command-docs/db/db-status.md
+++ b/docs/docs/command-docs/db/db-status.md
@@ -25,6 +25,6 @@ n98-magerun2.phar db:status [options] [--] [<search>]
 | Option                   | Description                                                                 |
 |--------------------------|-----------------------------------------------------------------------------|
 | `--connection=CONNECTION`| Select DB connection type for Magento configurations with several databases |
-| `--format[=FORMAT]`      | Output Format. One of [csv,json,json_array,yaml,xml]                        |
+| `--format[=FORMAT]`      | Output Format. One of [csv,tsv,json,json_array,jsonl,yaml,markdown,xml]. Aliases: yml,md,ndjson                        |
 | `--rounding[=ROUNDING]`  | Amount of decimals to display. If -1 then disabled [default: 0]             |
 | `--no-description`       | Disable description                                                         |

--- a/docs/docs/command-docs/db/db-variables.md
+++ b/docs/docs/command-docs/db/db-variables.md
@@ -25,6 +25,6 @@ n98-magerun2.phar db:variables [options] [--] [<search>]
 | Option                   | Description                                                                 |
 |--------------------------|-----------------------------------------------------------------------------|
 | `--connection=CONNECTION`| Select DB connection type for Magento configurations with several databases |
-| `--format[=FORMAT]`      | Output Format. One of [csv,json,json_array,yaml,xml]                        |
+| `--format[=FORMAT]`      | Output Format. One of [csv,tsv,json,json_array,jsonl,yaml,markdown,xml]. Aliases: yml,md,ndjson                        |
 | `--rounding[=ROUNDING]`  | Amount of decimals to display. If -1 then disabled [default: 0]             |
 | `--no-description`       | Disable description                                                         |

--- a/docs/docs/command-docs/development/dev-module-list.md
+++ b/docs/docs/command-docs/development/dev-module-list.md
@@ -11,7 +11,7 @@ n98-magerun2.phar dev:module:list [options]
 | `--vendor[=VENDOR]` | Show modules of a specific vendor (case insensitive)   |
 | `-e, --only-enabled`| Show only enabled modules                              |
 | `-d, --only-disabled`| Show only disabled modules                             |
-| `--format[=FORMAT]` | Output Format. One of [csv,json,json_array,yaml,xml]   |
+| `--format[=FORMAT]` | Output Format. One of [csv,tsv,json,json_array,jsonl,yaml,markdown,xml]. Aliases: yml,md,ndjson   |
 
 :::info
 Lists all installed modules. You can filter by vendor, enabled/disabled state, and output format. Useful for auditing and debugging module status.

--- a/docs/docs/command-docs/development/dev-module-observer-list.md
+++ b/docs/docs/command-docs/development/dev-module-observer-list.md
@@ -24,4 +24,4 @@ n98-magerun2.phar dev:module:observer:list [--sort] [--format=FORMAT] [<event> [
 | Option            | Description                                         |
 |-------------------|-----------------------------------------------------|
 | --sort            | Sort output ascending by event name                 |
-| --format=FORMAT   | Output Format. One of [csv,json,json_array,yaml,xml]|
+| --format=FORMAT   | Output Format. One of [csv,tsv,json,json_array,jsonl,yaml,markdown,xml]. Aliases: yml,md,ndjson|

--- a/docs/docs/command-docs/development/dev-theme-list.md
+++ b/docs/docs/command-docs/development/dev-theme-list.md
@@ -8,7 +8,7 @@ n98-magerun2.phar dev:theme:list [--format[=FORMAT]]
 **Options:**
 | Option             | Description                                          |
 |--------------------|------------------------------------------------------|
-| `--format[=FORMAT]` | Output Format. One of [csv,json,json_array,yaml,xml] |
+| `--format[=FORMAT]` | Output Format. One of [csv,tsv,json,json_array,jsonl,yaml,markdown,xml]. Aliases: yml,md,ndjson |
 
 :::info
 Lists all available Magento themes. You can change the output format for easier integration with other tools or scripts.

--- a/docs/docs/command-docs/eav/eav-attribute-list.md
+++ b/docs/docs/command-docs/eav/eav-attribute-list.md
@@ -22,4 +22,4 @@ n98-magerun2.phar eav:attribute:list [options]
 | `--add-source`             | Add source models to list.                           |
 | `--add-backend`            | Add backend type to list.                            |
 | `--filter-type[=FILTER-TYPE]` | Filter attributes by entity type.                    |
-| `--format[=FORMAT]`        | Output Format. One of [csv,json,json_array,yaml,xml] |
+| `--format[=FORMAT]`        | Output Format. One of [csv,tsv,json,json_array,jsonl,yaml,markdown,xml]. Aliases: yml,md,ndjson |

--- a/docs/docs/command-docs/eav/eav-attribute-view.md
+++ b/docs/docs/command-docs/eav/eav-attribute-view.md
@@ -24,4 +24,4 @@ n98-magerun2.phar eav:attribute:view [--format[="..."]] <entityType> <attributeC
 **Options:**
 | Option             | Description                                          |
 |--------------------|------------------------------------------------------|
-| `--format[=FORMAT]` | Output Format. One of [csv,json,json_array,yaml,xml] |
+| `--format[=FORMAT]` | Output Format. One of [csv,tsv,json,json_array,jsonl,yaml,markdown,xml]. Aliases: yml,md,ndjson |

--- a/docs/docs/command-docs/index/index-list.md
+++ b/docs/docs/command-docs/index/index-list.md
@@ -18,4 +18,4 @@ n98-magerun2.phar index:list [--format[=FORMAT]]
 ## Options
 | Option              | Description                                         |
 |---------------------|-----------------------------------------------------|
-| `--format[=FORMAT]` | Output Format. One of [csv,json,json_array,yaml,xml] |
+| `--format[=FORMAT]` | Output Format. One of [csv,tsv,json,json_array,jsonl,yaml,markdown,xml]. Aliases: yml,md,ndjson |

--- a/docs/docs/command-docs/integration/integration-create.md
+++ b/docs/docs/command-docs/integration/integration-create.md
@@ -28,7 +28,7 @@ n98-magerun2.phar integration:create [options] [--] <name> [<email> [<endpoint>]
 | `--access-token=ACCESS-TOKEN`               | Access-Token (length 32 chars)                           |
 | `--access-token-secret=ACCESS-TOKEN-SECRET` | Access-Token Secret (length 32 chars)                    |
 | `--resource=RESOURCE` `-r`                  | Defines a granted ACL resource (multiple values allowed) |
-| `--format[=FORMAT]`                         | Output Format. One of [csv,json,json_array,yaml,xml]     |
+| `--format[=FORMAT]`                         | Output Format. One of [csv,tsv,json,json_array,jsonl,yaml,markdown,xml]. Aliases: yml,md,ndjson     |
 
 :::warning
 If no ACL resource is defined, the new integration token will be created with FULL ACCESS. To restrict access, provide a list of ACL resources using the `--resource` option.

--- a/docs/docs/command-docs/integration/integration-list.md
+++ b/docs/docs/command-docs/integration/integration-list.md
@@ -16,4 +16,4 @@ n98-magerun2.phar integration:list [--format[=FORMAT]]
 **Options:**
 | Option              | Description                                         |
 |---------------------|-----------------------------------------------------|
-| `--format[=FORMAT]` | Output Format. One of [csv,json,json_array,yaml,xml] |
+| `--format[=FORMAT]` | Output Format. One of [csv,tsv,json,json_array,jsonl,yaml,markdown,xml]. Aliases: yml,md,ndjson |

--- a/docs/docs/command-docs/integration/integration-show.md
+++ b/docs/docs/command-docs/integration/integration-show.md
@@ -24,7 +24,7 @@ n98-magerun2.phar integration:show [--format[=FORMAT]] <name_or_id> [<key>]
 **Options:**
 | Option             | Description                                          |
 |--------------------|------------------------------------------------------|
-| `--format[=FORMAT]` | Output Format. One of [csv,json,json_array,yaml,xml] |
+| `--format[=FORMAT]` | Output Format. One of [csv,tsv,json,json_array,jsonl,yaml,markdown,xml]. Aliases: yml,md,ndjson |
 
 ## Example (print only Access Key)
 ```sh

--- a/docs/docs/command-docs/routes/route-list.md
+++ b/docs/docs/command-docs/routes/route-list.md
@@ -13,7 +13,7 @@ n98-magerun2.phar route:list [-a|--area=AREA] [-m|--module=MODULE] [--format=FOR
 |--------------------------|------------------------------------------------------|
 | `-a, --area[=AREA]`      | Route area code. One of [frontend,adminhtml]         |
 | `-m, --module[=MODULE]`  | Show registered routes of a module                   |
-| `--format[=FORMAT]`      | Output Format. One of [csv,json,json_array,yaml,xml] |
+| `--format[=FORMAT]`      | Output Format. One of [csv,tsv,json,json_array,jsonl,yaml,markdown,xml]. Aliases: yml,md,ndjson |
 
 
 ---

--- a/docs/docs/command-docs/search/search-engine-list.md
+++ b/docs/docs/command-docs/search/search-engine-list.md
@@ -17,4 +17,4 @@ n98-magerun2.phar search:engine:list [--format[=FORMAT]]
 
 | Option              | Description                                         |
 |---------------------|-----------------------------------------------------|
-| `--format[=FORMAT]` | Output Format. One of [csv,json,json_array,yaml,xml] |
+| `--format[=FORMAT]` | Output Format. One of [csv,tsv,json,json_array,jsonl,yaml,markdown,xml]. Aliases: yml,md,ndjson |

--- a/docs/docs/command-docs/system/sys-cron-history.md
+++ b/docs/docs/command-docs/system/sys-cron-history.md
@@ -18,4 +18,4 @@ n98-magerun2.phar sys:cron:history [--format[="..."]] [--timezone[="..."]]
 | Option                | Description                                          |
 |-----------------------|------------------------------------------------------|
 | `--timezone[=TIMEZONE]`| Timezone to show finished at in                      |
-| `--format[=FORMAT]`   | Output Format. One of [csv,json,json_array,yaml,xml] |
+| `--format[=FORMAT]`   | Output Format. One of [csv,tsv,json,json_array,jsonl,yaml,markdown,xml]. Aliases: yml,md,ndjson |

--- a/docs/docs/command-docs/system/sys-cron-list.md
+++ b/docs/docs/command-docs/system/sys-cron-list.md
@@ -21,7 +21,7 @@ n98-magerun2.phar sys:cron:list [<job_code>] [--format[="..."]]
 ## Options
 | Option              | Description                                          |
 |---------------------|------------------------------------------------------|
-| `--format[=FORMAT]` | Output Format. One of [csv,json,json_array,yaml,xml] |
+| `--format[=FORMAT]` | Output Format. One of [csv,tsv,json,json_array,jsonl,yaml,markdown,xml]. Aliases: yml,md,ndjson |
 
 The `--format` option allows you to specify the output format for the list of cronjobs. Supported formats are:
 - csv

--- a/docs/docs/command-docs/system/sys-setup-compare-versions.md
+++ b/docs/docs/command-docs/system/sys-setup-compare-versions.md
@@ -14,7 +14,6 @@ n98-magerun2.phar sys:setup:compare-versions [--ignore-data] [--log-junit="..."]
 |------------------------|------------------------------------------------------|
 | `--ignore-data`        | Ignore data updates                                  |
 | `--log-junit=LOG-JUNIT`| Log output to a JUnit xml file.                      |
-| `--format[=FORMAT]`    | Output Format. One of [csv,json,json_array,yaml,xml] |
+| `--format[=FORMAT]`    | Output Format. One of [csv,tsv,json,json_array,jsonl,yaml,markdown,xml]. Aliases: yml,md,ndjson |
 
 - If a filename with `--log-junit` option is set the tool generates an XML file and no output to *stdout*.
-

--- a/docs/docs/concepts/index.md
+++ b/docs/docs/concepts/index.md
@@ -3,3 +3,4 @@ title: Concepts
 ---
 
 - [Proxy Commands for bin/magento](./bin-magento-proxy-commands.md)
+- [Table Output Formats](./table-output-formats.md)

--- a/docs/docs/concepts/table-output-formats.md
+++ b/docs/docs/concepts/table-output-formats.md
@@ -1,0 +1,71 @@
+---
+title: Table Output Formats
+sidebar_label: Table Output Formats
+---
+
+# Table Output Formats
+
+Commands that display tabular data provide a shared `--format` option. The option is available on commands such as `cache:list`, `customer:list`, `index:list`, and `sys:cron:list`.
+
+## Supported Formats
+
+| Format | Description |
+| --- | --- |
+| `csv` | Comma-separated values with a header row. Suitable for spreadsheets and general data exchange. |
+| `tsv` | Tab-separated values with a header row. Useful when values commonly contain commas. |
+| `json` | Pretty-printed JSON object output. |
+| `json_array` | Pretty-printed JSON array output. Use this when consumers expect a JSON array rather than an object. |
+| `jsonl` | One JSON object per line. Also known as JSON Lines. Useful for streaming and shell pipelines. |
+| `yaml` | YAML output for human-readable structured data. |
+| `markdown` | Pipe-delimited Markdown table output for documentation and issue trackers. |
+| `xml` | XML output wrapped in a `<table>` element. |
+
+## Format Aliases
+
+The following aliases produce the same output as their canonical format:
+
+| Alias | Format |
+| --- | --- |
+| `yml` | `yaml` |
+| `md` | `markdown` |
+| `ndjson` | `jsonl` |
+
+Aliases are case-insensitive, as are canonical format names.
+
+## Examples
+
+Export an indexer list as CSV:
+
+```sh
+n98-magerun2.phar index:list --format=csv
+```
+
+Generate a Markdown table:
+
+```sh
+n98-magerun2.phar customer:list --format=markdown
+```
+
+Process one JSON record at a time:
+
+```sh
+n98-magerun2.phar sys:cron:list --format=jsonl | while read -r row; do
+    printf '%s\n' "$row"
+done
+```
+
+Use an alias when preferred:
+
+```sh
+n98-magerun2.phar config:search "web/*" --format=yml
+```
+
+## Invalid Formats
+
+An unsupported value does not fall back to the default terminal table. The command exits with an error that identifies the invalid format and lists the supported canonical formats.
+
+```text
+Unknown output format "toml". Supported formats: csv, tsv, json, json_array, jsonl, yaml, markdown, xml.
+```
+
+TOML and TOON are intentionally not supported output formats. TOML is primarily intended for configuration, while TOON is a specialized, less widely supported notation for token-efficient data exchange. JSON, CSV, YAML, and Markdown provide better interoperability for the command-line use cases covered by n98-magerun2.

--- a/src/N98/Magento/Command/AbstractMagentoCommand.php
+++ b/src/N98/Magento/Command/AbstractMagentoCommand.php
@@ -124,7 +124,7 @@ abstract class AbstractMagentoCommand extends Command
             'format',
             null,
             InputOption::VALUE_OPTIONAL,
-            'Output Format. One of [' . implode(',', RendererFactory::getFormats()) . ']'
+            'Output Format. One of [' . implode(',', RendererFactory::getFormats()) . ']. Aliases: yml,md,ndjson'
         );
     }
 

--- a/src/N98/Util/Console/Helper/Table/Renderer/CsvRenderer.php
+++ b/src/N98/Util/Console/Helper/Table/Renderer/CsvRenderer.php
@@ -18,6 +18,8 @@ use Symfony\Component\Console\Output\StreamOutput;
  */
 class CsvRenderer implements RendererInterface
 {
+    protected $delimiter = ',';
+
     /**
      * @param OutputInterface $output
      * @param array           $rows
@@ -33,9 +35,9 @@ class CsvRenderer implements RendererInterface
         $i = 0;
         foreach ($rows as $row) {
             if ($i++ == 0) {
-                fputcsv($stream, array_keys($row), escape: '"');
+                fputcsv($stream, array_keys($row), $this->delimiter, '"', escape: '"');
             }
-            fputcsv($stream, $row, escape: '"');
+            fputcsv($stream, $row, $this->delimiter, '"', escape: '"');
         }
     }
 }

--- a/src/N98/Util/Console/Helper/Table/Renderer/JsonLinesRenderer.php
+++ b/src/N98/Util/Console/Helper/Table/Renderer/JsonLinesRenderer.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * This file is part of the n98-magerun2 project.
+ *
+ * For the full copyright and license information, please view the MIT-LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+namespace N98\Util\Console\Helper\Table\Renderer;
+
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * One JSON object per line renderer.
+ */
+class JsonLinesRenderer implements RendererInterface
+{
+    public function render(OutputInterface $output, array $rows)
+    {
+        foreach ($rows as $row) {
+            $output->writeln(
+                \json_encode($row, JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES),
+                OutputInterface::OUTPUT_RAW
+            );
+        }
+    }
+}

--- a/src/N98/Util/Console/Helper/Table/Renderer/MarkdownRenderer.php
+++ b/src/N98/Util/Console/Helper/Table/Renderer/MarkdownRenderer.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * This file is part of the n98-magerun2 project.
+ *
+ * For the full copyright and license information, please view the MIT-LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+namespace N98\Util\Console\Helper\Table\Renderer;
+
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * GitHub-flavoured Markdown table renderer.
+ */
+class MarkdownRenderer implements RendererInterface
+{
+    public function render(OutputInterface $output, array $rows)
+    {
+        if ($rows === []) {
+            return;
+        }
+
+        $headers = array_keys($rows[0]);
+        $output->writeln($this->row($headers), OutputInterface::OUTPUT_RAW);
+        $output->writeln($this->row(array_fill(0, count($headers), '---')), OutputInterface::OUTPUT_RAW);
+
+        foreach ($rows as $row) {
+            $output->writeln($this->row(array_values($row)), OutputInterface::OUTPUT_RAW);
+        }
+    }
+
+    private function row(array $cells): string
+    {
+        $cells = array_map(fn ($cell) => $this->escape($cell), $cells);
+
+        return '| ' . implode(' | ', $cells) . ' |';
+    }
+
+    private function escape($value): string
+    {
+        return str_replace(
+            ["\\", "|", "\r\n", "\r", "\n"],
+            ["\\\\", "\\|", '<br>', '<br>', '<br>'],
+            (string) $value
+        );
+    }
+}

--- a/src/N98/Util/Console/Helper/Table/Renderer/RendererFactory.php
+++ b/src/N98/Util/Console/Helper/Table/Renderer/RendererFactory.php
@@ -15,11 +15,20 @@ namespace N98\Util\Console\Helper\Table\Renderer;
 class RendererFactory
 {
     protected static $formats = [
-        'csv'  => 'N98\Util\Console\Helper\Table\Renderer\CsvRenderer',
-        'json' => 'N98\Util\Console\Helper\Table\Renderer\JsonRenderer',
+        'csv'        => 'N98\Util\Console\Helper\Table\Renderer\CsvRenderer',
+        'tsv'        => 'N98\Util\Console\Helper\Table\Renderer\TsvRenderer',
+        'json'       => 'N98\Util\Console\Helper\Table\Renderer\JsonRenderer',
         'json_array' => 'N98\Util\Console\Helper\Table\Renderer\JsonArrayRenderer',
-        'yaml'  => 'N98\Util\Console\Helper\Table\Renderer\YamlRenderer',
-        'xml'  => 'N98\Util\Console\Helper\Table\Renderer\XmlRenderer',
+        'jsonl'      => 'N98\Util\Console\Helper\Table\Renderer\JsonLinesRenderer',
+        'yaml'       => 'N98\Util\Console\Helper\Table\Renderer\YamlRenderer',
+        'markdown'   => 'N98\Util\Console\Helper\Table\Renderer\MarkdownRenderer',
+        'xml'        => 'N98\Util\Console\Helper\Table\Renderer\XmlRenderer',
+    ];
+
+    protected static $aliases = [
+        'yml'    => 'yaml',
+        'md'     => 'markdown',
+        'ndjson' => 'jsonl',
     ];
 
     /**
@@ -34,6 +43,7 @@ class RendererFactory
         }
 
         $format = strtolower($format);
+        $format = self::$aliases[$format] ?? $format;
         if (isset(self::$formats[$format])) {
             $rendererClass = self::$formats[$format];
             return new $rendererClass();

--- a/src/N98/Util/Console/Helper/Table/Renderer/TsvRenderer.php
+++ b/src/N98/Util/Console/Helper/Table/Renderer/TsvRenderer.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * This file is part of the n98-magerun2 project.
+ *
+ * For the full copyright and license information, please view the MIT-LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+namespace N98\Util\Console\Helper\Table\Renderer;
+
+/**
+ * Tab-separated table renderer.
+ */
+class TsvRenderer extends CsvRenderer
+{
+    protected $delimiter = "\t";
+}

--- a/src/N98/Util/Console/Helper/TableHelper.php
+++ b/src/N98/Util/Console/Helper/TableHelper.php
@@ -103,7 +103,17 @@ class TableHelper extends AbstractHelper implements CommandAware
         $rendererFactory = new RendererFactory();
         $renderer = $rendererFactory->create($format);
 
-        if ($renderer && $renderer instanceof RendererInterface) {
+        if ($format !== null && $renderer === false) {
+            throw new \InvalidArgumentException(
+                sprintf(
+                    'Unknown output format "%s". Supported formats: %s.',
+                    $format,
+                    implode(', ', RendererFactory::getFormats())
+                )
+            );
+        }
+
+        if ($renderer instanceof RendererInterface) {
             foreach ($rows as &$row) {
                 if (!empty($this->headers)) {
                     $row = array_combine($this->headers, $row);

--- a/tests/N98/Util/Console/Helper/Table/Renderer/JsonLinesRendererTest.php
+++ b/tests/N98/Util/Console/Helper/Table/Renderer/JsonLinesRendererTest.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * This file is part of the n98-magerun2 project.
+ *
+ * For the full copyright and license information, please view the MIT-LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+namespace N98\Util\Console\Helper\Table\Renderer;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Output\StreamOutput;
+
+class JsonLinesRendererTest extends TestCase
+{
+    public function testRender(): void
+    {
+        $stream = fopen('php://memory', 'r+');
+        $output = new StreamOutput($stream);
+
+        (new JsonLinesRenderer())->render($output, [
+            ['name' => 'Alice', 'active' => true],
+            ['name' => 'Bob', 'active' => false],
+        ]);
+
+        rewind($stream);
+        self::assertSame(
+            "{\"name\":\"Alice\",\"active\":true}\n{\"name\":\"Bob\",\"active\":false}\n",
+            stream_get_contents($stream)
+        );
+        fclose($stream);
+    }
+
+    public function testRenderEmptyRows(): void
+    {
+        $stream = fopen('php://memory', 'r+');
+        $output = new StreamOutput($stream);
+
+        (new JsonLinesRenderer())->render($output, []);
+
+        rewind($stream);
+        self::assertSame('', stream_get_contents($stream));
+        fclose($stream);
+    }
+}

--- a/tests/N98/Util/Console/Helper/Table/Renderer/MarkdownRendererTest.php
+++ b/tests/N98/Util/Console/Helper/Table/Renderer/MarkdownRendererTest.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * This file is part of the n98-magerun2 project.
+ *
+ * For the full copyright and license information, please view the MIT-LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+namespace N98\Util\Console\Helper\Table\Renderer;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Output\StreamOutput;
+
+class MarkdownRendererTest extends TestCase
+{
+    public function testRender(): void
+    {
+        $stream = fopen('php://memory', 'r+');
+        $output = new StreamOutput($stream);
+
+        (new MarkdownRenderer())->render($output, [
+            ['name' => 'Alice', 'note' => 'A | B'],
+            ['name' => 'Bob', 'note' => "line 1\nline 2"],
+        ]);
+
+        rewind($stream);
+        self::assertSame(
+            "| name | note |\n| --- | --- |\n| Alice | A \\| B |\n| Bob | line 1<br>line 2 |\n",
+            stream_get_contents($stream)
+        );
+        fclose($stream);
+    }
+
+    public function testRenderEmptyRows(): void
+    {
+        $stream = fopen('php://memory', 'r+');
+        $output = new StreamOutput($stream);
+
+        (new MarkdownRenderer())->render($output, []);
+
+        rewind($stream);
+        self::assertSame('', stream_get_contents($stream));
+        fclose($stream);
+    }
+}

--- a/tests/N98/Util/Console/Helper/Table/Renderer/RendererFactoryTest.php
+++ b/tests/N98/Util/Console/Helper/Table/Renderer/RendererFactoryTest.php
@@ -20,11 +20,33 @@ class RendererFactoryTest extends \PHPUnit\Framework\TestCase
         $csv = $renderFactory->create('csv');
         $this->assertInstanceOf('N98\Util\Console\Helper\Table\Renderer\CsvRenderer', $csv);
 
+        $tsv = $renderFactory->create('tsv');
+        $this->assertInstanceOf('N98\Util\Console\Helper\Table\Renderer\TsvRenderer', $tsv);
+
         $json = $renderFactory->create('json');
         $this->assertInstanceOf('N98\Util\Console\Helper\Table\Renderer\JsonRenderer', $json);
 
         $jsonArray = $renderFactory->create('json_array');
         $this->assertInstanceOf('N98\Util\Console\Helper\Table\Renderer\JsonArrayRenderer', $jsonArray);
+
+        $jsonLines = $renderFactory->create('jsonl');
+        $this->assertInstanceOf('N98\Util\Console\Helper\Table\Renderer\JsonLinesRenderer', $jsonLines);
+
+        $yaml = $renderFactory->create('yaml');
+        $this->assertInstanceOf('N98\Util\Console\Helper\Table\Renderer\YamlRenderer', $yaml);
+        $this->assertInstanceOf('N98\Util\Console\Helper\Table\Renderer\YamlRenderer', $renderFactory->create('yml'));
+
+        $markdown = $renderFactory->create('markdown');
+        $this->assertInstanceOf('N98\Util\Console\Helper\Table\Renderer\MarkdownRenderer', $markdown);
+        $this->assertInstanceOf(
+            'N98\Util\Console\Helper\Table\Renderer\MarkdownRenderer',
+            $renderFactory->create('md')
+        );
+
+        $this->assertInstanceOf(
+            'N98\Util\Console\Helper\Table\Renderer\JsonLinesRenderer',
+            $renderFactory->create('ndjson')
+        );
 
         $xml = $renderFactory->create('xml');
         $this->assertInstanceOf('N98\Util\Console\Helper\Table\Renderer\XmlRenderer', $xml);
@@ -43,8 +65,11 @@ class RendererFactoryTest extends \PHPUnit\Framework\TestCase
         $this->assertContains('csv', $formats);
         $this->assertContains('json', $formats);
         $this->assertContains('json_array', $formats);
+        $this->assertContains('tsv', $formats);
+        $this->assertContains('jsonl', $formats);
         $this->assertContains('yaml', $formats);
+        $this->assertContains('markdown', $formats);
         $this->assertContains('xml', $formats);
-        $this->assertCount(5, $formats);
+        $this->assertCount(8, $formats);
     }
 }

--- a/tests/N98/Util/Console/Helper/Table/Renderer/TsvRendererTest.php
+++ b/tests/N98/Util/Console/Helper/Table/Renderer/TsvRendererTest.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * This file is part of the n98-magerun2 project.
+ *
+ * For the full copyright and license information, please view the MIT-LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+namespace N98\Util\Console\Helper\Table\Renderer;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Output\StreamOutput;
+
+class TsvRendererTest extends TestCase
+{
+    public function testRender(): void
+    {
+        $stream = fopen('php://memory', 'r+');
+        $output = new StreamOutput($stream);
+
+        (new TsvRenderer())->render($output, [
+            ['col1' => 'val1', 'col2' => 'val2'],
+            ['col1' => 'val3', 'col2' => 'val4'],
+        ]);
+
+        rewind($stream);
+        self::assertSame("col1\tcol2\nval1\tval2\nval3\tval4\n", stream_get_contents($stream));
+        fclose($stream);
+    }
+}

--- a/tests/N98/Util/Console/Helper/TableHelperTest.php
+++ b/tests/N98/Util/Console/Helper/TableHelperTest.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * This file is part of the n98-magerun2 project.
+ *
+ * For the full copyright and license information, please view the MIT-LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+namespace N98\Util\Console\Helper;
+
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+class TableHelperTest extends TestCase
+{
+    public function testInvalidFormatRaisesAnError(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unknown output format "invalid"');
+
+        (new TableHelper())->renderByFormat(new BufferedOutput(), [], 'invalid');
+    }
+
+    public function testMissingFormatStillRendersTheDefaultTable(): void
+    {
+        $output = new BufferedOutput();
+        $helper = new TableHelper();
+        $helper->setHeaders(['name']);
+
+        $helper->renderByFormat($output, [['Alice']]);
+
+        self::assertStringContainsString('Alice', $output->fetch());
+    }
+}


### PR DESCRIPTION
## Summary
- add TSV, JSON Lines, and Markdown table exports
- support `yml`, `md`, and `ndjson` aliases
- reject unknown `--format` values instead of falling back silently
- document formats and aliases across the command reference

## Tests
- `vendor/bin/phpunit tests/N98/Util/Console/Helper/Table/Renderer`
- `vendor/bin/phpunit tests/N98/Util/Console/Helper/TableHelperTest.php`
- PHP-CS-Fixer dry run passes
- Full PHPUnit suite currently has existing environment-related failures: 168 errors, 11 skipped, 1 incomplete

## Commits
Changes are split into feature, validation fix, and documentation commits using Conventional Commit messages.