### PR TITLE
feat(system): add store group management commands

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -173,6 +173,8 @@ commands:
     - N98\Magento\Command\System\Setup\CompareVersionsCommand
     - N98\Magento\Command\System\Setup\DowngradeVersionsCommand
     - N98\Magento\Command\System\Store\ListCommand
+    - N98\Magento\Command\System\StoreGroup\CreateCommand
+    - N98\Magento\Command\System\StoreGroup\DeleteCommand
     - N98\Magento\Command\System\Url\ListCommand
     - N98\Magento\Command\System\Url\RegenerateCommand
     - N98\Magento\Command\System\Store\Config\BaseUrlListCommand
@@ -251,7 +253,7 @@ commands:
 
       - id: unsafe
         description: Commands that can mutate or delete data
-        commands: "admin:* cache:clean cache:disable cache:enable cache:flush cache:remove:id cms:block:toggle config:env:create config:env:delete config:env:set config:store:delete config:store:set customer:add-address customer:change-password customer:create customer:delete db:* dev:* eav:attribute:remove generation:flush indexer:trigger:recreate integration:create integration:delete install media:dump sales:sequence:* script script:repo:run sys:cron:kill sys:cron:run sys:cron:schedule sys:maintenance sys:setup:* sys:url:regenerate sys:website:create sys:website:delete"
+        commands: "admin:* cache:clean cache:disable cache:enable cache:flush cache:remove:id cms:block:toggle config:env:create config:env:delete config:env:set config:store:delete config:store:set customer:add-address customer:change-password customer:create customer:delete db:* dev:* eav:attribute:remove generation:flush indexer:trigger:recreate integration:create integration:delete install media:dump sales:sequence:* script script:repo:run sys:cron:kill sys:cron:run sys:cron:schedule sys:maintenance sys:setup:* sys:store-group:create sys:store-group:delete sys:url:regenerate sys:website:create sys:website:delete"
 
       - id: system
         description: System commands

--- a/docs/docs/command-docs/system/index.md
+++ b/docs/docs/command-docs/system/index.md
@@ -14,6 +14,8 @@ Commands for system-level information, checks, and maintenance tasks in Magento.
 ### System Information
 - sys:info - Provide system information like edition, version, cache backends
 - [sys:store:list](./sys-store-list.md) - List all store views
+- [sys:store-group:create](./sys-store-group.md) - Create a store group
+- [sys:store-group:delete](./sys-store-group.md) - Delete a store group
 - sys:website:list - List all websites
 - [sys:website:create](./sys-website.md) - Create a website
 - [sys:website:delete](./sys-website.md) - Delete a website

--- a/docs/docs/command-docs/system/sys-store-group.md
+++ b/docs/docs/command-docs/system/sys-store-group.md
@@ -1,0 +1,25 @@
+---
+title: Store Group Commands
+---
+
+# Store Group Commands
+
+## sys:store-group:create
+
+Creates a store group for an existing website. The website can be selected by ID or code. A root category ID is required.
+
+```bash
+bin/n98-magerun2 sys:store-group:create [<name>] --website-id=<id> \
+  --root-category-id=<id> [--default-store-id=<id>]
+
+bin/n98-magerun2 sys:store-group:create [<name>] --website-code=<code> \
+  --root-category-id=<id> [--default-store-id=<id>]
+```
+
+## sys:store-group:delete
+
+Deletes a store group by ID. The website's default store group cannot be deleted. The command asks for confirmation unless `--force` (or `-f`) is supplied.
+
+```bash
+bin/n98-magerun2 sys:store-group:delete <id> [--force]
+```

--- a/docs/docs/command-docs/system/sys-store-group.md
+++ b/docs/docs/command-docs/system/sys-store-group.md
@@ -6,9 +6,11 @@ title: Store Group Commands
 
 ## sys:store-group:create
 
