### PR TITLE
fix(customer): enable interactive address creation

### DIFF
--- a/src/N98/Magento/Command/Customer/AddAddressCommand.php
+++ b/src/N98/Magento/Command/Customer/AddAddressCommand.php
@@ -47,8 +47,8 @@ class AddAddressCommand extends AbstractCustomerCommand
         $this
             ->setName('customer:add-address')
             ->setDescription('Adds an address to a customer')
-            ->addArgument('email', InputArgument::REQUIRED, 'Customer email')
-            ->addArgument('website', InputArgument::REQUIRED, 'Customer website')
+            ->addArgument('email', InputArgument::OPTIONAL, 'Customer email')
+            ->addArgument('website', InputArgument::OPTIONAL, 'Customer website')
             ->addOption('firstname', null, InputOption::VALUE_REQUIRED, 'First name')
             ->addOption('lastname', null, InputOption::VALUE_REQUIRED, 'Last name')
             ->addOption('street', null, InputOption::VALUE_REQUIRED, 'Street address')
@@ -91,11 +91,7 @@ class AddAddressCommand extends AbstractCustomerCommand
 
         $isError = false;
 
-        // Email is a required argument, so we check and ask if it's not provided
-        $email = $input->getArgument('email');
-        if (!$email) {
-            $email = text('Please enter the customer\'s email: ');
-        }
+        $email = $this->getHelperSet()->get('parameter')->askEmail($input, $output);
 
         $website = $this->getHelperSet()->get('parameter')->askWebsite($input, $output);
 


### PR DESCRIPTION
## Summary

Make `customer:add-address` interactive when email and website arguments are omitted.

## Changes

- Make the email and website arguments optional.
- Use the shared email prompt and retain website/address prompts.

## Verification

- `php -l src/N98/Magento/Command/Customer/AddAddressCommand.php`
- `git diff --check`
- Verified both positional arguments are no longer required in the command definition.