### PR TITLE
fix(mcp): restore command name and boolean flag rendering for proxy commands

### DIFF
--- a/.github/workflows/mage-os_nightly_test.yml
+++ b/.github/workflows/mage-os_nightly_test.yml
@@ -117,3 +117,9 @@ jobs:
         env:
           N98_MAGERUN2_TEST_MAGENTO_ROOT: "${{ github.workspace }}/mage-os"
           N98_MAGERUN2_BIN: "${{ github.workspace }}/n98-magerun2.phar"
+
+      - name: Phar functional tests (MCP server)
+        run: bats tests/bats/functional_mcp_commands.bats
+        env:
+          N98_MAGERUN2_TEST_MAGENTO_ROOT: "${{ github.workspace }}/mage-os"
+          N98_MAGERUN2_BIN: "${{ github.workspace }}/n98-magerun2.phar"

--- a/.github/workflows/magento_platform_tests.yml
+++ b/.github/workflows/magento_platform_tests.yml
@@ -489,3 +489,9 @@ jobs:
         env:
           N98_MAGERUN2_TEST_MAGENTO_ROOT: "${{ github.workspace }}/magento"
           N98_MAGERUN2_BIN: "${{ github.workspace }}/n98-magerun2.phar"
+
+      - name: Phar functional tests (MCP server)
+        run: bats tests/bats/functional_mcp_commands.bats
+        env:
+          N98_MAGERUN2_TEST_MAGENTO_ROOT: "${{ github.workspace }}/magento"
+          N98_MAGERUN2_BIN: "${{ github.workspace }}/n98-magerun2.phar"

--- a/src/N98/Magento/Mcp/CommandToolHandler.php
+++ b/src/N98/Magento/Mcp/CommandToolHandler.php
@@ -92,9 +92,18 @@ class CommandToolHandler
     {
         $definition = $command->getDefinition();
 
-        [$parameters, $remainder] = $this->consumeOptions($definition, $arguments);
+        [$optionParameters, $remainder] = $this->consumeOptions($definition, $arguments);
 
-        $parameters['--no-interaction'] = true;
+        // Command::run() auto-fills a missing "command" argument on $input, but that happens
+        // via setArgument() after construction, which ArrayInput::__toString() never reflects.
+        // MagentoCoreProxyCommand relies on __toString() to reconstruct the proxied bin/magento
+        // shell command, so the command name must be set here explicitly.
+        $parameters = ['command' => $this->commandName] + $optionParameters;
+
+        // ArrayInput::__toString() always renders a VALUE_NONE option's `true` as `--flag=1`,
+        // which bin/magento's own option parser then rejects as "does not accept a value".
+        // An empty string renders as the bare flag instead, while still binding correctly.
+        $parameters['--no-interaction'] = '';
 
         $argumentNames = array_keys($definition->getArguments());
         $remainder = trim($remainder);
@@ -185,7 +194,9 @@ class CommandToolHandler
                 $consumed += $skippedBeforeValue + $valueLength;
             }
 
-            $parameters['--' . $option->getName()] = $value ?? true;
+            // $value is only still null here for a VALUE_NONE flag (see the --no-interaction
+            // comment above for why an empty string, not `true`, must be used for those).
+            $parameters['--' . $option->getName()] = $value ?? '';
             $offset += $consumed;
         }
 

--- a/tests/N98/Magento/Mcp/CommandToolHandlerTest.php
+++ b/tests/N98/Magento/Mcp/CommandToolHandlerTest.php
@@ -137,6 +137,73 @@ class CommandToolHandlerTest extends TestCase
         $this->assertSame(['config', 'layout'], $command->capturedInput->getArgument('type'));
     }
 