-Creates a store group for an existing website. The website can be selected by ID or code. A root category ID is required.
+Creates a store group for an existing website. When `--website-id` or `--website-code` is omitted, the command displays a website selector. The name and root category ID are also requested interactively when omitted. A default store ID is optional.
 
 ```bash
+bin/n98-magerun2 sys:store-group:create [<name>]
+
 bin/n98-magerun2 sys:store-group:create [<name>] --website-id=<id> \
   --root-category-id=<id> [--default-store-id=<id>]
 

--- a/docs/docs/command-docs/system/sys-store-group.md
+++ b/docs/docs/command-docs/system/sys-store-group.md
@@ -6,15 +6,15 @@ title: Store Group Commands
 
 ## sys:store-group:create
 
-Creates a store group for an existing website. When `--website-id` or `--website-code` is omitted, the command displays a website selector. The name and root category ID are also requested interactively when omitted. A default store ID is optional.
+Creates a store group for an existing website. The name, code, website, and root category ID are requested interactively when omitted. A default store ID is optional.
 
 ```bash
-bin/n98-magerun2 sys:store-group:create [<name>]
+bin/n98-magerun2 sys:store-group:create [<name>] [<code>]
 
-bin/n98-magerun2 sys:store-group:create [<name>] --website-id=<id> \
+bin/n98-magerun2 sys:store-group:create [<name>] [<code>] --website-id=<id> \
   --root-category-id=<id> [--default-store-id=<id>]
 
-bin/n98-magerun2 sys:store-group:create [<name>] --website-code=<code> \
+bin/n98-magerun2 sys:store-group:create [<name>] [<code>] --website-code=<code> \
   --root-category-id=<id> [--default-store-id=<id>]
 ```
 

--- a/docs/docs/command-docs/system/sys-store-group.md
+++ b/docs/docs/command-docs/system/sys-store-group.md
@@ -20,8 +20,8 @@ bin/n98-magerun2 sys:store-group:create [<name>] [<code>] --website-code=<code> 
 
 ## sys:store-group:delete
 
-Deletes a store group by ID. The website's default store group cannot be deleted. The command asks for confirmation unless `--force` (or `-f`) is supplied.
+Deletes a store group by ID. If no ID is supplied, the command displays a selector. The website's default store group cannot be deleted. The command asks for confirmation unless `--force` (or `-f`) is supplied.
 
 ```bash
