### PR TITLE
fix(db-query): strip wrapping quotes recommended by --help text

### DIFF
--- a/src/N98/Magento/Command/Database/QueryCommand.php
+++ b/src/N98/Magento/Command/Database/QueryCommand.php
@@ -75,6 +75,34 @@ HELP;
     }
 
     /**
+     * Strips a single pair of wrapping quotes from the query, as recommended by this
+     * command's own --help text (e.g. `db:query "SELECT 1"`). A real shell already
+     * consumes those quotes before PHP ever sees the argument, but callers that pass
+     * the argument through directly (e.g. the MCP tool) forward them literally, which
+     * would otherwise break the SQL. A genuine query never starts and ends with the
+     * same quote character wrapping the entire statement, so stripping is safe.
+     *
+     * @param string $query
+     * @return string
+     */
+    protected function stripWrappingQuotes($query)
+    {
+        $length = strlen($query);
+        if ($length < 2) {
+            return $query;
+        }
+
+        $first = $query[0];
+        $last = $query[$length - 1];
+
+        if (($first === '"' || $first === "'") && $first === $last) {
+            return substr($query, 1, -1);
+        }
+
+        return $query;
+    }
+
+    /**
      * @param \Symfony\Component\Console\Input\InputInterface $input
      * @param \Symfony\Component\Console\Output\OutputInterface $output
      * @return int
@@ -91,6 +119,7 @@ HELP;
             $query = text('SQL Query:');
         }
 
+        $query = $this->stripWrappingQuotes($query);
         $query = $this->getEscapedSql($query);
 
         $exec = 'mysql ' . $this->getDatabaseHelper()->getMysqlClientToolConnectionString() . " -e '" . $query . "'";

--- a/tests/N98/Magento/Command/Database/QueryCommandTest.php
+++ b/tests/N98/Magento/Command/Database/QueryCommandTest.php
@@ -27,6 +27,27 @@ class QueryCommandTest extends TestCase
         $this->assertStringContainsString('"1"', $tester->getDisplay());
     }
 
+    public function testDbQueryStripsWrappingDoubleQuotes()
+    {
+        $application = $this->getApplication();
+        $this->assertTrue($application->has('db:query'), 'Command db:query should be registered.');
+
+        // A caller that forwards its argument verbatim (e.g. the MCP tool) may still
+        // include the quotes recommended by this command's own --help text. Those
+        // quotes must be stripped rather than passed through to the mysql CLI.
+        $tester = $this->assertExecute(['command' => 'db:query', 'query' => '"SELECT 1"']);
+        $this->assertStringContainsString('1', $tester->getDisplay());
+    }
+
+    public function testDbQueryStripsWrappingSingleQuotes()
+    {
+        $application = $this->getApplication();
+        $this->assertTrue($application->has('db:query'), 'Command db:query should be registered.');
+
+        $tester = $this->assertExecute(['command' => 'db:query', 'query' => "'SELECT 1'"]);
+        $this->assertStringContainsString('1', $tester->getDisplay());
+    }
+
     public function testThrowsWhenNoQueryGivenNonInteractively()
     {
         $this->mockDatabaseHelper('--host=localhost --user=test --password=test test_db');

--- a/tests/bats/functional_mcp_commands.bats
+++ b/tests/bats/functional_mcp_commands.bats
@@ -59,3 +59,23 @@ mcp_call_tool() {
   assert_output --partial '"isError":false'
   assert_output --partial "Update On"
 }
+
+# CommandToolHandler forwards the "arguments" string to a command's single scalar
+# argument completely verbatim (see its buildInput() docblock), so a query wrapped
+# in quotes as recommended by `db:query --help` reaches QueryCommand with the quotes
+# still attached. Regression coverage for #2126.
+@test "MCP: db:query strips wrapping double quotes recommended by its own --help text (regression #2126)" {
+  run mcp_call_tool "db:query" "db_query" '\"SELECT 1 AS result\"'
+  assert_success
+  assert_output --partial '"isError":false'
+  assert_output --partial "result"
+  refute_output --partial "ERROR 1064"
+}
+
+@test "MCP: db:query strips wrapping single quotes recommended by its own --help text (regression #2126)" {
+  run mcp_call_tool "db:query" "db_query" "'SELECT 1 AS result'"
+  assert_success
+  assert_output --partial '"isError":false'
+  assert_output --partial "result"
+  refute_output --partial "ERROR 1064"
+}


### PR DESCRIPTION
## Summary
- `db:query`'s own `--help` text recommends wrapping the SQL in single or double quotes, but the MCP tool forwards its `arguments` string to the command's scalar argument verbatim (by design, see #2125/#2129), so those quotes reached the `mysql` CLI literally and broke the query with `ERROR 1064`.
- `QueryCommand` now strips a single matching pair of wrapping quotes from the query before executing it. A real shell already consumes such quotes before PHP sees them, so this is a no-op for normal CLI usage and only fixes the MCP passthrough path.

## Test plan
- [x] `vendor/bin/phpunit tests/N98/Magento/Command/Database/QueryCommandTest.php` — added unit tests for double- and single-quoted queries
- [x] `bats tests/bats/functional_mcp_commands.bats` (run inside the project's DDEV container) — added end-to-end regression tests that call `db:query` via `mcp:server:start` with a quote-wrapped argument, asserting success instead of `ERROR 1064`

Fixes #2126