### PR TITLE
fix(db:dump): avoid duplicate DROP/CREATE TABLE statements with --include

### DIFF
--- a/src/N98/Magento/Command/Database/DumpCommand.php
+++ b/src/N98/Magento/Command/Database/DumpCommand.php
@@ -418,8 +418,9 @@ HELP;
                 $ignore .= '--ignore-table=' . $dbName . '.' . $prefixedIgnoreItem . ' ';
             }
         }
+        $mainDumpOptions = $includeTablesUserInput ? '--no-create-info ' : '';
         $execs->add(
-            rtrim($ignore) // Use rtrim to remove trailing space if any
+            $mainDumpOptions . rtrim($ignore) // Use rtrim to remove trailing space if any
             . ' ' . $mysqlClientToolConnectionString
             . $postDumpGitFriendlyPipeCommands
             . $this->postDumpPipeCommands($input)

--- a/tests/N98/Magento/Command/Database/DumpCommandUnitTest.php
+++ b/tests/N98/Magento/Command/Database/DumpCommandUnitTest.php
@@ -135,6 +135,7 @@ class DumpCommandUnitTest extends TestCase
         $this->assertStringContainsString('--ignore-table=magento.table3', $fullOutput, 'table3 should be ignored (excluded)');
         $this->assertStringNotContainsString('--ignore-table=magento.table1', $fullOutput, 'table1 should NOT be ignored (included)');
         $this->assertStringNotContainsString('--ignore-table=magento.table2', $fullOutput, 'table2 should NOT be ignored (included)');
+        $this->assertSame(1, substr_count($fullOutput, '--no-create-info'));
     }
 
     public function testTildeExpansionInFilename()


### PR DESCRIPTION
## Summary
- When `db:dump --include=...` is used, the included tables were emitted by both the structure-only pass and the main data dump, producing duplicated `DROP TABLE IF EXISTS`/`CREATE TABLE` statements per table.
- Add `--no-create-info` to the main dump exec when include tables are present, so structure is emitted only once (by the structure-only pass) and the main dump contributes data only.

Fixes #2119

## Test plan
- [x] `./vendor/bin/phpunit tests/N98/Magento/Command/Database/DumpCommandUnitTest.php` passes, including a new assertion that `--no-create-info` appears exactly once in the generated command when `--include` is used.