-bin/n98-magerun2 sys:store-group:delete <id> [--force]
+bin/n98-magerun2 sys:store-group:delete [<id>] [--force]
 ```

--- a/src/N98/Magento/Command/System/StoreGroup/CreateCommand.php
+++ b/src/N98/Magento/Command/System/StoreGroup/CreateCommand.php
@@ -1,0 +1,124 @@
+<?php
+/**
+ * This file is part of the n98-magerun2 project.
+ *
+ * For the full copyright and license information, please view the MIT-LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+namespace N98\Magento\Command\System\StoreGroup;
+
+use function Laravel\Prompts\text;
+use Magento\Store\Model\GroupFactory;
+use Magento\Store\Model\WebsiteFactory;
+use N98\Magento\Command\AbstractMagentoCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Exception\RuntimeException;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class CreateCommand extends AbstractMagentoCommand
+{
+    /**
+     * @var GroupFactory
+     */
+    private $groupFactory;
+
+    /**
+     * @var WebsiteFactory
+     */
+    private $websiteFactory;
+
+    protected function configure()
+    {
+        $this
+            ->setName('sys:store-group:create')
+            ->addArgument('name', InputArgument::OPTIONAL, 'Store group name')
+            ->addOption('website-id', null, InputOption::VALUE_REQUIRED, 'Website ID')
+            ->addOption('website-code', null, InputOption::VALUE_REQUIRED, 'Website code')
+            ->addOption('root-category-id', null, InputOption::VALUE_REQUIRED, 'Root category ID')
+            ->addOption('default-store-id', null, InputOption::VALUE_REQUIRED, 'ID of the default store')
+            ->setDescription('Create a new store group');
+    }
+
+    public function inject(GroupFactory $groupFactory, WebsiteFactory $websiteFactory)
+    {
+        $this->groupFactory = $groupFactory;
+        $this->websiteFactory = $websiteFactory;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $name = $input->getArgument('name');
+        if ($name === null || $name === '') {
+            $name = text(
+                '<question>Store group name:</question>',
+                validate: fn ($value) => $value === '' ? 'Please enter a store group name' : null
+            );
+        }
+
+        $websiteId = $input->getOption('website-id');
+        $websiteCode = $input->getOption('website-code');
+        if ($websiteId !== null && $websiteCode !== null) {
+            throw new RuntimeException('Specify either --website-id or --website-code, not both.');
+        }
+
+        if ($websiteId === null && $websiteCode === null) {
+            throw new RuntimeException('Either --website-id or --website-code is required.');
+        }
+
+        if ($websiteId !== null && (!ctype_digit((string) $websiteId) || (int) $websiteId < 1)) {
+            throw new RuntimeException('The website ID must be a positive integer.');
+        }
+
+        $website = $this->websiteFactory->create();
+        if ($websiteId !== null) {
+            $website->load((int) $websiteId);
+        } else {
+            $website->load($websiteCode, 'code');
+        }
+
+        if (!$website->getId()) {
+            $identifier = $websiteId ?? $websiteCode;
+            throw new RuntimeException(sprintf('Website with code or ID "%s" does not exist.', $identifier));
+        }
+
+        $rootCategoryId = $input->getOption('root-category-id');
+        if ($rootCategoryId === null || !ctype_digit((string) $rootCategoryId) || (int) $rootCategoryId < 1) {
+            throw new RuntimeException('The root category ID must be a positive integer.');
+        }
+
+        $defaultStoreId = $input->getOption('default-store-id');
+        if ($defaultStoreId !== null && (!ctype_digit((string) $defaultStoreId) || (int) $defaultStoreId < 1)) {
+            throw new RuntimeException('The default store ID must be a positive integer.');
+        }
+
+        $group = $this->groupFactory->create();
+        $group->setName($name);
+        $group->setWebsiteId((int) $website->getId());
+        $group->setRootCategoryId((int) $rootCategoryId);
+        if ($defaultStoreId !== null) {
+            $group->setDefaultStoreId((int) $defaultStoreId);
+        }
+
+        try {
+            $group->save();
+        } catch (\Exception $exception) {
+            $output->writeln('<error>' . $exception->getMessage() . '</error>');
+
+            return Command::FAILURE;
+        }
+
+        $output->writeln(
+            sprintf(
+                '<info>Successfully created store group <comment>%s</comment> with ID: <comment>%d</comment></info>',
+                $group->getName(),
+                $group->getId()
+            )
+        );
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/N98/Magento/Command/System/StoreGroup/CreateCommand.php
+++ b/src/N98/Magento/Command/System/StoreGroup/CreateCommand.php
@@ -38,6 +38,7 @@ class CreateCommand extends AbstractMagentoCommand
         $this
             ->setName('sys:store-group:create')
             ->addArgument('name', InputArgument::OPTIONAL, 'Store group name')
+            ->addArgument('code', InputArgument::OPTIONAL, 'Store group code')
             ->addOption('website-id', null, InputOption::VALUE_REQUIRED, 'Website ID')
             ->addOption('website-code', null, InputOption::VALUE_REQUIRED, 'Website code')
             ->addOption('root-category-id', null, InputOption::VALUE_REQUIRED, 'Root category ID')
@@ -59,6 +60,19 @@ class CreateCommand extends AbstractMagentoCommand
                 '<question>Store group name:</question>',
                 validate: fn ($value) => $value === '' ? 'Please enter a store group name' : null
             );
+        }
+
+        $code = $input->getArgument('code');
+        if ($code === null || $code === '') {
+            $code = text(
+                '<question>Store group code:</question>',
+                validate: fn ($value) => $this->validateStoreGroupCode($value)
+            );
+        }
+
+        $codeValidationError = $this->validateStoreGroupCode($code);
+        if ($codeValidationError !== null) {
+            throw new RuntimeException($codeValidationError);
         }
 
         $websiteId = $input->getOption('website-id');
@@ -112,6 +126,7 @@ class CreateCommand extends AbstractMagentoCommand
 
         $group = $this->groupFactory->create();
         $group->setName($name);
+        $group->setCode($code);
         $group->setWebsiteId((int) $website->getId());
         $group->setRootCategoryId((int) $rootCategoryId);
         if ($defaultStoreId !== null) {
@@ -162,5 +177,15 @@ class CreateCommand extends AbstractMagentoCommand
     private function validatePositiveInteger(string $value, string $message): ?string
     {
         return ctype_digit($value) && (int) $value > 0 ? null : $message;
+    }
+
+    private function validateStoreGroupCode(string $code): ?string
+    {
+        if (preg_match('/^[a-zA-Z][a-zA-Z0-9_]*$/', $code) !== 1) {
+            return 'Store group code may only contain letters (a-z), numbers (0-9) or underscore (_), '
+                . 'and the first character must be a letter.';
+        }
+
+        return null;
     }
 }

--- a/src/N98/Magento/Command/System/StoreGroup/CreateCommand.php
+++ b/src/N98/Magento/Command/System/StoreGroup/CreateCommand.php
@@ -8,7 +8,9 @@
 
 namespace N98\Magento\Command\System\StoreGroup;
 
+use function Laravel\Prompts\select;
 use function Laravel\Prompts\text;
+use Magento\Store\Api\Data\WebsiteInterface;
 use Magento\Store\Model\GroupFactory;
 use Magento\Store\Model\WebsiteFactory;
 use N98\Magento\Command\AbstractMagentoCommand;
@@ -65,10 +67,6 @@ class CreateCommand extends AbstractMagentoCommand
             throw new RuntimeException('Specify either --website-id or --website-code, not both.');
         }
 
-        if ($websiteId === null && $websiteCode === null) {
-            throw new RuntimeException('Either --website-id or --website-code is required.');
-        }
-
         if ($websiteId !== null && (!ctype_digit((string) $websiteId) || (int) $websiteId < 1)) {
             throw new RuntimeException('The website ID must be a positive integer.');
         }
@@ -76,7 +74,14 @@ class CreateCommand extends AbstractMagentoCommand
         $website = $this->websiteFactory->create();
         if ($websiteId !== null) {
             $website->load((int) $websiteId);
+        } elseif ($websiteCode !== null) {
+            $website->load($websiteCode, 'code');
         } else {
+            $websiteCode = $this->selectWebsite();
+            if ($websiteCode === null) {
+                throw new RuntimeException('No websites found.');
+            }
+
             $website->load($websiteCode, 'code');
         }
 
@@ -86,6 +91,16 @@ class CreateCommand extends AbstractMagentoCommand
         }
 
         $rootCategoryId = $input->getOption('root-category-id');
+        if ($rootCategoryId === null) {
+            $rootCategoryId = text(
+                '<question>Root category ID:</question>',
+                validate: fn ($value) => $this->validatePositiveInteger(
+                    $value,
+                    'The root category ID must be a positive integer.'
+                )
+            );
+        }
+
         if ($rootCategoryId === null || !ctype_digit((string) $rootCategoryId) || (int) $rootCategoryId < 1) {
             throw new RuntimeException('The root category ID must be a positive integer.');
         }
@@ -120,5 +135,32 @@ class CreateCommand extends AbstractMagentoCommand
         );
 
         return Command::SUCCESS;
+    }
+
+    private function selectWebsite(): ?string
+    {
+        $options = [];
+        foreach ($this->websiteFactory->create()->getCollection()->getItems() as $website) {
+            if ($website->getCode() === WebsiteInterface::ADMIN_CODE) {
+                continue;
+            }
+
+            $options[$website->getCode()] = sprintf(
+                '%s (ID: %d)',
+                $website->getCode(),
+                $website->getId()
+            );
+        }
+
+        if ($options === []) {
+            return null;
+        }
+
+        return select('<question>Select a website:</question>', $options);
+    }
+
+    private function validatePositiveInteger(string $value, string $message): ?string
+    {
+        return ctype_digit($value) && (int) $value > 0 ? null : $message;
     }
 }

--- a/src/N98/Magento/Command/System/StoreGroup/DeleteCommand.php
+++ b/src/N98/Magento/Command/System/StoreGroup/DeleteCommand.php
@@ -1,0 +1,107 @@
+<?php
+/**
+ * This file is part of the n98-magerun2 project.
+ *
+ * For the full copyright and license information, please view the MIT-LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+namespace N98\Magento\Command\System\StoreGroup;
+
+use function Laravel\Prompts\confirm;
+use Magento\Framework\Registry;
+use Magento\Store\Model\GroupFactory;
+use N98\Magento\Command\AbstractMagentoCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Exception\RuntimeException;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class DeleteCommand extends AbstractMagentoCommand
+{
+    /**
+     * @var GroupFactory
+     */
+    private $groupFactory;
+
+    /**
+     * @var Registry
+     */
+    private $registry;
+
+    protected function configure()
+    {
+        $this
+            ->setName('sys:store-group:delete')
+            ->addArgument('id', InputArgument::REQUIRED, 'Store group ID')
+            ->addOption('force', 'f', InputOption::VALUE_NONE, 'Delete without confirmation')
+            ->setDescription('Delete an existing store group');
+    }
+
+    public function inject(GroupFactory $groupFactory, Registry $registry)
+    {
+        $this->groupFactory = $groupFactory;
+        $this->registry = $registry;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $identifier = $input->getArgument('id');
+        if (!ctype_digit((string) $identifier) || (int) $identifier < 1) {
+            throw new RuntimeException('The store group ID must be a positive integer.');
+        }
+
+        $group = $this->groupFactory->create()->load((int) $identifier);
+        if (!$group->getId()) {
+            throw new RuntimeException(sprintf('Store group with ID "%s" does not exist.', $identifier));
+        }
+
+        if ((int) $group->getWebsite()->getDefaultGroupId() === (int) $group->getId()) {
+            throw new RuntimeException('The default store group cannot be deleted.');
+        }
+
+        if (!$group->isCanDelete()) {
+            throw new RuntimeException('The store group cannot be deleted because it is the only group of its website.');
+        }
+
+        if (!$input->getOption('force') && !confirm(
+            sprintf(
+                '<question>Are you sure you want to delete store group "%s" (ID: %d)?</question>',
+                $group->getName(),
+                $group->getId()
+            ),
+            default: false
+        )) {
+            $output->writeln('<error>Operation cancelled.</error>');
+
+            return Command::FAILURE;
+        }
+
+        $isSecure = $this->registry->registry('isSecureArea');
+        $this->registry->unregister('isSecureArea');
+        $this->registry->register('isSecureArea', true);
+
+        try {
+            $group->delete();
+        } catch (\Throwable $exception) {
+            $output->writeln('<error>' . $exception->getMessage() . '</error>');
+
+            return Command::FAILURE;
+        } finally {
+            $this->registry->unregister('isSecureArea');
+            $this->registry->register('isSecureArea', $isSecure);
+        }
+
+        $output->writeln(
+            sprintf(
+                '<info>Successfully deleted store group <comment>%s</comment> with ID: <comment>%d</comment></info>',
+                $group->getName(),
+                $group->getId()
+            )
+        );
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/N98/Magento/Command/System/StoreGroup/DeleteCommand.php
+++ b/src/N98/Magento/Command/System/StoreGroup/DeleteCommand.php
@@ -9,6 +9,7 @@
 namespace N98\Magento\Command\System\StoreGroup;
 
 use function Laravel\Prompts\confirm;
+use function Laravel\Prompts\select;
 use Magento\Framework\Registry;
 use Magento\Store\Model\GroupFactory;
 use N98\Magento\Command\AbstractMagentoCommand;
@@ -35,7 +36,7 @@ class DeleteCommand extends AbstractMagentoCommand
     {
         $this
             ->setName('sys:store-group:delete')
-            ->addArgument('id', InputArgument::REQUIRED, 'Store group ID')
+            ->addArgument('id', InputArgument::OPTIONAL, 'Store group ID')
             ->addOption('force', 'f', InputOption::VALUE_NONE, 'Delete without confirmation')
             ->setDescription('Delete an existing store group');
     }
@@ -49,6 +50,16 @@ class DeleteCommand extends AbstractMagentoCommand
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $identifier = $input->getArgument('id');
+        if ($identifier === null) {
+            $identifier = $this->selectStoreGroup();
+        }
+
+        if ($identifier === null) {
+            $output->writeln('<info>No store groups found.</info>');
+
+            return Command::SUCCESS;
+        }
+
         if (!ctype_digit((string) $identifier) || (int) $identifier < 1) {
             throw new RuntimeException('The store group ID must be a positive integer.');
         }
@@ -103,5 +114,23 @@ class DeleteCommand extends AbstractMagentoCommand
         );
 
         return Command::SUCCESS;
+    }
+
+    private function selectStoreGroup(): ?string
+    {
+        $options = [];
+        foreach ($this->groupFactory->create()->getCollection()->getItems() as $group) {
+            $options[(string) $group->getId()] = sprintf(
+                '%s (ID: %d)',
+                $group->getName(),
+                $group->getId()
+            );
+        }
+
+        if ($options === []) {
+            return null;
+        }
+
+        return (string) select('<question>Select a store group to delete:</question>', $options);
     }
 }

--- a/tests/bats/functional_magerun_commands.bats
+++ b/tests/bats/functional_magerun_commands.bats
@@ -1173,6 +1173,21 @@ function cleanup_files_in_magento() {
   assert_output --partial "$group_name"
 }
 
+@test "Command: sys:store-group:create prompts for missing parameters" {
+  group_name="Bats Interactive Store Group $(date +%s%N)"
+
+  run bash -c "printf '%s\\n0\\n2\\n' \"$group_name\" | $BIN_INTERACTION sys:store-group:create"
+  assert [ "$status" -eq 0 ]
+  assert_output --partial "Successfully created store group"
+  assert_output --partial "$group_name"
+
+  group_id=$(printf '%s\n' "$output" | sed -n 's/.*ID: \([0-9][0-9]*\).*/\1/p')
+  assert [ -n "$group_id" ]
+
+  run $BIN "sys:store-group:delete" "$group_id" --force
+  assert [ "$status" -eq 0 ]
+}
+
 @test "Command: sys:store-group:create validates website and root category" {
   run $BIN "sys:store-group:create" "Invalid Store Group" --website-id=999999 --root-category-id=2
   assert [ "$status" -ne 0 ]

--- a/tests/bats/functional_magerun_commands.bats
+++ b/tests/bats/functional_magerun_commands.bats
@@ -1186,7 +1186,7 @@ function cleanup_files_in_magento() {
   group_id=$(printf '%s\n' "$output" | sed -n 's/.*ID: \([0-9][0-9]*\).*/\1/p')
   assert [ -n "$group_id" ]
 
-  run $BIN "sys:store-group:delete" "$group_id" --force
+  run bash -c "printf '%s\\n' \"$group_id\" | $BIN_INTERACTION sys:store-group:delete --force"
   assert [ "$status" -eq 0 ]
 }
 

--- a/tests/bats/functional_magerun_commands.bats
+++ b/tests/bats/functional_magerun_commands.bats
@@ -1178,15 +1178,15 @@ function cleanup_files_in_magento() {
   group_name="Bats Interactive Store Group $(date +%s%N)"
   group_code="bats_interactive_group_$(date +%s%N)"
 
-  run bash -c "printf '%s\\n%s\\n0\\n2\\n' \"$group_name\" \"$group_code\" | $BIN_INTERACTION sys:store-group:create"
+  run bash -c "printf '%s\\n%s\\nbase\\n2\\n' \"$group_name\" \"$group_code\" | $BIN_INTERACTION sys:store-group:create"
   assert [ "$status" -eq 0 ]
   assert_output --partial "Successfully created store group"
   assert_output --partial "$group_name"
 
-  group_id=$(printf '%s\n' "$output" | sed -n 's/.*ID: \([0-9][0-9]*\).*/\1/p')
+  group_id=$(printf '%s\n' "$output" | sed -n 's/.*ID: \([0-9][0-9]*\).*/\1/p' | sed -n '$p')
   assert [ -n "$group_id" ]
 
-  run bash -c "printf '%s\\n' \"$group_id\" | $BIN_INTERACTION sys:store-group:delete --force"
+  run $BIN "sys:store-group:delete" "$group_id" --force
   assert [ "$status" -eq 0 ]
 }
 

--- a/tests/bats/functional_magerun_commands.bats
+++ b/tests/bats/functional_magerun_commands.bats
@@ -1158,8 +1158,9 @@ function cleanup_files_in_magento() {
 
 @test "Command: sys:store-group:create and sys:store-group:delete" {
   group_name="Bats Store Group $(date +%s%N)"
+  group_code="bats_store_group_$(date +%s%N)"
 
-  run $BIN "sys:store-group:create" "$group_name" --website-id=1 --root-category-id=2
+  run $BIN "sys:store-group:create" "$group_name" "$group_code" --website-id=1 --root-category-id=2
   assert [ "$status" -eq 0 ]
   assert_output --partial "Successfully created store group"
   assert_output --partial "$group_name"
@@ -1175,8 +1176,9 @@ function cleanup_files_in_magento() {
 
 @test "Command: sys:store-group:create prompts for missing parameters" {
   group_name="Bats Interactive Store Group $(date +%s%N)"
+  group_code="bats_interactive_group_$(date +%s%N)"
 
-  run bash -c "printf '%s\\n0\\n2\\n' \"$group_name\" | $BIN_INTERACTION sys:store-group:create"
+  run bash -c "printf '%s\\n%s\\n0\\n2\\n' \"$group_name\" \"$group_code\" | $BIN_INTERACTION sys:store-group:create"
   assert [ "$status" -eq 0 ]
   assert_output --partial "Successfully created store group"
   assert_output --partial "$group_name"
@@ -1189,11 +1191,11 @@ function cleanup_files_in_magento() {
 }
 
 @test "Command: sys:store-group:create validates website and root category" {
-  run $BIN "sys:store-group:create" "Invalid Store Group" --website-id=999999 --root-category-id=2
+  run $BIN "sys:store-group:create" "Invalid Store Group" invalid_group --website-id=999999 --root-category-id=2
   assert [ "$status" -ne 0 ]
   assert_output --partial "does not exist"
 
-  run $BIN "sys:store-group:create" "Invalid Store Group" --website-id=1 --root-category-id=0
+  run $BIN "sys:store-group:create" "Invalid Store Group" invalid_group --website-id=1 --root-category-id=0
   assert [ "$status" -ne 0 ]
   assert_output --partial "root category ID must be a positive integer"
 }

--- a/tests/bats/functional_magerun_commands.bats
+++ b/tests/bats/functional_magerun_commands.bats
@@ -1156,6 +1156,45 @@ function cleanup_files_in_magento() {
   assert_output --partial "Website code may only contain letters"
 }
 
+@test "Command: sys:store-group:create and sys:store-group:delete" {
+  group_name="Bats Store Group $(date +%s%N)"
+
+  run $BIN "sys:store-group:create" "$group_name" --website-id=1 --root-category-id=2
+  assert [ "$status" -eq 0 ]
+  assert_output --partial "Successfully created store group"
+  assert_output --partial "$group_name"
+
+  group_id=$(printf '%s\n' "$output" | sed -n 's/.*ID: \([0-9][0-9]*\).*/\1/p')
+  assert [ -n "$group_id" ]
+
+  run $BIN "sys:store-group:delete" "$group_id" --force
+  assert [ "$status" -eq 0 ]
+  assert_output --partial "Successfully deleted store group"
+  assert_output --partial "$group_name"
+}
+
+@test "Command: sys:store-group:create validates website and root category" {
+  run $BIN "sys:store-group:create" "Invalid Store Group" --website-id=999999 --root-category-id=2
+  assert [ "$status" -ne 0 ]
+  assert_output --partial "does not exist"
+
+  run $BIN "sys:store-group:create" "Invalid Store Group" --website-id=1 --root-category-id=0
+  assert [ "$status" -ne 0 ]
+  assert_output --partial "root category ID must be a positive integer"
+}
+
+@test "Command: sys:store-group:delete rejects the default store group" {
+  run $BIN "sys:store:list" --format=csv
+  assert [ "$status" -eq 0 ]
+
+  default_group_id=$(printf '%s\n' "$output" | awk -F, '$2 == "1" { print $3; exit }')
+  assert [ -n "$default_group_id" ]
+
+  run $BIN "sys:store-group:delete" "$default_group_id" --force
+  assert [ "$status" -ne 0 ]
+  assert_output --partial "The default store group cannot be deleted"
+}
+
 
 # ============================================
 # Command: dev: keep-calm


### PR DESCRIPTION
## Summary

Adds CLI management commands for store groups, addressing #2094.

- Adds `sys:store-group:create` with website ID/code, root category, and default store options.
- Adds `sys:store-group:delete` with confirmation, `--force`, and default-group protection.
- Adds functional Bats coverage and command documentation.

## Validation

- PHP syntax checks passed.
- YAML validation passed.
- PHP-CS-Fixer dry run passed.
- Bats file parsed successfully.
- Full Bats execution was not run because Magento test environment variables were unavailable.

Closes #2094