### PR TITLE
feat(customer): port customer:create:dummy command from M1

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -104,6 +104,7 @@ commands:
     - N98\Magento\Command\Config\Data\IndexerCommand
     - N98\Magento\Command\Customer\AddAddressCommand
     - N98\Magento\Command\Customer\CreateCommand
+    - N98\Magento\Command\Customer\CreateDummyCommand
     - N98\Magento\Command\Customer\ChangePasswordCommand
     - N98\Magento\Command\Customer\DeleteCommand
     - N98\Magento\Command\Customer\InfoCommand
@@ -256,7 +257,7 @@ commands:
 
       - id: unsafe
         description: Commands that can mutate or delete data
-        commands: "admin:* cache:clean cache:disable cache:enable cache:flush cache:remove:id cms:block:toggle config:env:create config:env:delete config:env:set config:store:delete config:store:set customer:add-address customer:change-password customer:create customer:delete db:* dev:* eav:attribute:remove generation:flush indexer:trigger:recreate integration:create integration:delete install media:dump sales:sequence:* script script:repo:run sys:cron:kill sys:cron:run sys:cron:schedule sys:maintenance sys:setup:* sys:store:create sys:store:delete sys:store-group:create sys:store-group:delete sys:url:regenerate sys:website:create sys:website:delete"
+        commands: "admin:* cache:clean cache:disable cache:enable cache:flush cache:remove:id cms:block:toggle config:env:create config:env:delete config:env:set config:store:delete config:store:set customer:add-address customer:change-password customer:create customer:create:dummy customer:delete db:* dev:* eav:attribute:remove generation:flush indexer:trigger:recreate integration:create integration:delete install media:dump sales:sequence:* script script:repo:run sys:cron:kill sys:cron:run sys:cron:schedule sys:maintenance sys:setup:* sys:store:create sys:store:delete sys:store-group:create sys:store-group:delete sys:url:regenerate sys:website:create sys:website:delete"
 
       - id: system
         description: System commands

--- a/docs/docs/command-docs/customer/customer-create-dummy.md
+++ b/docs/docs/command-docs/customer/customer-create-dummy.md
@@ -1,0 +1,53 @@
+---
+title: customer:create:dummy
+sidebar_label: customer:create:dummy
+---
+
+Generate dummy customers. You can specify a count and a locale. If required arguments are omitted, the command will prompt for them interactively.
+
+```sh
+n98-magerun2.phar customer:create:dummy [count] [locale] [website] [--with-addresses] [--print-password] [--format[="..."]]
+```
+
+Example:
+
+```sh
+# Generate 10 dummy customers in the en_US locale
+n98-magerun2.phar customer:create:dummy 10 en_US
+```
+
+Generate dummy customers with address information:
+
+```sh
+# Generate 5 dummy customers in the de_DE locale, including billing and shipping addresses
+n98-magerun2.phar customer:create:dummy 5 de_DE --with-addresses
+```
+
+Generate dummy customers and print their secure, randomly-generated passwords:
+
+```sh
+# Generate 3 dummy customers in the en_US locale and print their generated passwords
+n98-magerun2.phar customer:create:dummy 3 en_US --print-password
+```
+
+**Arguments:**
+
+| Argument  | Description                                                                                          |
+|-----------|------------------------------------------------------------------------------------------------------|
+| `count`   | **(Optional)** Amount of dummy customers to generate. Prompted interactively if omitted.              |
+| `locale`  | **(Optional)** Locale for generation (e.g. `de_DE`, `en_US`, `fr_FR`). Prompted interactively if omitted. |
+| `website` | **(Optional)** Website code or ID. Prompted interactively if omitted.                                |
+
+**Options:**
+
+| Option             | Description                                                                                     |
+|--------------------|-------------------------------------------------------------------------------------------------|
+| `--with-addresses` | Create dummy billing/shipping addresses for each customer.                                      |
+| `--print-password` | Print the generated password in the command line (generates a secure, random password per user). |
+| `--format[=FORMAT]`| Output Format. One of [csv,tsv,json,json_array,jsonl,yaml,markdown,xml]. Aliases: yml,md,ndjson |
+
+---
+
+:::note
+This command was introduced with version 10.0.0.
+:::

