### PR TITLE
feat(admin/user): make enable/disable commands interactive

### DIFF
--- a/src/N98/Magento/Command/Admin/User/ActivateCommand.php
+++ b/src/N98/Magento/Command/Admin/User/ActivateCommand.php
@@ -22,12 +22,31 @@ class ActivateCommand extends ChangeStatusCommand
         $this
             ->setName('admin:user:activate')
             ->setAliases(['admin:user:enable'])
-            ->addArgument(self::USER_ARGUMENT, InputArgument::REQUIRED, 'Username or email for the admin user')
+            ->addArgument(
+                self::USER_ARGUMENT,
+                InputArgument::OPTIONAL,
+                'Username or email for the admin user. If omitted, you will be prompted to select one.'
+            )
             ->setDescription('Activates an admin user.');
     }
 
     protected function getNewStatusForUser(User $user, InputInterface $input): bool
     {
         return true;
+    }
+
+    protected function isSelectableUser(User $user): bool
+    {
+        return !$user->getIsActive();
+    }
+
+    protected function getSelectQuestion(): string
+    {
+        return '<question>Select an admin user to activate:</question>';
+    }
+
+    protected function getNoUsersMessage(): string
+    {
+        return 'No inactive admin users found.';
     }
 }

--- a/src/N98/Magento/Command/Admin/User/ChangeStatusCommand.php
+++ b/src/N98/Magento/Command/Admin/User/ChangeStatusCommand.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 
 namespace N98\Magento\Command\Admin\User;
 
+use function Laravel\Prompts\select;
 use Magento\User\Model\ResourceModel\User as UserResourceModel;
 use Magento\User\Model\ResourceModel\User\CollectionFactory;
 use Magento\User\Model\User;
@@ -48,7 +49,7 @@ class ChangeStatusCommand extends AbstractMagentoCommand
     {
         $this
             ->setName('admin:user:change-status')
-            ->addArgument(self::USER_ARGUMENT, InputArgument::REQUIRED, 'Username or email for the admin user')
+            ->addArgument(self::USER_ARGUMENT, InputArgument::OPTIONAL, 'Username or email for the admin user')
             ->addOption(self::ACTIVATE_OPTION, null, InputOption::VALUE_NONE, 'Activate the user')
             ->addOption(self::DEACTIVATE_OPTION, null, InputOption::VALUE_NONE, 'Deactivate the user')
             ->setDescription(
@@ -72,10 +73,21 @@ class ChangeStatusCommand extends AbstractMagentoCommand
         }
 
         $username = $input->getArgument(self::USER_ARGUMENT);
-        if (!\is_string($username)) {
-            $output->writeln('Please provide an username or email for the admin user. Use --help for more information.');
+        if (!\is_string($username) || $username === '') {
+            if (!$input->isInteractive()) {
+                $output->writeln(
+                    'Please provide an username or email for the admin user. Use --help for more information.'
+                );
 
-            return Command::FAILURE;
+                return Command::FAILURE;
+            }
+
+            $username = $this->selectUsername();
+            if ($username === null) {
+                $output->writeln(\sprintf('<info>%s</info>', $this->getNoUsersMessage()));
+
+                return Command::SUCCESS;
+            }
         }
 
         $user = $this->getUser($username);
@@ -133,5 +145,43 @@ class ChangeStatusCommand extends AbstractMagentoCommand
 
         // If no option is supplied, toggle the status.
         return !$user->getIsActive();
+    }
+
+    protected function selectUsername(): ?string
+    {
+        $options = [];
+        foreach ($this->userCollectionFactory->create()->getItems() as $user) {
+            if (!$this->isSelectableUser($user)) {
+                continue;
+            }
+
+            $options[(string) $user->getUsername()] = \sprintf(
+                '%s (%s) - %s',
+                $user->getUsername(),
+                $user->getEmail(),
+                $user->getIsActive() ? 'active' : 'inactive'
+            );
+        }
+
+        if ($options === []) {
+            return null;
+        }
+
+        return (string) select($this->getSelectQuestion(), $options);
+    }
+
+    protected function isSelectableUser(User $user): bool
+    {
+        return true;
+    }
+
+    protected function getSelectQuestion(): string
+    {
+        return '<question>Select an admin user:</question>';
+    }
+
+    protected function getNoUsersMessage(): string
+    {
+        return 'No admin users found.';
     }
 }

--- a/src/N98/Magento/Command/Admin/User/DeactivateCommand.php
+++ b/src/N98/Magento/Command/Admin/User/DeactivateCommand.php
@@ -22,12 +22,31 @@ class DeactivateCommand extends ChangeStatusCommand
         $this
             ->setName('admin:user:deactivate')
             ->setAliases(['admin:user:disable'])
-            ->addArgument(self::USER_ARGUMENT, InputArgument::REQUIRED, 'Username or email for the admin user')
+            ->addArgument(
+                self::USER_ARGUMENT,
+                InputArgument::OPTIONAL,
+                'Username or email for the admin user. If omitted, you will be prompted to select one.'
+            )
             ->setDescription('Deactivates an admin user.');
     }
 
     protected function getNewStatusForUser(User $user, InputInterface $input): bool
     {
         return false;
+    }
+
+    protected function isSelectableUser(User $user): bool
+    {
+        return (bool) $user->getIsActive();
+    }
+
+    protected function getSelectQuestion(): string
+    {
+        return '<question>Select an admin user to deactivate:</question>';
+    }
+
+    protected function getNoUsersMessage(): string
+    {
+        return 'No active admin users found.';
     }
 }

