### PR TITLE
feat(system): add website create and delete commands

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -177,6 +177,8 @@ commands:
     - N98\Magento\Command\System\Url\RegenerateCommand
     - N98\Magento\Command\System\Store\Config\BaseUrlListCommand
     - N98\Magento\Command\System\Website\ListCommand
+    - N98\Magento\Command\System\Website\CreateCommand
+    - N98\Magento\Command\System\Website\DeleteCommand
     - N98\Magento\Command\Indexer\ListCommand
     - N98\Magento\Command\Indexer\RecreateTriggersCommand
     - N98\Magento\Command\Integration\CreateCommand
@@ -249,7 +251,7 @@ commands:
 
       - id: unsafe
         description: Commands that can mutate or delete data
-        commands: "admin:* cache:clean cache:disable cache:enable cache:flush cache:remove:id cms:block:toggle config:env:create config:env:delete config:env:set config:store:delete config:store:set customer:add-address customer:change-password customer:create customer:delete db:* dev:* eav:attribute:remove generation:flush index:trigger:recreate integration:create integration:delete install media:dump sales:sequence:* script script:repo:run sys:cron:kill sys:cron:run sys:cron:schedule sys:maintenance sys:setup:* sys:url:regenerate"
+        commands: "admin:* cache:clean cache:disable cache:enable cache:flush cache:remove:id cms:block:toggle config:env:create config:env:delete config:env:set config:store:delete config:store:set customer:add-address customer:change-password customer:create customer:delete db:* dev:* eav:attribute:remove generation:flush index:trigger:recreate integration:create integration:delete install media:dump sales:sequence:* script script:repo:run sys:cron:kill sys:cron:run sys:cron:schedule sys:maintenance sys:setup:* sys:url:regenerate sys:website:create sys:website:delete"
 
       - id: system
         description: System commands

--- a/docs/docs/command-docs/system/index.md
+++ b/docs/docs/command-docs/system/index.md
@@ -15,6 +15,8 @@ Commands for system-level information, checks, and maintenance tasks in Magento.
 - sys:info - Provide system information like edition, version, cache backends
 - [sys:store:list](./sys-store-list.md) - List all store views
 - sys:website:list - List all websites
+- [sys:website:create](./sys-website.md) - Create a website
+- [sys:website:delete](./sys-website.md) - Delete a website
 
 ### Cron Jobs
 - [sys:cron:list](./sys-cron-list.md) - List all cronjobs defined in crontab.xml files

--- a/docs/docs/command-docs/system/sys-website.md
+++ b/docs/docs/command-docs/system/sys-website.md
@@ -1,0 +1,21 @@
+---
+title: Website Commands
+---
+
+# Website Commands
+
+## sys:website:create
+
+Creates a website from the supplied code and name. If either value is omitted, the command prompts for it.
+
+```bash
+bin/n98-magerun2 sys:website:create [<code>] [<name>] [--default-group-id=<id>]
+```
+
+## sys:website:delete
+
+Deletes a website by code or ID. If no identifier is supplied, the command displays a selector. The default website cannot be deleted. The command asks for confirmation unless `--force` (or `-f`) is supplied.
+
+```bash
+bin/n98-magerun2 sys:website:delete [<code-or-id>] [--force]
+```