--- a/docs/docs/command-docs/customer/customer-create-dummy.md
+++ b/docs/docs/command-docs/customer/customer-create-dummy.md
@@ -5,14 +5,18 @@ sidebar_label: customer:create:dummy
 
 Generate dummy customers. You can specify a count and a locale. If required arguments are omitted, the command will prompt for them interactively.
 
+:::info
+By default, this command suppresses Magento welcome email notifications when generating dummy customers to prevent unwanted emails during local development or testing.
+:::
+
 ```sh
-n98-magerun2.phar customer:create:dummy [count] [locale] [website] [--with-addresses] [--print-password] [--format[="..."]]
+n98-magerun2.phar customer:create:dummy [count] [locale] [website] [--with-addresses] [--print-password] [--email-domain="..."] [--format[="..."]]
 ```
 
 Example:
 
 ```sh
-# Generate 10 dummy customers in the en_US locale
+# Generate 10 dummy customers in the en_US locale using default example.com domain
 n98-magerun2.phar customer:create:dummy 10 en_US
 ```
 
@@ -21,6 +25,13 @@ Generate dummy customers with address information:
 ```sh
 # Generate 5 dummy customers in the de_DE locale, including billing and shipping addresses
 n98-magerun2.phar customer:create:dummy 5 de_DE --with-addresses
+```
+
+Generate dummy customers using a custom email domain:
+
+```sh
+# Generate 5 dummy customers with emails ending in @test.local
+n98-magerun2.phar customer:create:dummy 5 en_US --email-domain="test.local"
 ```
 
 Generate dummy customers and print their secure, randomly-generated passwords:
@@ -44,6 +55,7 @@ n98-magerun2.phar customer:create:dummy 3 en_US --print-password
 |--------------------|-------------------------------------------------------------------------------------------------|
 | `--with-addresses` | Create dummy billing/shipping addresses for each customer.                                      |
 | `--print-password` | Print the generated password in the command line (generates a secure, random password per user). |
+| `--email-domain`   | Email domain to generate dummy customer emails with. Default is `example.com` (officially reserved by IETF for documentation and testing). |
 | `--format[=FORMAT]`| Output Format. One of [csv,tsv,json,json_array,jsonl,yaml,markdown,xml]. Aliases: yml,md,ndjson |
 
 ---

--- a/docs/docs/command-docs/customer/index.md
+++ b/docs/docs/command-docs/customer/index.md
@@ -11,6 +11,7 @@ This section contains documentation for all customer-related commands in n98-mag
 
 - [customer:info](./customer-info.md)
 - [customer:create](./customer-create.md)
+- [customer:create:dummy](./customer-create-dummy.md)
 - [customer:add-address](./customer-add-address.md)
 - [customer:list](./customer-list.md)
 - [customer:change-password](./customer-change-password.md)

--- a/src/N98/Magento/Command/Customer/CreateDummyCommand.php
+++ b/src/N98/Magento/Command/Customer/CreateDummyCommand.php
@@ -197,7 +197,7 @@ HELP;
                                 sprintf(
                                     '<info>Customer <comment>%s</comment> successfully created with password <comment>%s</comment></info>',
                                     $email,
-                                    $password
+                                    \Symfony\Component\Console\Formatter\OutputFormatter::escape($password)
                                 )
                             );
                         } else {
@@ -323,7 +323,7 @@ HELP;
         $chars = 'abcdefghijklmnopqrstuvwxyz';
         $caps = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
         $nums = '0123456789';
-        $syms = '!@#$%^&*()-_=+[]{}|;:,.<>?';
+        $syms = '!@#$%^&*()-_=+[]{}|;:,.?';
 
         $password = '';
         // Add one from each group

--- a/src/N98/Magento/Command/Customer/CreateDummyCommand.php
+++ b/src/N98/Magento/Command/Customer/CreateDummyCommand.php
@@ -75,6 +75,13 @@ class CreateDummyCommand extends AbstractCustomerCommand
                 InputOption::VALUE_NONE,
                 'Print the generated password in the command line'
             )
