### PR TITLE
fix(mcp): keep proxied command argument binding stable across repeated calls

### DIFF
--- a/src/N98/Magento/Mcp/CommandToolHandler.php
+++ b/src/N98/Magento/Mcp/CommandToolHandler.php
@@ -105,7 +105,15 @@ class CommandToolHandler
         // An empty string renders as the bare flag instead, while still binding correctly.
         $parameters['--no-interaction'] = '';
 
-        $argumentNames = array_keys($definition->getArguments());
+        // Command::run() merges the Application's own "command" argument into the command's
+        // definition on first use (mergeApplicationDefinition()), and that mutation sticks
+        // around on the cached Command instance for the lifetime of the process. Excluding it
+        // here keeps argument targeting stable regardless of whether this is the first or a
+        // later call against the same proxied command.
+        $argumentNames = array_values(array_filter(
+            array_keys($definition->getArguments()),
+            static fn (string $name): bool => $name !== 'command'
+        ));
         $remainder = trim($remainder);
 
         if ($remainder !== '') {

--- a/tests/N98/Magento/Mcp/CommandToolHandlerTest.php
+++ b/tests/N98/Magento/Mcp/CommandToolHandlerTest.php
@@ -204,6 +204,83 @@ class CommandToolHandlerTest extends TestCase
         );
     }
 
+    public function testInvokeBindsArgumentCorrectlyOnRepeatedCalls()
+    {
+        $command = new class('proxy:command') extends Command {
+            /** @var InputInterface|null */
+            public $capturedInput;
+
+            protected function configure(): void
+            {
+                $this->addArgument('foo', InputArgument::OPTIONAL);
+            }
+
+            protected function execute(InputInterface $input, OutputInterface $output): int
+            {
+                $this->capturedInput = $input;
+                $output->writeln((string) $input->getArgument('foo'));
+
+                return 0;
+            }
+        };
+
+        $application = new Application();
+        $application->setAutoExit(false);
+        $application->add($command);
+
+        $handler = new CommandToolHandler($application, 'proxy:command');
+
+        $firstResult = $handler('bar');
+        $this->assertSame('bar', $firstResult);
+        $this->assertSame('bar', $command->capturedInput->getArgument('foo'));
+
+        $secondResult = $handler('baz');
+        $this->assertSame('baz', $secondResult);
+        $this->assertSame('baz', $command->capturedInput->getArgument('foo'));
+    }
+
+    public function testInvokeBindsQueryArgumentOnRepeatedCalls()
+    {
+        $command = new class('proxy:query') extends Command {
+            /** @var InputInterface|null */
+            public $capturedInput;
+
+            protected function configure(): void
+            {
+                $this->addArgument('query', InputArgument::OPTIONAL);
+            }
+
+            protected function execute(InputInterface $input, OutputInterface $output): int
+            {
+                $this->capturedInput = $input;
+
+                if ($input->getArgument('query') === null) {
+                    throw new \RuntimeException('No SQL query provided. Please pass the query as a command argument.');
+                }
+
+                $output->writeln((string) $input->getArgument('query'));
+
+                return 0;
+            }
+        };
+
+        $application = new Application();
+        $application->setAutoExit(false);
+        $application->add($command);
+
+        $handler = new CommandToolHandler($application, 'proxy:query');
+
+        $this->assertSame('SELECT 1', $handler('SELECT 1'));
+        $this->assertSame(
+            'SELECT store_id, code, name FROM store LIMIT 5',
+            $handler('SELECT store_id, code, name FROM store LIMIT 5')
+        );
+        $this->assertSame(
+            'SELECT COUNT(*) FROM catalog_product_entity',
+            $handler('SELECT COUNT(*) FROM catalog_product_entity')
+        );
+    }
+
     public function testInvokeThrowsWhenCommandAcceptsNoArgumentsButExtraTextGiven()
     {
         $command = new class('proxy:noargs') extends Command {


### PR DESCRIPTION
## Summary
- Fixes #2125: `db:query` (and any single-argument proxied MCP command) only worked correctly on the first call per MCP process; every subsequent call failed with `No SQL query provided...`
- Root cause: `CommandToolHandler` resolves commands via `Application::find()`, which returns a cached `Command` instance. `Command::run()` merges the Application's own `command` argument into that instance's `InputDefinition` on first use, and the mutation persists on the cached instance for the life of the process. `CommandToolHandler::buildInput()` picked `argumentNames[0]` to receive the free-form remainder, so after the first call it targeted `command` instead of the command's real argument (e.g. `query`), leaving the real argument unset.
- Fix excludes the reserved `command` argument name when computing the target for the leftover free-form text, making the behavior independent of call order/definition-merge state.

## Test plan
- [x] Added regression tests in `tests/N98/Magento/Mcp/CommandToolHandlerTest.php` that invoke the same handler instance multiple times, including a `query`-style argument mirroring `db:query`
- [x] Confirmed the new tests fail with the exact reported error before the fix, and pass after
- [x] `vendor/bin/phpunit tests/N98/Magento/Mcp/` and full unit suite pass