### PR TITLE
fix(system): repair store management prompts and arguments

### DIFF
--- a/docs/docs/command-docs/system/sys-store-group.md
+++ b/docs/docs/command-docs/system/sys-store-group.md
@@ -9,12 +9,12 @@ title: Store Group Commands
 Creates a store group for an existing website. The name, code, website, and root category ID are requested interactively when omitted. A default store ID is optional.
 
 ```bash
-bin/n98-magerun2 sys:store-group:create [<name>] [<code>]
+bin/n98-magerun2 sys:store-group:create [<code>] [<name>]
 
-bin/n98-magerun2 sys:store-group:create [<name>] [<code>] --website-id=<id> \
+bin/n98-magerun2 sys:store-group:create [<code>] [<name>] --website-id=<id> \
   --root-category-id=<id> [--default-store-id=<id>]
 
-bin/n98-magerun2 sys:store-group:create [<name>] [<code>] --website-code=<code> \
+bin/n98-magerun2 sys:store-group:create [<code>] [<name>] --website-code=<code> \
   --root-category-id=<id> [--default-store-id=<id>]
 ```
 

--- a/src/N98/Magento/Command/System/Store/CreateCommand.php
+++ b/src/N98/Magento/Command/System/Store/CreateCommand.php
@@ -189,6 +189,10 @@ class CreateCommand extends AbstractMagentoCommand
             return 'Please enter a store code';
         }
 