--- a/src/N98/Magento/Command/System/Website/CreateCommand.php
+++ b/src/N98/Magento/Command/System/Website/CreateCommand.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * This file is part of the n98-magerun2 project.
+ *
+ * For the full copyright and license information, please view the MIT-LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+namespace N98\Magento\Command\System\Website;
+
+use function Laravel\Prompts\text;
+use Magento\Store\Model\WebsiteFactory;
+use N98\Magento\Command\AbstractMagentoCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Exception\RuntimeException;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class CreateCommand extends AbstractMagentoCommand
+{
+    /**
+     * @var WebsiteFactory
+     */
+    private $websiteFactory;
+
+    protected function configure()
+    {
+        $this
+            ->setName('sys:website:create')
+            ->addArgument('code', InputArgument::OPTIONAL, 'Website code')
+            ->addArgument('name', InputArgument::OPTIONAL, 'Website name')
+            ->addOption(
+                'default-group-id',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'ID of the default store group'
+            )
+            ->setDescription('Create a new website');
+    }
+
+    public function inject(WebsiteFactory $websiteFactory)
+    {
+        $this->websiteFactory = $websiteFactory;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $code = $input->getArgument('code');
+        if ($code === null || $code === '') {
+            $code = text(
+                '<question>Website code:</question>',
+                validate: fn ($value) => $this->validateWebsiteCode($value)
+            );
+        }
+
+        $codeValidationError = $this->validateWebsiteCode($code);
+        if ($codeValidationError !== null) {
+            throw new RuntimeException($codeValidationError);
+        }
+
+        $name = $input->getArgument('name');
+        if ($name === null || $name === '') {
+            $name = text(
+                '<question>Website name:</question>',
+                validate: fn ($value) => $value === '' ? 'Please enter a website name' : null
+            );
+        }
+
+        $website = $this->websiteFactory->create();
+        $website->setCode($code);
+        $website->setName($name);
+
+        $defaultGroupId = $input->getOption('default-group-id');
+        if ($defaultGroupId !== null) {
+            if (!ctype_digit((string) $defaultGroupId) || (int) $defaultGroupId < 1) {
+                throw new RuntimeException('The default group ID must be a positive integer.');
+            }
+
+            $website->setDefaultGroupId((int) $defaultGroupId);
+        }
+
+        try {
+            $website->save();
+        } catch (\Exception $exception) {
+            $output->writeln('<error>' . $exception->getMessage() . '</error>');
+
+            return Command::FAILURE;
+        }
+
+        $output->writeln(
+            sprintf(
+                '<info>Successfully created website <comment>%s</comment> with ID: <comment>%d</comment></info>',
+                $website->getCode(),
+                $website->getId()
+            )
+        );
+
+        return Command::SUCCESS;
+    }
+
+    private function validateWebsiteCode(string $code): ?string
+    {
+        if ($code === '') {
+            return 'Please enter a website code';
+        }
+
+        if (preg_match('/^[a-zA-Z][a-zA-Z0-9_]*$/', $code) !== 1) {
+            return 'Website code may only contain letters (a-z), numbers (0-9) or underscore (_), '
+                . 'and the first character must be a letter.';
+        }
+
+        return null;
+    }
+}