--- a/tests/bats/functional_magerun_commands.bats
+++ b/tests/bats/functional_magerun_commands.bats
@@ -34,9 +34,28 @@ function extract_store_id() {
   sed -n 's/.*ID: \([0-9][0-9]*\).*/\1/p' | sed -n '$p'
 }
 
+function create_test_admin_user() {
+  local username="$1"
+  local is_active="$2"
+
+  php "${N98_MAGERUN2_TEST_MAGENTO_ROOT}/bin/magento" admin:user:create \
+    --admin-user="${username}" \
+    --admin-password="BatsPassw0rd#1" \
+    --admin-email="${username}@example.com" \
+    --admin-firstname="Bats" \
+    --admin-lastname="User" >/dev/null 2>&1
+
+  if [ "${is_active}" = "0" ]; then
+    $BIN "db:query" "UPDATE admin_user SET is_active = 0 WHERE username = '${username}'" >/dev/null 2>&1
+  fi
+}
+
 teardown() {
   if [ -n "${store_id:-}" ]; then
     $BIN "sys:store:delete" "$store_id" --force >/dev/null 2>&1 || true
+  fi
+  if [ -n "${admin_test_username:-}" ]; then
+    $BIN "db:query" "DELETE FROM admin_user WHERE username = '${admin_test_username}'" >/dev/null 2>&1 || true
   fi
 }
 
@@ -174,6 +193,90 @@ teardown() {
   assert_output --partial "id"
   assert_output --partial "status"
   assert [ "$status" -eq 0 ]
+}
+
+# ============================================
+# Command: admin:user:enable / admin:user:activate
+# ============================================
+
+@test "Command: admin:user:enable activates the given user" {
+  admin_test_username="bats_enable_$(date +%s%N)"
+  create_test_admin_user "$admin_test_username" 0
+
+  run $BIN "admin:user:enable" "$admin_test_username"
+  assert [ "$status" -eq 0 ]
+  assert_output --partial "User has been"
+  assert_output --partial "activated"
+
+  run $BIN "admin:user:list" --format=csv --columns=username,is_active
+  assert_output --partial "${admin_test_username},active"
+}
+
+@test "Command: admin:user:activate is an alias for admin:user:enable" {
+  admin_test_username="bats_activate_$(date +%s%N)"
+  create_test_admin_user "$admin_test_username" 0
+
+  run $BIN "admin:user:activate" "$admin_test_username"
+  assert [ "$status" -eq 0 ]
+  assert_output --partial "activated"
+}
+
+@test "Command: admin:user:enable fails without a username when not interactive" {
+  run $BIN "admin:user:enable"
+  assert [ "$status" -eq 1 ]
+  assert_output --partial "Please provide an username or email"
+}
+
+@test "Command: admin:user:enable prompts for a user to select when omitted" {
+  admin_test_username="bats_enable_prompt_$(date +%s%N)"
+  create_test_admin_user "$admin_test_username" 0
+
+  run bash -c "printf '%s\\n' \"$admin_test_username\" | $BIN_INTERACTION admin:user:enable"
+  assert [ "$status" -eq 0 ]
+  assert_output --partial "User has been"
+  assert_output --partial "activated"
+}
+
+# ============================================
+# Command: admin:user:disable / admin:user:deactivate
+# ============================================
+
+@test "Command: admin:user:disable deactivates the given user" {
+  admin_test_username="bats_disable_$(date +%s%N)"
+  create_test_admin_user "$admin_test_username" 1
+
+  run $BIN "admin:user:disable" "$admin_test_username"
+  assert [ "$status" -eq 0 ]
+  assert_output --partial "User has been"
+  assert_output --partial "deactivated"
+
+  run $BIN "admin:user:list" --format=csv --columns=username,is_active
+  assert_output --partial "${admin_test_username},inactive"
+}
+
+@test "Command: admin:user:deactivate is an alias for admin:user:disable" {
+  admin_test_username="bats_deactivate_$(date +%s%N)"
+  create_test_admin_user "$admin_test_username" 1
+
+  run $BIN "admin:user:deactivate" "$admin_test_username"
+  assert [ "$status" -eq 0 ]
+  assert_output --partial "deactivated"
+}
+
+@test "Command: admin:user:disable fails without a username when not interactive" {
+  run $BIN "admin:user:disable"
+  assert [ "$status" -eq 1 ]
+  assert_output --partial "Please provide an username or email"
+}
+
+@test "Command: admin:user:disable prompts for a user to select when omitted" {
+  admin_test_username="bats_disable_prompt_$(date +%s%N)"
+  create_test_admin_user "$admin_test_username" 1
+
+  run bash -c "printf '%s\\n' \"$admin_test_username\" | $BIN_INTERACTION admin:user:disable"
+  assert [ "$status" -eq 0 ]
+  assert_output --partial "User has been"
+  assert_output --partial "deactivated"
 }
 
 # ============================================


### PR DESCRIPTION
## Summary
- `admin:user:enable`/`admin:user:disable` (and their `activate`/`deactivate`/`change-status` counterparts) now prompt for the admin user to select when the argument is omitted and the shell is interactive, instead of just failing.
- The selection list is filtered per command: `enable` only offers currently inactive users, `disable` only offers currently active users.
- Non-interactive invocations without the argument still fail immediately with a clear error message, so scripted/cron usage is unaffected.

## Test plan
- [x] `bats tests/bats/functional_magerun_commands.bats --filter 'admin:user'` passes (17/17) against a Mage-OS 1.2.0 test environment via ddev
- [x] Manual check that `admin:user:change-status --activate` still works with an explicit username
- [x] `php-cs-fixer --dry-run` clean on changed files