+    public function testInvokePassesCommandNameToInput()
+    {
+        $command = new class('proxy:command') extends Command {
+            /** @var InputInterface|null */
+            public $capturedInput;
+
+            protected function configure(): void
+            {
+                $this->addArgument('foo', InputArgument::OPTIONAL)
+                     ->addOption('format', null, InputOption::VALUE_OPTIONAL);
+            }
+
+            protected function execute(InputInterface $input, OutputInterface $output): int
+            {
+                $this->capturedInput = $input;
+                $output->writeln((string) $input->getArgument('foo'));
+
+                return 0;
+            }
+        };
+
+        $application = new Application();
+        $application->setAutoExit(false);
+        $application->add($command);
+
+        $handler = new CommandToolHandler($application, 'proxy:command');
+        $handler('--format=csv bar');
+
+        $this->assertNotNull($command->capturedInput);
+        $this->assertSame(
+            "'proxy:command' --format=csv --no-interaction bar",
+            (string) $command->capturedInput
+        );
+    }
+
+    public function testInvokeRendersBooleanFlagsWithoutAValue()
+    {
+        $command = new class('proxy:flag') extends Command {
+            public $capturedInput;
+
+            protected function configure(): void
+            {
+                $this->addOption('enabled', null, InputOption::VALUE_NONE);
+            }
+
+            protected function execute(InputInterface $input, OutputInterface $output): int
+            {
+                $this->capturedInput = $input;
+
+                return 0;
+            }
+        };
+
+        $application = new Application();
+        $application->setAutoExit(false);
+        $application->add($command);
+
+        $handler = new CommandToolHandler($application, 'proxy:flag');
+        $handler('--enabled');
+
+        $this->assertNotFalse($command->capturedInput->getOption('enabled'));
+        $this->assertSame(
+            "'proxy:flag' --enabled --no-interaction",
+            (string) $command->capturedInput
+        );
+    }
+
     public function testInvokeThrowsWhenCommandAcceptsNoArgumentsButExtraTextGiven()
     {
         $command = new class('proxy:noargs') extends Command {

--- a/tests/bats/functional_mcp_commands.bats
+++ b/tests/bats/functional_mcp_commands.bats
@@ -1,0 +1,61 @@
+#!/usr/bin/env bats
+
+setup() {
+    load 'test_helper/bats-support/load'
+    load 'test_helper/bats-assert/load'
+
+    declare PHP_BIN
+    if ! PHP_BIN=$(which php); then
+      echo "Error: PHP binary not found"
+      exit 1
+    fi
+
+    if [ -z "$N98_MAGERUN2_BIN" ]; then
+      echo "ENV variable N98_MAGERUN2_BIN is missing"
+      exit 1
+    fi
+
+    if [ -z "$N98_MAGERUN2_TEST_MAGENTO_ROOT" ]; then
+      echo "ENV variable N98_MAGERUN2_TEST_MAGENTO_ROOT is missing"
+      exit 1
+    fi
+
+    export BIN="${PHP_BIN} -f ${N98_MAGERUN2_BIN} -- --no-interaction --root-dir=${N98_MAGERUN2_TEST_MAGENTO_ROOT}"
+}
+
+# Speaks minimal MCP JSON-RPC (newline-delimited, per the stdio transport) to call a
+# single tool on a freshly started `mcp:server:start` process, and prints only the
+# JSON-RPC response line for that tool call.
+mcp_call_tool() {
+  local include_filter="$1"
+  local tool_name="$2"
+  local tool_arguments="$3"
+
+  printf '%s\n%s\n%s\n' \
+    '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"bats","version":"1.0"}}}' \
+    '{"jsonrpc":"2.0","method":"notifications/initialized"}' \
+    "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/call\",\"params\":{\"name\":\"${tool_name}\",\"arguments\":{\"arguments\":\"${tool_arguments}\"}}}" \
+    | $BIN "mcp:server:start" --include="${include_filter}" \
+    | grep '"id":2'
+}
+
+@test "MCP: module:status core proxy command returns actual command output (regression #2074 / #2127)" {
+  run mcp_call_tool "module:status" "module_status" ""
+  assert_success
+  assert_output --partial '"isError":false'
+  assert_output --partial "List of enabled modules"
+}
+
+@test "MCP: module:status core proxy command forwards boolean flags correctly" {
+  run mcp_call_tool "module:status" "module_status" "--enabled"
+  assert_success
+  assert_output --partial '"isError":false'
+  assert_output --partial "Magento_Catalog"
+}
+
+@test "MCP: indexer:status core proxy command returns actual command output" {
+  run mcp_call_tool "indexer:status" "indexer_status" ""
+  assert_success
+  assert_output --partial '"isError":false'
+  assert_output --partial "Update On"
+}


### PR DESCRIPTION
## Summary
- Proxy commands (e.g. `module:status`, `indexer:status`) invoked via `mcp:server:start` were regressing back to the generic `bin/magento` command list instead of returning their actual output.
- `ArrayInput::__toString()` never reflects the `command` argument that `Command::run()` fills in after construction, so `MagentoCoreProxyCommand`'s reconstructed `bin/magento` call was missing the command name.
- `ArrayInput::__toString()` also always renders a `VALUE_NONE` option's `true` as `--flag=1`, which `bin/magento`'s own option parser rejects as "does not accept a value" — this broke `--no-interaction` and any other boolean flag.
- Fixes both issues by explicitly setting `command` in the parameters array and rendering `VALUE_NONE` flags as an empty string instead of `true`.

Fixes #2127

## Test plan
- [x] Added unit tests in `CommandToolHandlerTest` covering command-name propagation and boolean flag rendering.
- [x] Added a new functional bats test (`tests/bats/functional_mcp_commands.bats`) that speaks MCP JSON-RPC over stdio to a real `mcp:server:start` process and asserts proxy commands return actual output.
- [x] Verified locally (in the project's ddev environment against a real Magento test install) that the new bats test fails with the exact regression symptoms when the fix is reverted, and passes with the fix applied.