### PR TITLE
feat(system): add interactive store view commands

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -172,6 +172,8 @@ commands:
     - N98\Magento\Command\System\Setup\ChangeVersionCommand
     - N98\Magento\Command\System\Setup\CompareVersionsCommand
     - N98\Magento\Command\System\Setup\DowngradeVersionsCommand
+    - N98\Magento\Command\System\Store\CreateCommand
+    - N98\Magento\Command\System\Store\DeleteCommand
     - N98\Magento\Command\System\Store\ListCommand
     - N98\Magento\Command\System\StoreGroup\CreateCommand
     - N98\Magento\Command\System\StoreGroup\DeleteCommand
@@ -253,7 +255,7 @@ commands:
 
       - id: unsafe
         description: Commands that can mutate or delete data
-        commands: "admin:* cache:clean cache:disable cache:enable cache:flush cache:remove:id cms:block:toggle config:env:create config:env:delete config:env:set config:store:delete config:store:set customer:add-address customer:change-password customer:create customer:delete db:* dev:* eav:attribute:remove generation:flush indexer:trigger:recreate integration:create integration:delete install media:dump sales:sequence:* script script:repo:run sys:cron:kill sys:cron:run sys:cron:schedule sys:maintenance sys:setup:* sys:store-group:create sys:store-group:delete sys:url:regenerate sys:website:create sys:website:delete"
+        commands: "admin:* cache:clean cache:disable cache:enable cache:flush cache:remove:id cms:block:toggle config:env:create config:env:delete config:env:set config:store:delete config:store:set customer:add-address customer:change-password customer:create customer:delete db:* dev:* eav:attribute:remove generation:flush indexer:trigger:recreate integration:create integration:delete install media:dump sales:sequence:* script script:repo:run sys:cron:kill sys:cron:run sys:cron:schedule sys:maintenance sys:setup:* sys:store:create sys:store:delete sys:store-group:create sys:store-group:delete sys:url:regenerate sys:website:create sys:website:delete"
 
       - id: system
         description: System commands

--- a/docs/docs/command-docs/system/index.md
+++ b/docs/docs/command-docs/system/index.md
@@ -14,6 +14,8 @@ Commands for system-level information, checks, and maintenance tasks in Magento.
 ### System Information
 - sys:info - Provide system information like edition, version, cache backends
 - [sys:store:list](./sys-store-list.md) - List all store views
+- [sys:store:create](./sys-store.md) - Create a store view
+- [sys:store:delete](./sys-store.md) - Delete a store view
 - [sys:store-group:create](./sys-store-group.md) - Create a store group
 - [sys:store-group:delete](./sys-store-group.md) - Delete a store group
 - sys:website:list - List all websites

--- a/docs/docs/command-docs/system/sys-store.md
+++ b/docs/docs/command-docs/system/sys-store.md
@@ -1,0 +1,28 @@
+---
+title: Store Commands
+---
+
+# Store Commands
+
+## sys:store:create
+
+Creates a store view. In interactive mode, the command asks for the store code, name, and store group. For automation, provide all required values using arguments and options.
+
+```bash
+bin/n98-magerun2 sys:store:create [<code>] [<name>] \
+  --group-id=<id> [--is-active=0|1]
+
+bin/n98-magerun2 sys:store:create [<code>] [<name>] \
+  --group-code=<code> [--is-active=0|1]
+
+bin/n98-magerun2 sys:store:create [<code>] [<name>] \
+  --website-id=<id> [--is-active=0|1]
+```
+
+## sys:store:delete
+
+Deletes a store view by code or ID. If no identifier is supplied, the command displays a selector. The default store of a store group cannot be deleted. The command asks for confirmation unless `--force` (or `-f`) is supplied.
+
+```bash
+bin/n98-magerun2 sys:store:delete [<code-or-id>] [--force]
+```

--- a/src/N98/Magento/Command/System/Store/CreateCommand.php
+++ b/src/N98/Magento/Command/System/Store/CreateCommand.php
@@ -55,7 +55,7 @@ class CreateCommand extends AbstractMagentoCommand
         if ($input->isInteractive() || $code === null || $code === '') {
             $code = text(
                 '<question>Store code:</question>',
-                default: $input->isInteractive() ? null : $code,
+                default: (string) ($code ?? ''),
                 validate: fn ($value) => $this->validateStoreCode($value)
             );
         }