--- a/src/N98/Magento/Command/System/Website/DeleteCommand.php
+++ b/src/N98/Magento/Command/System/Website/DeleteCommand.php
@@ -1,0 +1,151 @@
+<?php
+/**
+ * This file is part of the n98-magerun2 project.
+ *
+ * For the full copyright and license information, please view the MIT-LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+namespace N98\Magento\Command\System\Website;
+
+use function Laravel\Prompts\confirm;
+use function Laravel\Prompts\select;
+use Magento\Framework\Registry;
+use Magento\Store\Api\Data\WebsiteInterface;
+use Magento\Store\Model\WebsiteFactory;
+use N98\Magento\Command\AbstractMagentoCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Exception\RuntimeException;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class DeleteCommand extends AbstractMagentoCommand
+{
+    /**
+     * @var WebsiteFactory
+     */
+    private $websiteFactory;
+
+    /**
+     * @var Registry
+     */
+    private $registry;
+
+    protected function configure()
+    {
+        $this
+            ->setName('sys:website:delete')
+            ->addArgument('code', InputArgument::OPTIONAL, 'Website code or ID')
+            ->addOption('force', 'f', InputOption::VALUE_NONE, 'Delete without confirmation')
+            ->setDescription('Delete an existing website');
+    }
+
+    public function inject(WebsiteFactory $websiteFactory, Registry $registry)
+    {
+        $this->websiteFactory = $websiteFactory;
+        $this->registry = $registry;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $identifier = $input->getArgument('code');
+        if ($identifier === null) {
+            $identifier = $this->selectWebsite();
+        }
+
+        if ($identifier === null) {
+            $output->writeln('<info>No websites found.</info>');
+
+            return Command::SUCCESS;
+        }
+
+        if ((string) $identifier === WebsiteInterface::ADMIN_CODE) {
+            throw new RuntimeException('The admin website cannot be deleted.');
+        }
+
+        $website = $this->websiteFactory->create()->load($identifier, 'code');
+
+        if (!$website->getId() && ctype_digit((string) $identifier)) {
+            $website = $this->websiteFactory->create()->load((int) $identifier);
+        }
+
+        if ($website->getCode() === WebsiteInterface::ADMIN_CODE) {
+            throw new RuntimeException('The admin website cannot be deleted.');
+        }
+
+        if (!$website->getId()) {
+            throw new RuntimeException(sprintf('Website with code or ID "%s" does not exist.', $identifier));
+        }
+
+        if ($website->getIsDefault()) {
+            throw new RuntimeException('The default website cannot be deleted.');
+        }
+
+        if (!$input->getOption('force') && !confirm(
+            sprintf(
+                '<question>Are you sure you want to delete website "%s" (ID: %d)?</question>',
+                $website->getCode(),
+                $website->getId()
+            ),
+            default: false
+        )) {
+            $output->writeln('<error>Operation cancelled.</error>');
+
+            return Command::FAILURE;
+        }
+
+        $isSecure = $this->registry->registry('isSecureArea');
+        $this->registry->unregister('isSecureArea');
+        $this->registry->register('isSecureArea', true);
+
+        try {
+            $website->delete();
+        } catch (\Throwable $exception) {
+            $output->writeln('<error>' . $exception->getMessage() . '</error>');
+
+            return Command::FAILURE;
+        } finally {
+            $this->registry->unregister('isSecureArea');
+            $this->registry->register('isSecureArea', $isSecure);
+        }
+
+        $output->writeln(
+            sprintf(
+                '<info>Successfully deleted website <comment>%s</comment> with ID: <comment>%d</comment></info>',
+                $website->getCode(),
+                $website->getId()
+            )
+        );
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * @return string|null
+     */
+    private function selectWebsite(): ?string
+    {
+        $websites = $this->websiteFactory->create()->getCollection()->getItems();
+        $options = [];
+
+        foreach ($websites as $website) {
+            if ($website->getCode() === WebsiteInterface::ADMIN_CODE) {
+                continue;
+            }
+
+            $options[$website->getCode()] = sprintf(
+                '%s (ID: %d)',
+                $website->getCode(),
+                $website->getId()
+            );
+        }
+
+        if ($options === []) {
+            return null;
+        }
+
+        return select('<question>Select a website to delete:</question>', $options);
+    }
+}

--- a/tests/bats/functional_magerun_commands.bats
+++ b/tests/bats/functional_magerun_commands.bats
@@ -1135,6 +1135,27 @@ function cleanup_files_in_magento() {
   assert_output --partial "1,base"
 }
 
+@test "Command: sys:website:create and sys:website:delete" {
+  website_code="bats_website_$(date +%s%N)"
+  website_name="Bats Website"
+
+  run $BIN "sys:website:create" "$website_code" "$website_name"
+  assert [ "$status" -eq 0 ]
+  assert_output --partial "Successfully created website"
+  assert_output --partial "$website_code"
+
+  run $BIN "sys:website:delete" "$website_code" --force
+  assert [ "$status" -eq 0 ]
+  assert_output --partial "Successfully deleted website"
+  assert_output --partial "$website_code"
+}
+
+@test "Command: sys:website:create rejects invalid website code" {
+  run $BIN "sys:website:create" "1invalid" "Invalid Website"
+  assert [ "$status" -ne 0 ]
+  assert_output --partial "Website code may only contain letters"
+}
+
 
 # ============================================
 # Command: dev: keep-calm


### PR DESCRIPTION
## Summary

Adds `sys:website:create` and `sys:website:delete` commands for automated Magento website management.

- Supports interactive prompts for missing create parameters
- Validates website codes
- Supports optional default store group assignment
- Provides interactive website selection for deletion
- Requires confirmation unless `--force` is supplied
- Protects the default and admin websites
- Enables Magento secure-area deletion handling
- Adds BATS coverage and command documentation

## Testing

- PHP syntax checks passed
- PHP-CS-Fixer checks passed
- BATS file parses successfully
- Functional BATS execution requires `N98_MAGERUN2_BIN` and `N98_MAGERUN2_TEST_MAGENTO_ROOT`

Closes #2093