### PR TITLE
🔒 Fix plaintext password exposure in customer:create CLI output

### DIFF
--- a/src/N98/Magento/Command/Customer/CreateCommand.php
+++ b/src/N98/Magento/Command/Customer/CreateCommand.php
@@ -151,7 +151,6 @@ class CreateCommand extends AbstractCustomerCommand
                 } else {
                     $table[] = [
                         $email,
-                        $password,
                         $firstname,
                         $lastname,
                     ];
@@ -166,7 +165,7 @@ class CreateCommand extends AbstractCustomerCommand
 
         if (!$outputPlain) {
             $this->getHelper('table')
-                ->setHeaders(['email', 'password', 'firstname', 'lastname'])
+                ->setHeaders(['email', 'firstname', 'lastname'])
                 ->renderByFormat($output, $table, $input->getOption('format'));
         }
 

--- a/tests/N98/Magento/Command/Customer/CreateCommandTest.php
+++ b/tests/N98/Magento/Command/Customer/CreateCommandTest.php
@@ -37,8 +37,8 @@ class CreateCommandTest extends TestCase
         $input['email'] = $generatedEmail;
         $input['--format'] = 'csv';
 
-        $this->assertDisplayContains($input, 'email,password,firstname,lastname');
-        $this->assertdisplayContains($input, $generatedEmail . ',Password123,John,Doe');
+        $this->assertDisplayContains($input, 'email,firstname,lastname');
+        $this->assertdisplayContains($input, $generatedEmail . ',John,Doe');
     }
 
     public function testExecuteAdditionalFields()
@@ -61,8 +61,8 @@ class CreateCommandTest extends TestCase
         $input['email'] = $generatedEmail;
         $input['--format'] = 'csv';
 
-        $this->assertDisplayContains($input, 'email,password,firstname,lastname');
-        $this->assertdisplayContains($input, $generatedEmail . ',Password123,John,Doe');
+        $this->assertDisplayContains($input, 'email,firstname,lastname');
+        $this->assertdisplayContains($input, $generatedEmail . ',John,Doe');
     }
 
     /**


### PR DESCRIPTION
🎯 **What:** Fixed a security vulnerability where plaintext passwords were exposed in the CLI output of the `customer:create` command.

⚠️ **Risk:** Displaying plaintext passwords in terminal output poses a risk of sensitive data exposure via shoulder surfing, terminal scrollback history, or insecure logging of command output.

🛡️ **Solution:** The password field has been removed from the output table and its headers in `src/N98/Magento/Command/Customer/CreateCommand.php`. Corresponding test assertions in `tests/N98/Magento/Command/Customer/CreateCommandTest.php` have been updated to reflect this change.

---
*PR created automatically by Jules for task [4436192053789305013](https://jules.google.com/task/4436192053789305013) started by @cmuench*