### PR TITLE
fix(customer): support B2B customer deletion

### DIFF
--- a/src/N98/Magento/Command/Customer/DeleteCommand.php
+++ b/src/N98/Magento/Command/Customer/DeleteCommand.php
@@ -296,7 +296,10 @@ class DeleteCommand extends AbstractCustomerCommand
         $this->registry->register('isSecureArea', true);
         $isSecure = $this->registry->registry('isSecureArea');
         foreach ($customerCollection as $customerToDelete) {
-            if ($this->customerRepository->deleteById($customerToDelete->getId())) {
+            // Load the complete customer data before deleting it. This avoids Magento B2B
+            // plugins receiving the partially loaded collection entity through deleteById().
+            $customer = $this->customerRepository->getById($customerToDelete->getId());
+            if ($this->customerRepository->delete($customer)) {
                 $count++;
             }
         }

--- a/tests/N98/Magento/Command/Customer/DeleteCommandTest.php
+++ b/tests/N98/Magento/Command/Customer/DeleteCommandTest.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * This file is part of the n98-magerun2 project.
+ *
+ * For the full copyright and license information, please view the MIT-LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+namespace N98\Magento\Command\Customer;
+
+use Magento\Store\Model\StoreManagerInterface;
+use N98\Magento\Command\TestCase;
+
+class DeleteCommandTest extends TestCase
+{
+    public function testDeleteByEmail(): void
+    {
+        $email = uniqid('', true) . '@example.com';
+
+        $this->assertDisplayContains([
+            'command'   => 'customer:create',
+            'email'     => $email,
+            'password'  => 'Password123',
+            'firstname' => 'John',
+            'lastname'  => 'Doe',
+            'website'   => $this->getWebsiteCode(),
+        ], 'successfully created');
+
+        $this->assertDisplayContains([
+            'command' => 'customer:delete',
+            '--email' => $email,
+            '--force' => true,
+        ], 'Successfully deleted 1 customer/s');
+    }
+
+    private function getWebsiteCode(): string
+    {
+        $storeManager = $this->getApplication()->getObjectManager()->get(StoreManagerInterface::class);
+
+        return $storeManager->getWebsite('base')->getCode();
+    }
+}


### PR DESCRIPTION
## Problem
`customer:delete --email=...` uses the batch deletion path, which calls `deleteById()`. With Magento B2B modules installed, the Negotiable Quote plugin can receive an incompletely loaded customer and fail while extracting the customer email.

## Changes
- Load the complete customer with `getById()` before batch deletion.
- Use `delete()` so the repository receives the full customer data.
- Add a command-level regression test for deletion by email.

## Testing
- PHP syntax checks passed.
- PHP-CS-Fixer passed for changed files.
- PHPUnit was attempted but the local Magento test root is unavailable/misconfigured (`TestApplication` reads a directory as a file).
- PHPStan was attempted but this checkout does not contain Magento classes.