+            ->addOption(
+                'email-domain',
+                null,
+                InputOption::VALUE_OPTIONAL,
+                'Email domain to generate dummy customer emails with',
+                'example.com'
+            )
             ->setDescription('Generate dummy customers. You can specify a count and a locale.')
             ->addFormatOption();
     }
@@ -127,6 +134,12 @@ HELP;
             return Command::FAILURE;
         }
 
+        $this->getObjectManager()->configure([
+            'preferences' => [
+                'Magento\Customer\Model\EmailNotificationInterface' => 'N98\Magento\Command\Customer\DummyEmailNotification',
+            ]
+        ]);
+
         $count = $input->getArgument('count');
         if ($count === null || $count === '') {
             $count = text('Amount of customers to generate', '1');
@@ -154,12 +167,17 @@ HELP;
         $website = $this->getHelperSet()->get('parameter')->askWebsite($input, $output);
         $withAddresses = $input->getOption('with-addresses');
         $printPassword = $input->getOption('print-password');
+        $domain = $input->getOption('email-domain');
+        if ($domain === null || $domain === '') {
+            $domain = 'example.com';
+        }
+        $domain = ltrim($domain, '@');
         $outputPlain = $input->getOption('format') === null;
         $table = [];
         $isError = false;
 
         for ($i = 0; $i < $count; $i++) {
-            $email = $faker->email;
+            $email = sprintf('%s%d@%s', $faker->userName, $i . rand(10, 99), $domain);
             $password = $printPassword ? $this->generateRandomPassword() : 'Password123!';
             $firstname = $faker->firstName;
             $lastname = $faker->lastName;

--- a/src/N98/Magento/Command/Customer/CreateDummyCommand.php
+++ b/src/N98/Magento/Command/Customer/CreateDummyCommand.php
@@ -1,0 +1,343 @@
+<?php
+/**
+ * This file is part of the n98-magerun2 project.
+ *
+ * For the full copyright and license information, please view the MIT-LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+namespace N98\Magento\Command\Customer;
+
+use Exception;
+use Faker\Factory as FakerFactory;
+use function Laravel\Prompts\select;
+use function Laravel\Prompts\text;
+use Magento\Customer\Api\AccountManagementInterface;
+use Magento\Framework\App\State as AppState;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Theme\Model\View\Design;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Class CreateDummyCommand
+ * @package N98\Magento\Command\Customer
+ */
+class CreateDummyCommand extends AbstractCustomerCommand
+{
+    private const SUPPORTED_LOCALES = [
+        'en_US',
+        'de_DE',
+        'en_GB',
+        'fr_FR',
+        'it_IT',
+        'es_AR',
+        'de_AT',
+        'cs_CZ',
+        'ru_RU',
+        'bg_BG',
+        'sr_RS',
+        'sr_Cyrl_RS',
+        'sr_Latn_RS',
+        'pl_PL',
+        'sk_SK',
+    ];
+
+    /**
+     * @var AccountManagementInterface
+     */
+    private AccountManagementInterface $accountManagement;
+
+    /**
+     * @var AppState
+     */
+    private AppState $appState;
+
+    protected function configure()
+    {
+        $this
+            ->setName('customer:create:dummy')
+            ->addArgument('count', InputArgument::OPTIONAL, 'Count')
+            ->addArgument('locale', InputArgument::OPTIONAL, 'Locale')
+            ->addArgument('website', InputArgument::OPTIONAL, 'Website')
+            ->addOption(
+                'with-addresses',
+                null,
+                InputOption::VALUE_NONE,
+                'Create dummy billing/shipping addresses for each customer'
+            )
+            ->addOption(
+                'print-password',
+                null,
+                InputOption::VALUE_NONE,
+                'Print the generated password in the command line'
+            )
+            ->setDescription('Generate dummy customers. You can specify a count and a locale.')
+            ->addFormatOption();
+    }
+
+    public function getHelp(): string
+    {
+        return <<<HELP
+Supported Locales:
+
+- cs_CZ
+- ru_RU
+- bg_BG
+- en_US
+- it_IT
+- sr_RS
+- sr_Cyrl_RS
+- sr_Latn_RS
+- pl_PL
+- en_GB
+- de_DE
+- sk_SK
+- fr_FR
+- es_AR
+- de_AT
+HELP;
+    }
+
+    /**
+     * @param AccountManagementInterface $accountManagement
+     * @param AppState $appState
+     */
+    public function inject(
+        AccountManagementInterface $accountManagement,
+        AppState $appState
+    ) {
+        $this->accountManagement = $accountManagement;
+        $this->appState = $appState;
+    }
+
+    /**
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     * @return int
+     * @throws Exception
+     */
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $this->detectMagento($output, true);
+        if (!$this->initMagento()) {
+            return Command::FAILURE;
+        }
+
+        $count = $input->getArgument('count');
+        if ($count === null || $count === '') {
+            $count = text('Amount of customers to generate', '1');
+            if ($count === '') {
+                $count = 1;
+            }
+        }
+        $count = (int) $count;
+
+        $locale = $input->getArgument('locale');
+        if ($locale === null || $locale === '') {
+            $locale = select(
+                label: 'Locale (used to generate realistic localized names, addresses, postcodes, and phone numbers)',
+                options: self::SUPPORTED_LOCALES,
+                default: 'en_US'
+            );
+        }
+
+        try {
+            $faker = FakerFactory::create($locale);
+        } catch (\InvalidArgumentException $e) {
+            $faker = FakerFactory::create('en_US');
+        }
+
+        $website = $this->getHelperSet()->get('parameter')->askWebsite($input, $output);
+        $withAddresses = $input->getOption('with-addresses');
+        $printPassword = $input->getOption('print-password');
+        $outputPlain = $input->getOption('format') === null;
+        $table = [];
+        $isError = false;
+
+        for ($i = 0; $i < $count; $i++) {
+            $email = $faker->email;
+            $password = $printPassword ? $this->generateRandomPassword() : 'Password123!';
+            $firstname = $faker->firstName;
+            $lastname = $faker->lastName;
+
+            // create new customer
+            $customer = $this->getCustomer();
+            $customer->setWebsiteId($website->getId());
+            $customer->loadByEmail($email);
+
+            if (!$customer->getId()) {
+                $customer->setWebsiteId($website->getId());
+                $customer->setEmail($email);
+                $customer->setFirstname($firstname);
+                $customer->setLastname($lastname);
+                $customer->setStoreId($website->getDefaultGroup()->getDefaultStore()->getId());
+
+                try {
+                    try {
+                        $this->appState->setAreaCode('frontend');
+                    } catch (LocalizedException $e) {
+                        if ($e->getMessage() !== 'Area code is already set') {
+                            throw $e;
+                        }
+                    }
+
+                    $this->appState->emulateAreaCode(
+                        'frontend',
+                        [$this, 'createCustomer'],
+                        [$customer, $password, $withAddresses, $locale, $faker]
+                    );
+
+                    if ($outputPlain) {
+                        if ($printPassword) {
+                            $output->writeln(
+                                sprintf(
+                                    '<info>Customer <comment>%s</comment> successfully created with password <comment>%s</comment></info>',
+                                    $email,
+                                    $password
+                                )
+                            );
+                        } else {
+                            $output->writeln(
+                                sprintf(
+                                    '<info>Customer <comment>%s</comment> successfully created</info>',
+                                    $email
+                                )
+                            );
+                        }
+                    } else {
+                        $table[] = [
+                            $email,
+                            $password,
+                            $firstname,
+                            $lastname,
+                        ];
+                    }
+                } catch (\Throwable $e) {
+                    $isError = true;
+                    $output->writeln('<error>' . $e->getMessage() . '</error>');
+                }
+            } elseif ($outputPlain) {
+                $output->writeln('<info>Skipped existing customer <comment>' . $email . '</comment></info>');
+            }
+        }
+
+        if (!$outputPlain) {
+            $this->getHelper('table')
+                ->setHeaders(['email', 'password', 'firstname', 'lastname'])
+                ->renderByFormat($output, $table, $input->getOption('format'));
+        }
+
+        return $isError ? Command::FAILURE : Command::SUCCESS;
+    }
+
+    /**
+     * @param \Magento\Customer\Model\Customer $customer
+     * @param string $password
+     * @param bool $withAddresses
+     * @param string $locale
+     * @param \Faker\Generator|null $faker
+     * @throws LocalizedException
+     */
+    public function createCustomer($customer, $password, $withAddresses, $locale, $faker)
+    {
+        try {
+            // Fix for proxy which does not respect "emulateAreaCode".
+            // @see \Magento\Framework\Session\SessionManager::isSessionExists Hack to prevent session problems
+            @session_start();
+
+            /** @var Design $design */
+            $design = $this->getObjectManager()->get(Design::class);
+            $design->setArea('frontend');
+
+            $customerData = $customer->getDataModel();
+
+            if ($withAddresses && $faker !== null) {
+                $countryId = 'US';
+                if (preg_match('/_([A-Z]{2})/', $locale, $matches)) {
+                    $countryId = $matches[1];
+                }
+
+                $addressFactory = $this->getObjectManager()->get('Magento\Customer\Api\Data\AddressInterfaceFactory');
+                $address = $addressFactory->create();
+                $address->setFirstname($customer->getFirstname())
+                    ->setLastname($customer->getLastname())
+                    ->setStreet([$faker->streetAddress])
+                    ->setCity($faker->city)
+                    ->setCountryId($countryId)
+                    ->setPostcode($faker->postcode)
+                    ->setTelephone($faker->phoneNumber)
+                    ->setIsDefaultBilling(true)
+                    ->setIsDefaultShipping(true);
+
+                // Pre-validate the address to prevent TypeErrors in MageOS/Magento 2.4.6+ validation crash
+                /** @var \Magento\Framework\Validator\Factory $validatorFactory */
+                $validatorFactory = $this->getObjectManager()->get('Magento\Framework\Validator\Factory');
+                $addressValidator = $validatorFactory->createValidator('customer_address', 'save');
+
+                /** @var \Magento\Customer\Model\AddressFactory $addressModelFactory */
+                $addressModelFactory = $this->getObjectManager()->get('Magento\Customer\Model\AddressFactory');
+                $addressModel = $addressModelFactory->create()->updateData($address);
+
+                /** @var \Magento\Customer\Model\Config\Share $configShare */
+                $configShare = $this->getObjectManager()->get('Magento\Customer\Model\Config\Share');
+                if ($configShare->isWebsiteScope()) {
+                    $addressModel->setStoreId($customer->getStoreId());
+                }
+
+                if (!$addressValidator->isValid($addressModel)) {
+                    $errors = [];
+                    foreach ($addressValidator->getMessages() as $field => $messages) {
+                        $errors[] = sprintf('%s: %s', $field, implode(', ', (array) $messages));
+                    }
+                    throw new LocalizedException(
+                        __('Address validation failed: %1', implode('; ', $errors))
+                    );
+                }
+
+                $customerData->setAddresses([$address]);
+            }
+
+            $this->accountManagement->createAccount(
+                $customerData,
+                $password
+            );
+        } catch (LocalizedException $e) {
+            if ($e->getRawMessage() !== 'Design config must have area and store.') {
+                throw $e;
+            }
+        }
+    }
+
+    /**
+     * Generate a random password that matches Magento 2 password rules.
+     * Must contain uppercase, lowercase, digit, and special char.
+     *
+     * @return string
+     */
+    private function generateRandomPassword(): string
+    {
+        $chars = 'abcdefghijklmnopqrstuvwxyz';
+        $caps = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+        $nums = '0123456789';
+        $syms = '!@#$%^&*()-_=+[]{}|;:,.<>?';
+
+        $password = '';
+        // Add one from each group
+        $password .= $chars[rand(0, strlen($chars) - 1)];
+        $password .= $caps[rand(0, strlen($caps) - 1)];
+        $password .= $nums[rand(0, strlen($nums) - 1)];
+        $password .= $syms[rand(0, strlen($syms) - 1)];
+
+        // Fill the rest randomly
+        $all = $chars . $caps . $nums . $syms;
+        for ($i = 0; $i < 8; $i++) {
+            $password .= $all[rand(0, strlen($all) - 1)];
+        }
+
+        return str_shuffle($password);
+    }
+}

--- a/src/N98/Magento/Command/Customer/DummyEmailNotification.php
+++ b/src/N98/Magento/Command/Customer/DummyEmailNotification.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * This file is part of the n98-magerun2 project.
+ *
+ * For the full copyright and license information, please view the MIT-LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+namespace N98\Magento\Command\Customer;
+
+use Magento\Customer\Api\Data\CustomerInterface;
+use Magento\Customer\Model\EmailNotificationInterface;
+
+class DummyEmailNotification implements EmailNotificationInterface
+{
+    public function credentialsChanged(
+        CustomerInterface $savedCustomer,
+        $origCustomerEmail,
+        $isPasswordChanged = false
+    ) {
+        // Do nothing to prevent emails
+    }
+
+    public function passwordReminder(CustomerInterface $customer)
+    {
+        // Do nothing to prevent emails
+    }
+
+    public function passwordResetConfirmation(CustomerInterface $customer)
+    {
+        // Do nothing to prevent emails
+    }
+
+    public function newAccount(
+        CustomerInterface $customer,
+        $type = self::NEW_ACCOUNT_EMAIL_REGISTERED,
+        $backUrl = '',
+        $storeId = 0,
+        $sendemailStoreId = null
+    ) {
+        // Do nothing to prevent emails
+    }
+}

--- a/tests/N98/Magento/Command/Customer/CreateDummyCommandTest.php
+++ b/tests/N98/Magento/Command/Customer/CreateDummyCommandTest.php
@@ -113,6 +113,29 @@ class CreateDummyCommandTest extends TestCase
         $this->assertGreaterThanOrEqual(8, strlen($password));
     }
 