@@ -69,7 +69,7 @@ class CreateCommand extends AbstractMagentoCommand
         if ($input->isInteractive() || $name === null || $name === '') {
             $name = text(
                 '<question>Store name:</question>',
-                default: $input->isInteractive() ? null : $name,
+                default: (string) ($name ?? ''),
                 validate: fn ($value) => $value === '' ? 'Please enter a store name' : null
             );
         }
@@ -170,7 +170,10 @@ class CreateCommand extends AbstractMagentoCommand
             return null;
         }
 
-        return (string) select('<question>Select a store group:</question>', $options);
+        $selected = (string) select('<question>Select a store group:</question>', $options);
+        $selectedId = array_search($selected, $options, true);
+
+        return $selectedId === false ? $selected : (string) $selectedId;
     }
 
     private function validatePositiveInteger($value, string $message): void

--- a/src/N98/Magento/Command/System/Store/CreateCommand.php
+++ b/src/N98/Magento/Command/System/Store/CreateCommand.php
@@ -1,0 +1,196 @@
+<?php
+/**
+ * This file is part of the n98-magerun2 project.
+ *
+ * For the full copyright and license information, please view the MIT-LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+namespace N98\Magento\Command\System\Store;
+
+use function Laravel\Prompts\select;
+use function Laravel\Prompts\text;
+use Magento\Store\Model\GroupFactory;
+use Magento\Store\Model\StoreFactory;
+use Magento\Store\Model\WebsiteFactory;
+use N98\Magento\Command\AbstractMagentoCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Exception\RuntimeException;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class CreateCommand extends AbstractMagentoCommand
+{
+    private $storeFactory;
+
+    private $groupFactory;
+
+    private $websiteFactory;
+
+    protected function configure()
+    {
+        $this
+            ->setName('sys:store:create')
+            ->addArgument('code', InputArgument::OPTIONAL, 'Store code')
+            ->addArgument('name', InputArgument::OPTIONAL, 'Store name')
+            ->addOption('group-id', null, InputOption::VALUE_REQUIRED, 'Store group ID')
+            ->addOption('group-code', null, InputOption::VALUE_REQUIRED, 'Store group code')
+            ->addOption('website-id', null, InputOption::VALUE_REQUIRED, 'Use the website default store group')
+            ->addOption('is-active', null, InputOption::VALUE_REQUIRED, 'Whether the store is active (1 or 0)')
+            ->setDescription('Create a new store view');
+    }
+
+    public function inject(StoreFactory $storeFactory, GroupFactory $groupFactory, WebsiteFactory $websiteFactory)
+    {
+        $this->storeFactory = $storeFactory;
+        $this->groupFactory = $groupFactory;
+        $this->websiteFactory = $websiteFactory;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $code = $input->getArgument('code');
+        if ($input->isInteractive() || $code === null || $code === '') {
+            $code = text(
+                '<question>Store code:</question>',
+                default: $input->isInteractive() ? null : $code,
+                validate: fn ($value) => $this->validateStoreCode($value)
+            );
+        }
+
+        $codeValidationError = $this->validateStoreCode($code);
+        if ($codeValidationError !== null) {
+            throw new RuntimeException($codeValidationError);
+        }
+
+        $name = $input->getArgument('name');
+        if ($input->isInteractive() || $name === null || $name === '') {
+            $name = text(
+                '<question>Store name:</question>',
+                default: $input->isInteractive() ? null : $name,
+                validate: fn ($value) => $value === '' ? 'Please enter a store name' : null
+            );
+        }
+
+        $groupId = $this->resolveGroupId($input);
+        $store = $this->storeFactory->create();
+        $store->setCode($code);
+        $store->setName($name);
+        $store->setStoreGroupId($groupId);
+
+        $isActive = $input->getOption('is-active');
+        if ($isActive !== null) {
+            if (!in_array((string) $isActive, ['0', '1'], true)) {
+                throw new RuntimeException('The is-active value must be 0 or 1.');
+            }
+
+            $store->setIsActive((int) $isActive);
+        }
+
+        try {
+            $store->save();
+        } catch (\Throwable $exception) {
+            $output->writeln('<error>' . $exception->getMessage() . '</error>');
+
+            return Command::FAILURE;
+        }
+
+        $output->writeln(
+            sprintf(
+                '<info>Successfully created store <comment>%s</comment> with ID: <comment>%d</comment></info>',
+                $store->getCode(),
+                $store->getId()
+            )
+        );
+
+        return Command::SUCCESS;
+    }
+
+    private function resolveGroupId(InputInterface $input): int
+    {
+        if ($input->isInteractive()) {
+            $groupId = $this->selectGroup();
+        } else {
+            $groupId = $input->getOption('group-id');
+            $groupCode = $input->getOption('group-code');
+            $websiteId = $input->getOption('website-id');
+            $specified = array_filter([$groupId, $groupCode, $websiteId], static fn ($value) => $value !== null);
+            if (count($specified) > 1) {
+                throw new RuntimeException('Specify only one of --group-id, --group-code, or --website-id.');
+            }
+
+            if ($groupId !== null) {
+                $this->validatePositiveInteger($groupId, 'The store group ID must be a positive integer.');
+                $group = $this->groupFactory->create()->load((int) $groupId);
+            } elseif ($groupCode !== null) {
+                $group = $this->groupFactory->create()->load($groupCode, 'code');
+            } elseif ($websiteId !== null) {
+                $this->validatePositiveInteger($websiteId, 'The website ID must be a positive integer.');
+                $website = $this->websiteFactory->create()->load((int) $websiteId);
+                if (!$website->getId()) {
+                    throw new RuntimeException(sprintf('Website with ID "%s" does not exist.', $websiteId));
+                }
+
+                $group = $this->groupFactory->create()->load((int) $website->getDefaultGroupId());
+            } else {
+                throw new RuntimeException(
+                    'A store group is required. Specify --group-id, --group-code, or --website-id.'
+                );
+            }
+
+            $groupId = $group->getId();
+        }
+
+        if (empty($groupId)) {
+            throw new RuntimeException('No store groups found.');
+        }
+
+        $group = $this->groupFactory->create()->load((int) $groupId);
+        if (!$group->getId()) {
+            throw new RuntimeException(sprintf('Store group with ID "%s" does not exist.', $groupId));
+        }
+
+        return (int) $group->getId();
+    }
+
+    private function selectGroup(): ?string
+    {
+        $options = [];
+        foreach ($this->groupFactory->create()->getCollection()->getItems() as $group) {
+            $options[(string) $group->getId()] = sprintf(
+                '%s (ID: %d)',
+                $group->getName(),
+                $group->getId()
+            );
+        }
+
+        if ($options === []) {
+            return null;
+        }
+
+        return (string) select('<question>Select a store group:</question>', $options);
+    }
+
+    private function validatePositiveInteger($value, string $message): void
+    {
+        if (!ctype_digit((string) $value) || (int) $value < 1) {
+            throw new RuntimeException($message);
+        }
+    }
+
+    private function validateStoreCode(string $code): ?string
+    {
+        if ($code === '') {
+            return 'Please enter a store code';
+        }
+
+        if (preg_match('/^[a-zA-Z][a-zA-Z0-9_]*$/', $code) !== 1) {
+            return 'Store code may only contain letters (a-z), numbers (0-9) or underscore (_), '
+                . 'and the first character must be a letter.';
+        }
+
+        return null;
+    }
+}

--- a/src/N98/Magento/Command/System/Store/DeleteCommand.php
+++ b/src/N98/Magento/Command/System/Store/DeleteCommand.php
@@ -1,0 +1,132 @@
+<?php
+/**
+ * This file is part of the n98-magerun2 project.
+ *
+ * For the full copyright and license information, please view the MIT-LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+namespace N98\Magento\Command\System\Store;
+
+use function Laravel\Prompts\confirm;
+use function Laravel\Prompts\select;
+use Magento\Framework\Registry;
+use Magento\Store\Model\GroupFactory;
+use Magento\Store\Model\StoreFactory;
+use N98\Magento\Command\AbstractMagentoCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Exception\RuntimeException;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class DeleteCommand extends AbstractMagentoCommand
+{
+    private $storeFactory;
+
+    private $groupFactory;
+
+    private $registry;
+
+    protected function configure()
+    {
+        $this
+            ->setName('sys:store:delete')
+            ->addArgument('code', InputArgument::OPTIONAL, 'Store code or ID')
+            ->addOption('force', 'f', InputOption::VALUE_NONE, 'Delete without confirmation')
+            ->setDescription('Delete an existing store view');
+    }
+
+    public function inject(StoreFactory $storeFactory, GroupFactory $groupFactory, Registry $registry)
+    {
+        $this->storeFactory = $storeFactory;
+        $this->groupFactory = $groupFactory;
+        $this->registry = $registry;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $identifier = $input->getArgument('code');
+        if ($identifier === null) {
+            $identifier = $this->selectStore();
+        }
+
+        if ($identifier === null) {
+            $output->writeln('<info>No stores found.</info>');
+
+            return Command::SUCCESS;
+        }
+
+        $store = $this->storeFactory->create()->load($identifier, 'code');
+        if (!$store->getId() && ctype_digit((string) $identifier)) {
+            $store = $this->storeFactory->create()->load((int) $identifier);
+        }
+
+        if (!$store->getId()) {
+            throw new RuntimeException(sprintf('Store with code or ID "%s" does not exist.', $identifier));
+        }
+
+        $group = $this->groupFactory->create()->load((int) $store->getStoreGroupId());
+        if ((int) $group->getDefaultStoreId() === (int) $store->getId()) {
+            throw new RuntimeException('The default store of a store group cannot be deleted.');
+        }
+
+        if (!$input->getOption('force') && !confirm(
+            sprintf(
+                '<question>Are you sure you want to delete store "%s" (ID: %d)?</question>',
+                $store->getCode(),
+                $store->getId()
+            ),
+            default: false
+        )) {
+            $output->writeln('<error>Operation cancelled.</error>');
+
+            return Command::FAILURE;
+        }
+
+        $isSecure = $this->registry->registry('isSecureArea');
+        $this->registry->unregister('isSecureArea');
+        $this->registry->register('isSecureArea', true);
+
+        try {
+            $store->delete();
+        } catch (\Throwable $exception) {
+            $output->writeln('<error>' . $exception->getMessage() . '</error>');
+
+            return Command::FAILURE;
+        } finally {
+            $this->registry->unregister('isSecureArea');
+            $this->registry->register('isSecureArea', $isSecure);
+        }
+
+        $output->writeln(
+            sprintf(
+                '<info>Successfully deleted store <comment>%s</comment> with ID: <comment>%d</comment></info>',
+                $store->getCode(),
+                $store->getId()
+            )
+        );
+
+        return Command::SUCCESS;
+    }
+
+    private function selectStore(): ?string
+    {
+        $options = [];
+        foreach ($this->storeFactory->create()->getCollection()->getItems() as $store) {
+            $options[(string) $store->getId()] = sprintf(
+                '%s (ID: %d, code: %s)',
+                $store->getName(),
+                $store->getId(),
+                $store->getCode()
+            );
+        }
+
+        if ($options === []) {
+            return null;
+        }
+
+        return (string) select('<question>Select a store to delete:</question>', $options);
+    }
+}

--- a/src/N98/Magento/Command/System/Store/DeleteCommand.php
+++ b/src/N98/Magento/Command/System/Store/DeleteCommand.php
@@ -127,6 +127,9 @@ class DeleteCommand extends AbstractMagentoCommand
             return null;
         }
 
-        return (string) select('<question>Select a store to delete:</question>', $options);
+        $selected = (string) select('<question>Select a store to delete:</question>', $options);
+        $selectedId = array_search($selected, $options, true);
+
+        return $selectedId === false ? $selected : (string) $selectedId;
     }
 }

--- a/src/N98/Magento/Command/System/StoreGroup/CreateCommand.php
+++ b/src/N98/Magento/Command/System/StoreGroup/CreateCommand.php
@@ -58,7 +58,7 @@ class CreateCommand extends AbstractMagentoCommand
         if ($input->isInteractive() || $name === null || $name === '') {
             $name = text(
                 '<question>Store group name:</question>',
-                default: $input->isInteractive() ? null : $name,
+                default: (string) ($name ?? ''),
                 validate: fn ($value) => $value === '' ? 'Please enter a store group name' : null
             );
         }
@@ -67,7 +67,7 @@ class CreateCommand extends AbstractMagentoCommand
         if ($input->isInteractive() || $code === null || $code === '') {
             $code = text(
                 '<question>Store group code:</question>',
-                default: $input->isInteractive() ? null : $code,
+                default: (string) ($code ?? ''),
                 validate: fn ($value) => $this->validateStoreGroupCode($value)
             );
         }
@@ -117,7 +117,7 @@ class CreateCommand extends AbstractMagentoCommand
         if ($input->isInteractive() || $rootCategoryId === null) {
             $rootCategoryId = text(
                 '<question>Root category ID:</question>',
-                default: $input->isInteractive() ? null : $rootCategoryId,
+                default: (string) ($rootCategoryId ?? ''),
                 validate: fn ($value) => $this->validatePositiveInteger(
                     $value,
                     'The root category ID must be a positive integer.'

--- a/src/N98/Magento/Command/System/StoreGroup/CreateCommand.php
+++ b/src/N98/Magento/Command/System/StoreGroup/CreateCommand.php
@@ -55,17 +55,19 @@ class CreateCommand extends AbstractMagentoCommand
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $name = $input->getArgument('name');
-        if ($name === null || $name === '') {
+        if ($input->isInteractive() || $name === null || $name === '') {
             $name = text(
                 '<question>Store group name:</question>',
+                default: $input->isInteractive() ? null : $name,
                 validate: fn ($value) => $value === '' ? 'Please enter a store group name' : null
             );
         }
 
         $code = $input->getArgument('code');
-        if ($code === null || $code === '') {
+        if ($input->isInteractive() || $code === null || $code === '') {
             $code = text(
                 '<question>Store group code:</question>',
+                default: $input->isInteractive() ? null : $code,
                 validate: fn ($value) => $this->validateStoreGroupCode($value)
             );
         }
@@ -77,16 +79,23 @@ class CreateCommand extends AbstractMagentoCommand
 
         $websiteId = $input->getOption('website-id');
         $websiteCode = $input->getOption('website-code');
-        if ($websiteId !== null && $websiteCode !== null) {
+        if (!$input->isInteractive() && $websiteId !== null && $websiteCode !== null) {
             throw new RuntimeException('Specify either --website-id or --website-code, not both.');
         }
 
-        if ($websiteId !== null && (!ctype_digit((string) $websiteId) || (int) $websiteId < 1)) {
+        if (!$input->isInteractive() && $websiteId !== null && (!ctype_digit((string) $websiteId) || (int) $websiteId < 1)) {
             throw new RuntimeException('The website ID must be a positive integer.');
         }
 
         $website = $this->websiteFactory->create();
-        if ($websiteId !== null) {
+        if ($input->isInteractive()) {
+            $websiteCode = $this->selectWebsite();
+            if ($websiteCode === null) {
+                throw new RuntimeException('No websites found.');
+            }
+
+            $website->load($websiteCode, 'code');
+        } elseif ($websiteId !== null) {
             $website->load((int) $websiteId);
         } elseif ($websiteCode !== null) {
             $website->load($websiteCode, 'code');
@@ -105,9 +114,10 @@ class CreateCommand extends AbstractMagentoCommand
         }
 
         $rootCategoryId = $input->getOption('root-category-id');
-        if ($rootCategoryId === null) {
+        if ($input->isInteractive() || $rootCategoryId === null) {
             $rootCategoryId = text(
                 '<question>Root category ID:</question>',
+                default: $input->isInteractive() ? null : $rootCategoryId,
                 validate: fn ($value) => $this->validatePositiveInteger(
                     $value,
                     'The root category ID must be a positive integer.'

--- a/src/N98/Magento/Command/System/Website/CreateCommand.php
+++ b/src/N98/Magento/Command/System/Website/CreateCommand.php
@@ -48,9 +48,10 @@ class CreateCommand extends AbstractMagentoCommand
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $code = $input->getArgument('code');
-        if ($code === null || $code === '') {
+        if ($input->isInteractive() || $code === null || $code === '') {
             $code = text(
                 '<question>Website code:</question>',
+                default: $input->isInteractive() ? null : $code,
                 validate: fn ($value) => $this->validateWebsiteCode($value)
             );
         }
@@ -61,9 +62,10 @@ class CreateCommand extends AbstractMagentoCommand
         }
 
         $name = $input->getArgument('name');
-        if ($name === null || $name === '') {
+        if ($input->isInteractive() || $name === null || $name === '') {
             $name = text(
                 '<question>Website name:</question>',
+                default: $input->isInteractive() ? null : $name,
                 validate: fn ($value) => $value === '' ? 'Please enter a website name' : null
             );
         }

--- a/tests/bats/functional_magerun_commands.bats
+++ b/tests/bats/functional_magerun_commands.bats
@@ -1098,6 +1098,74 @@ function cleanup_files_in_magento() {
   assert_output --partial "default"
 }
 
+@test "Command: sys:store:create and sys:store:delete" {
+  store_code="bats_store_$(date +%s%N)"
+  store_name="Bats Store"
+
+  run $BIN "sys:store:create" "$store_code" "$store_name" --group-id=1
+  assert [ "$status" -eq 0 ]
+  assert_output --partial "Successfully created store"
+  assert_output --partial "$store_code"
+
+  store_id=$(printf '%s\n' "$output" | sed -n 's/.*ID: \([0-9][0-9]*\).*/\1/p')
+  assert [ -n "$store_id" ]
+
+  run $BIN "sys:store:delete" "$store_id" --force
+  assert [ "$status" -eq 0 ]
+  assert_output --partial "Successfully deleted store"
+  assert_output --partial "$store_code"
+}
+
+@test "Command: sys:store:create prompts for every required parameter" {
+  store_code="bats_interactive_store_$(date +%s%N)"
+  store_name="Bats Interactive Store"
+
+  run bash -c "printf '%s\\n%s\\n1\\n' \"$store_code\" \"$store_name\" | $BIN_INTERACTION sys:store:create"
+  assert [ "$status" -eq 0 ]
+  assert_output --partial "Successfully created store"
+  assert_output --partial "$store_code"
+
+  store_id=$(printf '%s\n' "$output" | sed -n 's/.*ID: \([0-9][0-9]*\).*/\1/p')
+  assert [ -n "$store_id" ]
+
+  run $BIN "sys:store:delete" "$store_id" --force
+  assert [ "$status" -eq 0 ]
+}
+
+@test "Command: sys:store:delete prompts for confirmation and selection" {
+  store_code="bats_select_store_$(date +%s%N)"
+  store_name="Bats Select Store"
+
+  run $BIN "sys:store:create" "$store_code" "$store_name" --group-id=1
+  assert [ "$status" -eq 0 ]
+
+  store_id=$(printf '%s\n' "$output" | sed -n 's/.*ID: \([0-9][0-9]*\).*/\1/p')
+  assert [ -n "$store_id" ]
+
+  run bash -c "printf '%s\\ny\\n' \"$store_id\" | $BIN_INTERACTION sys:store:delete"
+  assert [ "$status" -eq 0 ]
+  assert_output --partial "Successfully deleted store"
+  assert_output --partial "$store_code"
+}
+
+@test "Command: sys:store:create rejects invalid store code" {
+  run $BIN "sys:store:create" "1invalid" "Invalid Store" --group-id=1
+  assert [ "$status" -ne 0 ]
+  assert_output --partial "Store code may only contain letters"
+}
+
+@test "Command: sys:store:delete rejects the default store" {
+  run $BIN "sys:store:list" --format=csv
+  assert [ "$status" -eq 0 ]
+
+  default_store_id=$(printf '%s\n' "$output" | awk -F, '$1 == "1" { print $1; exit }')
+  assert [ -n "$default_store_id" ]
+
+  run $BIN "sys:store:delete" "$default_store_id" --force
+  assert [ "$status" -ne 0 ]
+  assert_output --partial "default store"
+}
+
 @test "Command: sys:url:list" {
   run $BIN "sys:url:list" --add-cmspages default '{host},{path}'
   assert_output --partial "/"

--- a/tests/bats/functional_magerun_commands.bats
+++ b/tests/bats/functional_magerun_commands.bats
@@ -30,6 +30,16 @@ function cleanup_files_in_magento() {
   rm -Rf "${N98_MAGERUN2_TEST_MAGENTO_ROOT:?}/$1"
 }
 
+function extract_store_id() {
+  sed -n 's/.*ID: \([0-9][0-9]*\).*/\1/p' | sed -n '$p'
+}
+
+teardown() {
+  if [ -n "${store_id:-}" ]; then
+    $BIN "sys:store:delete" "$store_id" --force >/dev/null 2>&1 || true
+  fi
+}
+
 @test "Issue: 1414" {
   tempfilename=$(mktemp)
   # Generate random numbers for email uniqueness
@@ -1103,11 +1113,12 @@ function cleanup_files_in_magento() {
   store_name="Bats Store"
 
   run $BIN "sys:store:create" "$store_code" "$store_name" --group-id=1
+  store_id=$(printf '%s\n' "$output" | extract_store_id)
+
   assert [ "$status" -eq 0 ]
   assert_output --partial "Successfully created store"
   assert_output --partial "$store_code"
 
-  store_id=$(printf '%s\n' "$output" | sed -n 's/.*ID: \([0-9][0-9]*\).*/\1/p')
   assert [ -n "$store_id" ]
 
   run $BIN "sys:store:delete" "$store_id" --force
@@ -1121,11 +1132,12 @@ function cleanup_files_in_magento() {
   store_name="Bats Interactive Store"
 
   run bash -c "printf '%s\\n%s\\n1\\n' \"$store_code\" \"$store_name\" | $BIN_INTERACTION sys:store:create"
+  store_id=$(printf '%s\n' "$output" | extract_store_id)
+
   assert [ "$status" -eq 0 ]
   assert_output --partial "Successfully created store"
   assert_output --partial "$store_code"
 
-  store_id=$(printf '%s\n' "$output" | sed -n 's/.*ID: \([0-9][0-9]*\).*/\1/p')
   assert [ -n "$store_id" ]
 
   run $BIN "sys:store:delete" "$store_id" --force
@@ -1137,15 +1149,15 @@ function cleanup_files_in_magento() {
   store_name="Bats Select Store"
 
   run $BIN "sys:store:create" "$store_code" "$store_name" --group-id=1
-  assert [ "$status" -eq 0 ]
+  store_id=$(printf '%s\n' "$output" | extract_store_id)
 
-  store_id=$(printf '%s\n' "$output" | sed -n 's/.*ID: \([0-9][0-9]*\).*/\1/p')
+  assert [ "$status" -eq 0 ]
   assert [ -n "$store_id" ]
 
   run bash -c "printf '%s\\ny\\n' \"$store_id\" | $BIN_INTERACTION sys:store:delete"
   assert [ "$status" -eq 0 ]
   assert_output --partial "Successfully deleted store"
-  assert_output --partial "$store_code"
+  assert_output --partial "ID: $store_id"
 }
 
 @test "Command: sys:store:create rejects invalid store code" {


### PR DESCRIPTION
## Summary

- add `sys:store:create` with interactive prompts and group resolution
- add `sys:store:delete` with interactive selection, confirmation, force mode, and default-store protection
- prompt for all required values in interactive website and store-group creation
- add Bats coverage and command documentation

## Testing

- PHP syntax checks passed
- Bats parsing passed
- Functional Bats execution was not available because `N98_MAGERUN2_BIN` and Magento test environment variables are unset
- PHP-CS-Fixer was unavailable because Composer dependencies are not installed

Closes #2095