### PR TITLE
docs(system): document email test command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ RECENT CHANGES
 - Break: raise minimum PHP requirement to 8.2 (and update laminas dependencies accordingly)
 - Break: remove the deprecated `install` command
 - Add: interactive download command for Magento/Adobe Commerce/Mage-OS
+- Add: `sys:email:test` command to send a test email for deliverability testing
 - Add: prompt interactively for `integration:create` arguments and make `integration:delete` interactive when no name is given
 - Add: `sys:website:create` and `sys:website:delete` commands
 - Add: `sys:store-group:create` and `sys:store-group:delete` commands with interactive prompts

--- a/docs/docs/command-docs/system/index.md
+++ b/docs/docs/command-docs/system/index.md
@@ -11,6 +11,9 @@ Commands for system-level information, checks, and maintenance tasks in Magento.
 
 ## Commands
 
+### Email
+- [sys:email:test](./sys-email-test.md) - Send a test email for deliverability testing
+
 ### System Information
 - sys:info - Provide system information like edition, version, cache backends
 - [sys:store:list](./sys-store-list.md) - List all store views


### PR DESCRIPTION
Add the missing `sys:email:test` documentation references omitted from the original command PR:

- Add the command to `CHANGELOG.md`.
- Add `sys:email:test` to the system command documentation index.

The detailed command documentation already exists at `docs/docs/command-docs/system/sys-email-test.md`.