### PR TITLE
feat(system): add sys:email:test command

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -167,6 +167,7 @@ commands:
     - N98\Magento\Command\System\Cron\ListCommand
     - N98\Magento\Command\System\Cron\RunCommand
     - N98\Magento\Command\System\Cron\ScheduleCommand
+    - N98\Magento\Command\System\Email\TestCommand
     - N98\Magento\Command\System\InfoCommand
     - N98\Magento\Command\System\MaintenanceCommand
     - N98\Magento\Command\System\Setup\ChangeVersionCommand

--- a/docs/docs/command-docs/system/sys-email-test.md
+++ b/docs/docs/command-docs/system/sys-email-test.md
@@ -1,0 +1,32 @@
+---
+title: sys:email:test
+sidebar_label: sys:email:test
+---
+
+# sys:email:test
+
+:::info
+Sends a minimal test email through Magento's own mail transport, without creating any customer accounts or other test data. This is useful for checking email deliverability with tools like mail-tester.com, and for verifying that SMTP settings are correctly configured for a given store view. The email re-uses the "Contact Form" template shipped with Magento, since it does not require any additional data to be set up.
+:::
+
+```sh
+n98-magerun2.phar sys:email:test [--to=<email>] [--from=<email>] [--cc=<email>]... [--store=<code-or-id>]
+```
+
+If `--to` is omitted, you will be prompted for it interactively.
+
+## Options
+
+- `--to` (required, prompted for interactively if omitted) - Recipient email address
+- `--from` (optional) - Sender email address, defaults to the store's configured general contact email
+- `--cc` (optional, repeatable) - Additional cc email address, can be used multiple times
+- `--store` (optional) - Store code or id, defaults to the current store
+
+## Examples
+
+```sh
+n98-magerun2.phar sys:email:test
+n98-magerun2.phar sys:email:test --to=you@example.com
+n98-magerun2.phar sys:email:test --to=you@example.com --store=2
+n98-magerun2.phar sys:email:test --to=you@example.com --from=sender@example.com --cc=cc1@example.com --cc=cc2@example.com
+```

--- a/src/N98/Magento/Command/System/Email/TestCommand.php
+++ b/src/N98/Magento/Command/System/Email/TestCommand.php
@@ -13,6 +13,7 @@ namespace N98\Magento\Command\System\Email;
 use function Laravel\Prompts\text;
 use Magento\Framework\App\Area;
 use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Framework\App\State;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Framework\Mail\Template\TransportBuilder;
 use Magento\Framework\Translate\Inline\StateInterface;
@@ -48,16 +49,23 @@ class TestCommand extends AbstractMagentoCommand
      */
     private $inlineTranslation;
 
+    /**
+     * @var State
+     */
+    private $appState;
+
     public function inject(
         TransportBuilder $transportBuilder,
         StoreManagerInterface $storeManager,
         ScopeConfigInterface $scopeConfig,
-        StateInterface $inlineTranslation
+        StateInterface $inlineTranslation,
+        State $appState
     ): void {
         $this->transportBuilder = $transportBuilder;
         $this->storeManager = $storeManager;
         $this->scopeConfig = $scopeConfig;
         $this->inlineTranslation = $inlineTranslation;
+        $this->appState = $appState;
     }
 
     protected function configure(): void