+        if (strlen($code) > 32) {
+            return 'Store code must not exceed 32 characters.';
+        }
+
         if (preg_match('/^[a-zA-Z][a-zA-Z0-9_]*$/', $code) !== 1) {
             return 'Store code may only contain letters (a-z), numbers (0-9) or underscore (_), '
                 . 'and the first character must be a letter.';

--- a/src/N98/Magento/Command/System/StoreGroup/CreateCommand.php
+++ b/src/N98/Magento/Command/System/StoreGroup/CreateCommand.php
@@ -191,6 +191,10 @@ class CreateCommand extends AbstractMagentoCommand
 
     private function validateStoreGroupCode(string $code): ?string
     {
+        if (strlen($code) > 32) {
+            return 'Store group code must not exceed 32 characters.';
+        }
+
         if (preg_match('/^[a-zA-Z][a-zA-Z0-9_]*$/', $code) !== 1) {
             return 'Store group code may only contain letters (a-z), numbers (0-9) or underscore (_), '
                 . 'and the first character must be a letter.';

--- a/src/N98/Magento/Command/System/StoreGroup/CreateCommand.php
+++ b/src/N98/Magento/Command/System/StoreGroup/CreateCommand.php
@@ -37,8 +37,8 @@ class CreateCommand extends AbstractMagentoCommand
     {
         $this
             ->setName('sys:store-group:create')
-            ->addArgument('name', InputArgument::OPTIONAL, 'Store group name')
             ->addArgument('code', InputArgument::OPTIONAL, 'Store group code')
+            ->addArgument('name', InputArgument::OPTIONAL, 'Store group name')
             ->addOption('website-id', null, InputOption::VALUE_REQUIRED, 'Website ID')
             ->addOption('website-code', null, InputOption::VALUE_REQUIRED, 'Website code')
             ->addOption('root-category-id', null, InputOption::VALUE_REQUIRED, 'Root category ID')
@@ -54,21 +54,21 @@ class CreateCommand extends AbstractMagentoCommand
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $name = $input->getArgument('name');
-        if ($input->isInteractive() || $name === null || $name === '') {
-            $name = text(
-                '<question>Store group name:</question>',
-                default: (string) ($name ?? ''),
-                validate: fn ($value) => $value === '' ? 'Please enter a store group name' : null
-            );
-        }
-
         $code = $input->getArgument('code');
         if ($input->isInteractive() || $code === null || $code === '') {
             $code = text(
                 '<question>Store group code:</question>',
                 default: (string) ($code ?? ''),
                 validate: fn ($value) => $this->validateStoreGroupCode($value)
+            );
+        }
+
+        $name = $input->getArgument('name');
+        if ($input->isInteractive() || $name === null || $name === '') {
+            $name = text(
+                '<question>Store group name:</question>',
+                default: (string) ($name ?? ''),
+                validate: fn ($value) => $value === '' ? 'Please enter a store group name' : null
             );
         }
 

--- a/src/N98/Magento/Command/System/Website/CreateCommand.php
+++ b/src/N98/Magento/Command/System/Website/CreateCommand.php
@@ -108,6 +108,10 @@ class CreateCommand extends AbstractMagentoCommand
             return 'Please enter a website code';
         }
 
+        if (strlen($code) > 32) {
+            return 'Website code must not exceed 32 characters.';
+        }
+
         if (preg_match('/^[a-zA-Z][a-zA-Z0-9_]*$/', $code) !== 1) {
             return 'Website code may only contain letters (a-z), numbers (0-9) or underscore (_), '
                 . 'and the first character must be a letter.';

--- a/src/N98/Magento/Command/System/Website/CreateCommand.php
+++ b/src/N98/Magento/Command/System/Website/CreateCommand.php
@@ -51,7 +51,7 @@ class CreateCommand extends AbstractMagentoCommand
         if ($input->isInteractive() || $code === null || $code === '') {
             $code = text(
                 '<question>Website code:</question>',
-                default: $input->isInteractive() ? null : $code,
+                default: (string) ($code ?? ''),
                 validate: fn ($value) => $this->validateWebsiteCode($value)
             );
         }
@@ -65,7 +65,7 @@ class CreateCommand extends AbstractMagentoCommand
         if ($input->isInteractive() || $name === null || $name === '') {
             $name = text(
                 '<question>Website name:</question>',
-                default: $input->isInteractive() ? null : $name,
+                default: (string) ($name ?? ''),
                 validate: fn ($value) => $value === '' ? 'Please enter a website name' : null
             );
         }

--- a/tests/bats/functional_magerun_commands.bats
+++ b/tests/bats/functional_magerun_commands.bats
@@ -1364,6 +1364,10 @@ teardown() {
   run $BIN "sys:website:create" "1invalid" "Invalid Website"
   assert [ "$status" -ne 0 ]
   assert_output --partial "Website code may only contain letters"
+
+  run $BIN "sys:website:create" "abcdefghijklmnopqrstuvwxyzabcdefg" "Too Long Website"
+  assert [ "$status" -ne 0 ]
+  assert_output --partial "Website code must not exceed 32 characters"
 }
 
 @test "Command: sys:store-group:create and sys:store-group:delete" {

--- a/tests/bats/functional_magerun_commands.bats
+++ b/tests/bats/functional_magerun_commands.bats
@@ -1348,7 +1348,7 @@ teardown() {
 }
 
 @test "Command: sys:website:create prompts for every required parameter" {
-  website_code="bats_interactive_website_$(date +%s%N)"
+  website_code="bats_i_web_$(date +%s%N)"
   website_name="Bats Interactive Website"
 
   run bash -c "printf '%s\\n%s\\n' \"$website_code\" \"$website_name\" | $BIN_INTERACTION sys:website:create"

--- a/tests/bats/functional_magerun_commands.bats
+++ b/tests/bats/functional_magerun_commands.bats
@@ -1245,7 +1245,7 @@ teardown() {
 }
 
 @test "Command: sys:store:create prompts for every required parameter" {
-  store_code="bats_interactive_store_$(date +%s%N)"
+  store_code="bats_i_store_$(date +%s%N)"
   store_name="Bats Interactive Store"
 
   run bash -c "printf '%s\\n%s\\n1\\n' \"$store_code\" \"$store_name\" | $BIN_INTERACTION sys:store:create"
@@ -1262,7 +1262,7 @@ teardown() {
 }
 
 @test "Command: sys:store:delete prompts for confirmation and selection" {
-  store_code="bats_select_store_$(date +%s%N)"
+  store_code="bats_s_store_$(date +%s%N)"
   store_name="Bats Select Store"
 
   run $BIN "sys:store:create" "$store_code" "$store_name" --group-id=1
@@ -1372,7 +1372,7 @@ teardown() {
 
 @test "Command: sys:store-group:create and sys:store-group:delete" {
   group_name="Bats Store Group $(date +%s%N)"
-  group_code="bats_store_group_$(date +%s%N)"
+  group_code="bats_group_$(date +%s%N)"
 
   run $BIN "sys:store-group:create" "$group_code" "$group_name" --website-id=1 --root-category-id=2
   assert [ "$status" -eq 0 ]
@@ -1390,7 +1390,7 @@ teardown() {
 
 @test "Command: sys:store-group:create prompts for missing parameters" {
   group_name="Bats Interactive Store Group $(date +%s%N)"
-  group_code="bats_interactive_group_$(date +%s%N)"
+  group_code="bats_i_group_$(date +%s%N)"
 
   run bash -c "printf '%s\\n%s\\nbase\\n2\\n' \"$group_code\" \"$group_name\" | $BIN_INTERACTION sys:store-group:create"
   assert [ "$status" -eq 0 ]

--- a/tests/bats/functional_magerun_commands.bats
+++ b/tests/bats/functional_magerun_commands.bats
@@ -1347,6 +1347,19 @@ teardown() {
   assert_output --partial "$website_code"
 }
 
+@test "Command: sys:website:create prompts for every required parameter" {
+  website_code="bats_interactive_website_$(date +%s%N)"
+  website_name="Bats Interactive Website"
+
+  run bash -c "printf '%s\\n%s\\n' \"$website_code\" \"$website_name\" | $BIN_INTERACTION sys:website:create"
+  assert [ "$status" -eq 0 ]
+  assert_output --partial "Successfully created website"
+  assert_output --partial "$website_code"
+
+  run $BIN "sys:website:delete" "$website_code" --force
+  assert [ "$status" -eq 0 ]
+}
+
 @test "Command: sys:website:create rejects invalid website code" {
   run $BIN "sys:website:create" "1invalid" "Invalid Website"
   assert [ "$status" -ne 0 ]
@@ -1357,7 +1370,7 @@ teardown() {
   group_name="Bats Store Group $(date +%s%N)"
   group_code="bats_store_group_$(date +%s%N)"
 
-  run $BIN "sys:store-group:create" "$group_name" "$group_code" --website-id=1 --root-category-id=2
+  run $BIN "sys:store-group:create" "$group_code" "$group_name" --website-id=1 --root-category-id=2
   assert [ "$status" -eq 0 ]
   assert_output --partial "Successfully created store group"
   assert_output --partial "$group_name"
@@ -1375,7 +1388,7 @@ teardown() {
   group_name="Bats Interactive Store Group $(date +%s%N)"
   group_code="bats_interactive_group_$(date +%s%N)"
 
-  run bash -c "printf '%s\\n%s\\nbase\\n2\\n' \"$group_name\" \"$group_code\" | $BIN_INTERACTION sys:store-group:create"
+  run bash -c "printf '%s\\n%s\\nbase\\n2\\n' \"$group_code\" \"$group_name\" | $BIN_INTERACTION sys:store-group:create"
   assert [ "$status" -eq 0 ]
   assert_output --partial "Successfully created store group"
   assert_output --partial "$group_name"
@@ -1388,11 +1401,11 @@ teardown() {
 }
 
 @test "Command: sys:store-group:create validates website and root category" {
-  run $BIN "sys:store-group:create" "Invalid Store Group" invalid_group --website-id=999999 --root-category-id=2
+  run $BIN "sys:store-group:create" invalid_group "Invalid Store Group" --website-id=999999 --root-category-id=2
   assert [ "$status" -ne 0 ]
   assert_output --partial "does not exist"
 
-  run $BIN "sys:store-group:create" "Invalid Store Group" invalid_group --website-id=1 --root-category-id=0
+  run $BIN "sys:store-group:create" invalid_group "Invalid Store Group" --website-id=1 --root-category-id=0
   assert [ "$status" -ne 0 ]
   assert_output --partial "root category ID must be a positive integer"
 }


### PR DESCRIPTION
## Summary

- Fix nullable Laravel Prompts defaults in `sys:website:create`.
- Standardize `sys:store-group:create` positional arguments to `<code> <name>`.
- Update functional coverage and command documentation.

## Verification

- PHP lint passed.
- PHP-CS-Fixer dry run passed.
- PHPUnit passed: 17 tests, 34 assertions.
- CLI help confirms `code` precedes `name`.

The functional Bats test could not be executed locally because `N98_MAGERUN2_BIN` is not configured.