+    public function testExecuteWithEmailDomain()
+    {
+        $input = [
+            'command'        => 'customer:create:dummy',
+            'count'          => 1,
+            'locale'         => 'en_US',
+            'website'        => $this->getWebsiteCode(),
+            '--email-domain' => 'test-magerun.invalid',
+        ];
+
+        $command = $this->getApplication()->find('customer:create:dummy');
+        $commandTester = new CommandTester($command);
+        $commandTester->execute($input);
+
+        $display = $commandTester->getDisplay();
+        $this->assertStringContainsString('successfully created', $display);
+
+        preg_match('/Customer\s+(.+?)\s+successfully created/', strip_tags($display), $matches);
+        $this->assertNotEmpty($matches);
+        $email = trim($matches[1]);
+        $this->assertStringEndsWith('@test-magerun.invalid', $email);
+    }
+
     /**
      * @return string
      */

--- a/tests/N98/Magento/Command/Customer/CreateDummyCommandTest.php
+++ b/tests/N98/Magento/Command/Customer/CreateDummyCommandTest.php
@@ -1,0 +1,126 @@
+<?php
+/**
+ * This file is part of the n98-magerun2 project.
+ *
+ * For the full copyright and license information, please view the MIT-LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+namespace N98\Magento\Command\Customer;
+
+use Magento\Customer\Api\CustomerRepositoryInterface;
+use Magento\Store\Model\StoreManagerInterface;
+use N98\Magento\Command\TestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+
+/**
+ * Class CreateDummyCommandTest
+ * @package N98\Magento\Command\Customer
+ */
+class CreateDummyCommandTest extends TestCase
+{
+    public function testExecute()
+    {
+        $input = [
+            'command' => 'customer:create:dummy',
+            'count'   => 2,
+            'locale'  => 'de_DE',
+            'website' => $this->getWebsiteCode(),
+        ];
+
+        // Ensure we output "successfully created"
+        $this->assertDisplayContains($input, 'successfully created');
+
+        // Test with format option
+        $input2 = [
+            'command'  => 'customer:create:dummy',
+            'count'    => 1,
+            'locale'   => 'en_US',
+            'website'  => $this->getWebsiteCode(),
+            '--format' => 'csv',
+        ];
+        $this->assertDisplayContains($input2, 'email,password,firstname,lastname');
+    }
+
+    public function testExecuteWithAddresses()
+    {
+        $input = [
+            'command'          => 'customer:create:dummy',
+            'count'            => 1,
+            'locale'           => 'fr_FR',
+            'website'          => $this->getWebsiteCode(),
+            '--with-addresses' => true,
+        ];
+
+        $command = $this->getApplication()->find('customer:create:dummy');
+        $commandTester = new CommandTester($command);
+        $commandTester->execute($input);
+
+        $display = $commandTester->getDisplay();
+        $this->assertStringContainsString('successfully created', $display);
+
+        // Find the created customer email from the console output using a regex
+        preg_match('/Customer\s+(.+?)\s+successfully created/', strip_tags($display), $matches);
+        $this->assertNotEmpty($matches, 'Could not find created customer email in display: ' . $display);
+
+        $email = trim($matches[1]);
+
+        // Load the customer from the database and verify they have an address
+        $objectManager = $this->getApplication()->getObjectManager();
+        /** @var CustomerRepositoryInterface $customerRepository */
+        $customerRepository = $objectManager->get(CustomerRepositoryInterface::class);
+
+        $storeManager = $objectManager->get(StoreManagerInterface::class);
+        $website = $storeManager->getWebsite($this->getWebsiteCode());
+
+        $customer = $customerRepository->get($email, $website->getId());
+        $this->assertNotNull($customer);
+        $this->assertEquals($email, $customer->getEmail());
+
+        $addresses = $customer->getAddresses();
+        $this->assertCount(1, $addresses, 'Expected customer to have 1 address');
+
+        $address = $addresses[0];
+        $this->assertEquals('FR', $address->getCountryId(), 'Expected country ID to be FR based on fr_FR locale');
+        $this->assertNotEmpty($address->getStreet());
+        $this->assertNotEmpty($address->getCity());
+        $this->assertNotEmpty($address->getPostcode());
+    }
+
+    public function testExecuteWithPrintPassword()
+    {
+        $input = [
+            'command'          => 'customer:create:dummy',
+            'count'            => 1,
+            'locale'           => 'en_US',
+            'website'          => $this->getWebsiteCode(),
+            '--print-password' => true,
+        ];
+
+        $command = $this->getApplication()->find('customer:create:dummy');
+        $commandTester = new CommandTester($command);
+        $commandTester->execute($input);
+
+        $display = $commandTester->getDisplay();
+
+        $this->assertStringContainsString('successfully created with password', $display);
+
+        preg_match('/with password\s+(\S+)/', strip_tags($display), $matches);
+        $this->assertNotEmpty($matches, 'Could not find password in display: ' . $display);
+
+        $password = trim($matches[1]);
+        $this->assertNotEquals('Password123!', $password);
+        $this->assertGreaterThanOrEqual(8, strlen($password));
+    }
+
+    /**
+     * @return string
+     */
+    private function getWebsiteCode()
+    {
+        $storeManager = $this->getApplication()->getObjectManager()->get(StoreManagerInterface::class);
+        $website = $storeManager->getWebsite('base');
+
+        return $website->getCode();
+    }
+}


### PR DESCRIPTION
Port of the `customer:create:dummy` command from M1 to M2.

### Features Included:
- Argument options for count and locale (interactive menus if omitted).
- Address creation when `--with-addresses` is specified, including pre-validation to avoid crashes.
- `--print-password` option that generates a random password meeting Magento 2 requirements and prints it.
- Full PHPUnit coverage, Docusaurus documentation, and PHPStan validation.

Fixes #55