@@ -200,6 +208,8 @@ HELP
 
         $this->inlineTranslation->suspend();
         try {
+            $this->appState->setAreaCode(Area::AREA_FRONTEND);
+
             $transportBuilder = $this->transportBuilder
                 ->setTemplateIdentifier($templateId)
                 ->setTemplateOptions(

--- a/src/N98/Magento/Command/System/Email/TestCommand.php
+++ b/src/N98/Magento/Command/System/Email/TestCommand.php
@@ -1,0 +1,262 @@
+<?php
+/**
+ * This file is part of the n98-magerun2 project.
+ *
+ * For the full copyright and license information, please view the MIT-LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace N98\Magento\Command\System\Email;
+
+use function Laravel\Prompts\text;
+use Magento\Framework\App\Area;
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Framework\Mail\Template\TransportBuilder;
+use Magento\Framework\Translate\Inline\StateInterface;
+use Magento\Store\Model\ScopeInterface;
+use Magento\Store\Model\StoreManagerInterface;
+use N98\Magento\Command\AbstractMagentoCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class TestCommand extends AbstractMagentoCommand
+{
+    private const DEFAULT_TEMPLATE = 'contact_email_email_template';
+
+    /**
+     * @var TransportBuilder
+     */
+    private $transportBuilder;
+
+    /**
+     * @var StoreManagerInterface
+     */
+    private $storeManager;
+
+    /**
+     * @var ScopeConfigInterface
+     */
+    private $scopeConfig;
+
+    /**
+     * @var StateInterface
+     */
+    private $inlineTranslation;
+
+    public function inject(
+        TransportBuilder $transportBuilder,
+        StoreManagerInterface $storeManager,
+        ScopeConfigInterface $scopeConfig,
+        StateInterface $inlineTranslation
+    ): void {
+        $this->transportBuilder = $transportBuilder;
+        $this->storeManager = $storeManager;
+        $this->scopeConfig = $scopeConfig;
+        $this->inlineTranslation = $inlineTranslation;
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->setName('sys:email:test')
+            ->addOption('to', null, InputOption::VALUE_REQUIRED, 'Recipient email address (prompted for if omitted)')
+            ->addOption(
+                'from',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Sender email address (defaults to the store\'s general contact email)'
+            )
+            ->addOption(
+                'cc',
+                null,
+                InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
+                'Additional cc email address (can be used multiple times)',
+                []
+            )
+            ->addOption('store', null, InputOption::VALUE_REQUIRED, 'Store code or id')
+            ->setDescription('Sends a test email through Magento\'s mail transport for deliverability testing');
+
+        $this->setHelp(
+            <<<HELP
+Sends a minimal test email through Magento's own mail transport, without creating
+any customer accounts or other test data. This is useful for checking email
+deliverability with tools like mail-tester.com, and for verifying that SMTP
+settings are correctly configured for a given store view.
+
+The email re-uses the "Contact Form" template shipped with Magento, since it does
+not require any additional data to be set up.
+
+If --to is omitted, you will be prompted for it interactively.
+
+Usage:
+
+    n98-magerun2 sys:email:test
+    n98-magerun2 sys:email:test --to=you@example.com
+    n98-magerun2 sys:email:test --to=you@example.com --store=2
+    n98-magerun2 sys:email:test --to=you@example.com --from=sender@example.com --cc=cc1@example.com --cc=cc2@example.com
+HELP
+        );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $this->detectMagento($output, true);
+        if (!$this->initMagento()) {
+            return Command::FAILURE;
+        }
+
+        $to = $input->getOption('to');
+        if ($to === null || $to === '') {
+            $to = text(
+                '<question>Recipient email address:</question>',
+                validate: fn ($value) => $this->validateRequiredEmail($value)
+            );
+        }
+
+        // In non-interactive mode (e.g. missing --to and no TTY), the prompt above cannot ask
+        // and just returns an empty default, so this check still needs to catch that case.
+        if (!is_string($to) || $to === '' || !filter_var($to, FILTER_VALIDATE_EMAIL)) {
+            $output->writeln('<error>Please provide a valid recipient email address with --to</error>');
+
+            return Command::FAILURE;
+        }
+
+        $from = $input->getOption('from');
+        if ($from !== null && !filter_var($from, FILTER_VALIDATE_EMAIL)) {
+            $output->writeln('<error>The --from email address is not valid</error>');
+
+            return Command::FAILURE;
+        }
+
+        $ccList = (array) $input->getOption('cc');
+        foreach ($ccList as $cc) {
+            if (!filter_var($cc, FILTER_VALIDATE_EMAIL)) {
+                $output->writeln(sprintf('<error>The --cc email address "%s" is not valid</error>', $cc));
+
+                return Command::FAILURE;
+            }
+        }
+
+        try {
+            $store = $this->storeManager->getStore($input->getOption('store'));
+        } catch (NoSuchEntityException $e) {
+            $output->writeln(sprintf('<error>%s</error>', $e->getMessage()));
+
+            return Command::FAILURE;
+        }
+
+        if ($from !== null) {
+            $fromEmail = $from;
+            $fromName = 'n98-magerun2';
+        } else {
+            $fromEmail = (string) $this->scopeConfig->getValue(
+                'trans_email/ident_general/email',
+                ScopeInterface::SCOPE_STORE,
+                $store->getCode()
+            );
+            $fromName = (string) $this->scopeConfig->getValue(
+                'trans_email/ident_general/name',
+                ScopeInterface::SCOPE_STORE,
+                $store->getCode()
+            );
+        }
+
+        if ($fromEmail === '') {
+            $output->writeln(
+                '<error>Could not determine a sender email address for this store. Use --from to specify one.</error>'
+            );
+
+            return Command::FAILURE;
+        }
+
+        $templateId = (string) $this->scopeConfig->getValue(
+            'contact/email/email_template',
+            ScopeInterface::SCOPE_STORE,
+            $store->getCode()
+        );
+        if ($templateId === '') {
+            $templateId = self::DEFAULT_TEMPLATE;
+        }
+
+        $variables = [
+            'data' => [
+                'name' => $fromName !== '' ? $fromName : 'n98-magerun2',
+                'email' => $fromEmail,
+                'telephone' => '',
+                'comment' => sprintf(
+                    'This is a test email sent by "n98-magerun2 sys:email:test" on %s for store "%s" (%s) '
+                    . 'to check email deliverability.',
+                    date('Y-m-d H:i:s'),
+                    $store->getName(),
+                    $store->getCode()
+                ),
+            ],
+        ];
+
+        $this->inlineTranslation->suspend();
+        try {
+            $transportBuilder = $this->transportBuilder
+                ->setTemplateIdentifier($templateId)
+                ->setTemplateOptions(
+                    [
+                        'area' => Area::AREA_FRONTEND,
+                        'store' => $store->getId(),
+                    ]
+                )
+                ->setTemplateVars($variables)
+                ->setFromByScope(['email' => $fromEmail, 'name' => $fromName ?: 'n98-magerun2'], $store->getId())
+                ->addTo($to)
+                ->setReplyTo($fromEmail, $fromName !== '' ? $fromName : null);
+
+            foreach ($ccList as $cc) {
+                $transportBuilder->addCc($cc);
+            }
+
+            $transportBuilder->getTransport()->sendMessage();
+        } catch (\Exception $e) {
+            $output->writeln(sprintf('<error>Could not send test email: %s</error>', $e->getMessage()));
+
+            return Command::FAILURE;
+        } finally {
+            $this->inlineTranslation->resume();
+        }
+
+        $output->writeln(
+            sprintf(
+                '<info>Test email sent to <comment>%s</comment> from <comment>%s</comment> '
+                . 'for store <comment>%s</comment></info>',
+                $to,
+                $fromEmail,
+                $store->getCode()
+            )
+        );
+
+        if ($ccList !== []) {
+            $output->writeln(sprintf('<info>Cc: <comment>%s</comment></info>', implode(', ', $ccList)));
+        }
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * @param string $value
+     * @return string|null
+     */
+    private function validateRequiredEmail(string $value): ?string
+    {
+        if ($value === '') {
+            return 'Please enter a recipient email address';
+        }
+
+        if (!filter_var($value, FILTER_VALIDATE_EMAIL)) {
+            return 'Please enter a valid email address';
+        }
+
+        return null;
+    }
+}

--- a/tests/N98/Magento/Command/System/Email/TestCommandTest.php
+++ b/tests/N98/Magento/Command/System/Email/TestCommandTest.php
@@ -9,6 +9,7 @@
 namespace N98\Magento\Command\System\Email;
 
 use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Framework\App\State as AppState;
 use Magento\Framework\Mail\Template\TransportBuilder;
 use Magento\Framework\Translate\Inline\StateInterface;
 use Magento\Store\Model\Store;
@@ -49,6 +50,9 @@ class TestCommandTest extends TestCase
         $inlineTranslation = $this->createMock(StateInterface::class);
         $inlineTranslation->expects($this->once())->method('suspend');
         $inlineTranslation->expects($this->once())->method('resume');
+
+        $appState = $this->createMock(AppState::class);
+        $appState->expects($this->once())->method('setAreaCode')->with('frontend');
 
         $store = $this->createMock(Store::class);
         $store->method('getId')->willReturn(1);
@@ -92,7 +96,7 @@ class TestCommandTest extends TestCase
             {
             }
         };
-        $command->inject($transportBuilder, $storeManager, $scopeConfig, $inlineTranslation);
+        $command->inject($transportBuilder, $storeManager, $scopeConfig, $inlineTranslation, $appState);
 
         $tester = new CommandTester($command);
         $status = $tester->execute([

--- a/tests/N98/Magento/Command/System/Email/TestCommandTest.php
+++ b/tests/N98/Magento/Command/System/Email/TestCommandTest.php
@@ -10,19 +10,20 @@ namespace N98\Magento\Command\System\Email;
 
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\Mail\Template\TransportBuilder;
-use Magento\Framework\Mail\TransportInterface;
 use Magento\Framework\Translate\Inline\StateInterface;
 use Magento\Store\Model\Store;
 use Magento\Store\Model\StoreManagerInterface;
 use N98\Magento\Command\TestCase;
-use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Tester\CommandTester;
 
 class TestCommandTest extends TestCase
 {
     public function testSendsUsingMockedMailTransport()
     {
-        $transport = $this->createMock(TransportInterface::class);
+        $transport = $this->getMockBuilder(\stdClass::class)
+            ->addMethods(['sendMessage'])
+            ->getMock();
         $transport->expects($this->once())->method('sendMessage');
 
         $transportBuilder = $this->createMock(TransportBuilder::class);
@@ -60,7 +61,7 @@ class TestCommandTest extends TestCase
             ['contact/email/email_template', 'stores', 'default', 'contact_email_email_template'],
         ]);
 
-        $command = new class extends TestCommand {
+        $command = new class() extends TestCommand {
             public function detectMagento(OutputInterface $output, $silent = true): bool
             {
                 return true;
@@ -76,7 +77,6 @@ class TestCommandTest extends TestCase
         $tester = new CommandTester($command);
         $status = $tester->execute([
             '--to' => 'recipient@example.com',
-            '--from' => null,
             '--cc' => ['copy@example.com'],
         ]);
 

--- a/tests/N98/Magento/Command/System/Email/TestCommandTest.php
+++ b/tests/N98/Magento/Command/System/Email/TestCommandTest.php
@@ -1,0 +1,125 @@
+<?php
+/**
+ * This file is part of the n98-magerun2 project.
+ *
+ * For the full copyright and license information, please view the MIT-LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+namespace N98\Magento\Command\System\Email;
+
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Framework\Mail\Template\TransportBuilder;
+use Magento\Framework\Mail\TransportInterface;
+use Magento\Framework\Translate\Inline\StateInterface;
+use Magento\Store\Model\Store;
+use Magento\Store\Model\StoreManagerInterface;
+use N98\Magento\Command\TestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class TestCommandTest extends TestCase
+{
+    public function testSendsUsingMockedMailTransport()
+    {
+        $transport = $this->createMock(TransportInterface::class);
+        $transport->expects($this->once())->method('sendMessage');
+
+        $transportBuilder = $this->createMock(TransportBuilder::class);
+        $transportBuilder->expects($this->once())->method('setTemplateIdentifier')
+            ->with('contact_email_email_template')->willReturnSelf();
+        $transportBuilder->expects($this->once())->method('setTemplateOptions')
+            ->with(['area' => 'frontend', 'store' => 1])->willReturnSelf();
+        $transportBuilder->expects($this->once())->method('setTemplateVars')->willReturnSelf();
+        $transportBuilder->expects($this->once())->method('setFromByScope')
+            ->with(['email' => 'sender@example.com', 'name' => 'Store Sender'], 1)->willReturnSelf();
+        $transportBuilder->expects($this->once())->method('addTo')
+            ->with('recipient@example.com')->willReturnSelf();
+        $transportBuilder->expects($this->once())->method('setReplyTo')
+            ->with('sender@example.com', 'Store Sender')->willReturnSelf();
+        $transportBuilder->expects($this->once())->method('addCc')
+            ->with('copy@example.com')->willReturnSelf();
+        $transportBuilder->expects($this->once())->method('getTransport')->willReturn($transport);
+
+        $inlineTranslation = $this->createMock(StateInterface::class);
+        $inlineTranslation->expects($this->once())->method('suspend');
+        $inlineTranslation->expects($this->once())->method('resume');
+
+        $store = $this->createMock(Store::class);
+        $store->method('getId')->willReturn(1);
+        $store->method('getCode')->willReturn('default');
+        $store->method('getName')->willReturn('Default Store');
+
+        $storeManager = $this->createMock(StoreManagerInterface::class);
+        $storeManager->expects($this->once())->method('getStore')->with(null)->willReturn($store);
+
+        $scopeConfig = $this->createMock(ScopeConfigInterface::class);
+        $scopeConfig->method('getValue')->willReturnMap([
+            ['trans_email/ident_general/email', 'stores', 'default', 'sender@example.com'],
+            ['trans_email/ident_general/name', 'stores', 'default', 'Store Sender'],
+            ['contact/email/email_template', 'stores', 'default', 'contact_email_email_template'],
+        ]);
+
+        $command = new class extends TestCommand {
+            public function detectMagento(OutputInterface $output, $silent = true): bool
+            {
+                return true;
+            }
+
+            protected function initMagento(): bool
+            {
+                return true;
+            }
+        };
+        $command->inject($transportBuilder, $storeManager, $scopeConfig, $inlineTranslation);
+
+        $tester = new CommandTester($command);
+        $status = $tester->execute([
+            '--to' => 'recipient@example.com',
+            '--from' => null,
+            '--cc' => ['copy@example.com'],
+        ]);
+
+        $this->assertSame(0, $status);
+        $this->assertStringContainsString('Test email sent to', $tester->getDisplay());
+    }
+
+    public function testMissingToOptionFailsWithoutPromptingOrSendingMail()
+    {
+        // Run with interactive=false so the "to" prompt resolves to its empty default instead
+        // of reading from stdin. This guarantees the command fails validation before it ever
+        // reaches the mail transport, regardless of the test runner's stdin/TTY state.
+        $tester = new CommandTester($this->getApplication()->find('sys:email:test'));
+        $status = $tester->execute([], ['interactive' => false]);
+
+        $this->assertSame(1, $status);
+        $this->assertStringContainsString(
+            'Please provide a valid recipient email address with --to',
+            $tester->getDisplay()
+        );
+    }
+
+    public function testInvalidToOptionFails()
+    {
+        $this->assertDisplayContains(
+            ['command' => 'sys:email:test', '--to' => 'not-an-email'],
+            'Please provide a valid recipient email address with --to'
+        );
+    }
+
+    public function testInvalidFromOptionFails()
+    {
+        $this->assertDisplayContains(
+            ['command' => 'sys:email:test', '--to' => 'test@example.com', '--from' => 'not-an-email'],
+            'The --from email address is not valid'
+        );
+    }
+
+    public function testInvalidCcOptionFails()
+    {
+        $this->assertDisplayContains(
+            ['command' => 'sys:email:test', '--to' => 'test@example.com', '--cc' => ['not-an-email']],
+            'not-an-email" is not valid'
+        );
+    }
+}

--- a/tests/N98/Magento/Command/System/Email/TestCommandTest.php
+++ b/tests/N98/Magento/Command/System/Email/TestCommandTest.php
@@ -14,6 +14,7 @@ use Magento\Framework\Translate\Inline\StateInterface;
 use Magento\Store\Model\Store;
 use Magento\Store\Model\StoreManagerInterface;
 use N98\Magento\Command\TestCase;
+use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Tester\CommandTester;
 
@@ -21,6 +22,9 @@ class TestCommandTest extends TestCase
 {
     public function testSendsUsingMockedMailTransport()
     {
+        // Load the Magento installation autoloader before creating framework mocks.
+        $this->getApplication();
+
         $transport = $this->getMockBuilder(\stdClass::class)
             ->addMethods(['sendMessage'])
             ->getMock();
@@ -55,13 +59,21 @@ class TestCommandTest extends TestCase
         $storeManager->expects($this->once())->method('getStore')->with(null)->willReturn($store);
 
         $scopeConfig = $this->createMock(ScopeConfigInterface::class);
-        $scopeConfig->method('getValue')->willReturnMap([
-            ['trans_email/ident_general/email', 'stores', 'default', 'sender@example.com'],
-            ['trans_email/ident_general/name', 'stores', 'default', 'Store Sender'],
-            ['contact/email/email_template', 'stores', 'default', 'contact_email_email_template'],
-        ]);
+        $scopeConfig->method('getValue')->willReturnCallback(static function (string $path): string {
+            return [
+                'trans_email/ident_general/email' => 'sender@example.com',
+                'trans_email/ident_general/name' => 'Store Sender',
+                'contact/email/email_template' => 'contact_email_email_template',
+            ][$path] ?? '';
+        });
 
         $command = new class() extends TestCommand {
+            public function __construct()
+            {
+                parent::__construct();
+                $this->addArgument('command', InputArgument::OPTIONAL);
+            }
+
             public function detectMagento(OutputInterface $output, $silent = true): bool
             {
                 return true;
@@ -71,11 +83,20 @@ class TestCommandTest extends TestCase
             {
                 return true;
             }
+
+            public function injectObjects(OutputInterface $output): void
+            {
+            }
+
+            protected function injectCommandToHelpers(): void
+            {
+            }
         };
         $command->inject($transportBuilder, $storeManager, $scopeConfig, $inlineTranslation);
 
         $tester = new CommandTester($command);
         $status = $tester->execute([
+            'command' => 'sys:email:test',
             '--to' => 'recipient@example.com',
             '--cc' => ['copy@example.com'],
         ]);

--- a/tests/bats/functional_magerun_commands.bats
+++ b/tests/bats/functional_magerun_commands.bats
@@ -1163,6 +1163,20 @@ teardown() {
   assert_output --partial "Last executed jobs"
 }
 
+@test "Command: sys:email:test missing --to" {
+  # --no-interaction avoids blocking on the interactive prompt and keeps this from ever
+  # reaching the real mail transport.
+  run $BIN "sys:email:test" --no-interaction
+  assert_output --partial "Please provide a valid recipient email address with --to"
+  assert [ "$status" -eq 1 ]
+}
+
+@test "Command: sys:email:test invalid --to" {
+  run $BIN "sys:email:test" --to=not-an-email --no-interaction
+  assert_output --partial "Please provide a valid recipient email address with --to"
+  assert [ "$status" -eq 1 ]
+}
+
 @test "Command: sys:info" {
   run $BIN "sys:info"
   assert_output --partial "Magento System Information"


### PR DESCRIPTION
## Summary

Port `sys:email:test` from cmuench/n98-magerun2#304 for deliverability testing through Magento's configured mail transport.

Related issue #2106

## Changes

- Add `sys:email:test` with `--to`, `--from`, repeatable `--cc`, and `--store` options.
- Reuse Magento's Contact Form email template.
- Add command and functional coverage for invalid recipient options.
- Add a success-path PHPUnit test with mocked `TransportBuilder`, transport, store configuration, and inline translation. No real mail transport is used by the test.

## Validation

- PHP syntax checks passed.
- PHP-CS-Fixer dry-run passed for the changed PHP files.
- `git diff --check` passed.
- PHPUnit could not bootstrap in this checkout because `N98_MAGERUN2_TEST_MAGENTO_ROOT` is not configured; the test requires a Magento installation.