### PR TITLE
fix(mcp): bind VALUE_NONE flags as true instead of empty string

### DIFF
--- a/src/N98/Magento/Command/MagentoCoreProxyCommand.php
+++ b/src/N98/Magento/Command/MagentoCoreProxyCommand.php
@@ -73,11 +73,26 @@ class MagentoCoreProxyCommand extends AbstractMagentoCommand
             );
         }
 
+        // Used both to decide whether to append --no-interaction below and, further down, to
+        // enable TTY only if input is interactive and output is a terminal (not piped).
+        $isInteractive = $input->isInteractive();
+
         $shellCommand = escapeshellarg(OperatingSystem::getPhpBinary())
                       . ' '
                       . escapeshellarg($this->magentoRootDir . '/bin/magento')
                       . ' '
                       . $magentoCoreCommandInput->__toString();
+
+        // A non-interactive $input (e.g. one built by CommandToolHandler for an MCP tool call,
+        // which never puts --no-interaction into its own parameters and instead forces this via
+        // setInteractive(false)) doesn't necessarily carry a --no-interaction/-n token that
+        // __toString() would reflect. Append it explicitly so the proxied bin/magento call is
+        // non-interactive too, unless the original input already spelled it out (avoiding a
+        // duplicate flag in that case).
+        if (!$isInteractive && !$input->hasParameterOption(['--no-interaction', '-n'], true)) {
+            $shellCommand .= ' --no-interaction';
+        }
+
         $process = Process::fromShellCommandline(
             $shellCommand,
             $this->magentoRootDir,
@@ -85,8 +100,6 @@ class MagentoCoreProxyCommand extends AbstractMagentoCommand
         );
 
         $process->setTimeout($config['timeout']);
-        // Enable TTY only if input is interactive and output is a terminal (not piped)
-        $isInteractive = $input->isInteractive();
         $isOutputTerminal = function_exists('posix_isatty') && posix_isatty(STDOUT);
         $process->setTty($isInteractive && $isOutputTerminal && Process::isTtySupported());
 

--- a/src/N98/Magento/Mcp/CommandToolHandler.php
+++ b/src/N98/Magento/Mcp/CommandToolHandler.php
@@ -100,11 +100,6 @@ class CommandToolHandler
         // shell command, so the command name must be set here explicitly.
         $parameters = ['command' => $this->commandName] + $optionParameters;
 
-        // ArrayInput::__toString() always renders a VALUE_NONE option's `true` as `--flag=1`,
-        // which bin/magento's own option parser then rejects as "does not accept a value".
-        // An empty string renders as the bare flag instead, while still binding correctly.
-        $parameters['--no-interaction'] = '';
-
         // Command::run() merges the Application's own "command" argument into the command's
         // definition on first use (mergeApplicationDefinition()), and that mutation sticks
         // around on the cached Command instance for the lifetime of the process. Excluding it
@@ -202,9 +197,10 @@ class CommandToolHandler
                 $consumed += $skippedBeforeValue + $valueLength;
             }
 
-            // $value is only still null here for a VALUE_NONE flag (see the --no-interaction
-            // comment above for why an empty string, not `true`, must be used for those).
-            $parameters['--' . $option->getName()] = $value ?? '';
+            // $value is only still null here for a VALUE_NONE flag. Binding it as null (rather
+            // than an empty string) lets ArrayInput::addLongOption() apply its normal semantics
+            // and convert it to `true`, matching how a real CLI invocation binds the flag.
+            $parameters['--' . $option->getName()] = $value;
             $offset += $consumed;
         }
 

--- a/tests/N98/Magento/Mcp/CommandToolHandlerTest.php
+++ b/tests/N98/Magento/Mcp/CommandToolHandlerTest.php
@@ -166,13 +166,14 @@ class CommandToolHandlerTest extends TestCase
         $handler('--format=csv bar');
 
         $this->assertNotNull($command->capturedInput);
+        $this->assertFalse($command->capturedInput->isInteractive());
         $this->assertSame(
-            "'proxy:command' --format=csv --no-interaction bar",
+            "'proxy:command' --format=csv bar",
             (string) $command->capturedInput
         );
     }
 
-    public function testInvokeRendersBooleanFlagsWithoutAValue()
+    public function testInvokeBindsBooleanFlagsAsTrue()
     {
         $command = new class('proxy:flag') extends Command {
             public $capturedInput;
@@ -197,9 +198,12 @@ class CommandToolHandlerTest extends TestCase
         $handler = new CommandToolHandler($application, 'proxy:flag');
         $handler('--enabled');
 
-        $this->assertNotFalse($command->capturedInput->getOption('enabled'));
+        // Regression test for https://github.com/netz98/n98-magerun2/issues/2132: a VALUE_NONE
+        // flag must bind as the boolean `true`, not the empty string, so that command code
+        // checking it with a plain truthy test (`if ($input->getOption('enabled'))`) works.
+        $this->assertTrue($command->capturedInput->getOption('enabled'));
         $this->assertSame(
-            "'proxy:flag' --enabled --no-interaction",
+            "'proxy:flag' --enabled",
             (string) $command->capturedInput
         );
     }

--- a/tests/bats/functional_mcp_commands.bats
+++ b/tests/bats/functional_mcp_commands.bats
@@ -79,3 +79,24 @@ mcp_call_tool() {
   assert_output --partial "result"
   refute_output --partial "ERROR 1064"
 }
+
+# CommandToolHandler used to bind every VALUE_NONE option (e.g. customer:delete --force)
+# to the empty string instead of null, so ArrayInput never converted it to `true`. Any
+# command checking the flag with a plain truthy test (`if ($force)`) then saw it as
+# unset, so `customer:delete --email=... --force` always fell into its "Aborting delete"
+# branch instead of actually deleting. Regression coverage for #2132.
+@test "MCP: customer:delete forwards the --force VALUE_NONE flag correctly (regression #2132)" {
+  run mcp_call_tool "customer:create:dummy" "customer_create_dummy" "1 de_DE"
+  assert_success
+  assert_output --partial '"isError":false'
+
+  local email
+  email=$(echo "$output" | grep -oP '(?<=Customer )\S+(?= successfully created)')
+  [ -n "$email" ]
+
+  run mcp_call_tool "customer:delete" "customer_delete" "--email=${email} --force"
+  assert_success
+  assert_output --partial '"isError":false'
+  assert_output --partial "Successfully deleted 1 customer"
+  refute_output --partial "Aborting delete"
+}


### PR DESCRIPTION
Thank you for contributing to n98-magerun2! 🚀

Before you submit your pull request, please review the checklist below:

- [x] This pull request targets the `develop` branch (if not, please close and re-open against it)
- [ ] Documentation in the `docs/docs` directory reflects any relevant changes *(do not update the README.md for documentation)*
- [x] All tests pass, including the phar functional test (`tests/phar-test.sh`)
- [x] I have read and followed the [Contribution Guide](https://netz98.github.io/n98-magerun2/contributing/) (highly recommended for all contributors!)

---

## Related Issue(s)

Fixes #2132

## Summary

Since 10.0.1, `CommandToolHandler::consumeOptions()` bound every `VALUE_NONE` option (e.g. `customer:delete --force`) to `''` rather than `null`, purely so that `ArrayInput::__toString()` would render `--no-interaction` as a bare flag instead of `--no-interaction=1`. Since `''` is not `null`, Symfony's `ArrayInput::addLongOption()` never applied its usual null-to-`true` conversion for `VALUE_NONE` options, so any command checking such a flag with a plain truthy test (`if ($input->getOption('force'))`) saw it as unset — even though it was explicitly passed via an MCP tool call.

This PR decouples the two concerns that were conflated:

1. `consumeOptions()` now binds `null` (not `''`) for `VALUE_NONE` flags, letting `ArrayInput` apply its normal semantics and correctly bind them to `true`.
2. `--no-interaction` no longer needs special-casing in the generic option parser — `CommandToolHandler` already calls `$input->setInteractive(false)` after construction, which is sufficient to make the current command run non-interactively. Instead, `MagentoCoreProxyCommand::execute()` now appends a literal `--no-interaction` to its shelled-out `bin/magento` call whenever `$input->isInteractive()` is false (covering both MCP-originated calls and a real CLI invocation with `--no-interaction`/`-n`), with a check to avoid appending it twice when the original input already spelled it out.

## Additional Notes

- Updated `CommandToolHandlerTest` to assert a `VALUE_NONE` flag binds as the boolean `true` (regression coverage for #2132), and that non-interactivity is still forced via `setInteractive(false)` without `--no-interaction` polluting the reconstructed `ArrayInput::__toString()` output.
- Full unit suite passes locally (479 tests). The only failures are pre-existing, environment-only issues unrelated to this change (missing `mydumper` binary, a `which`-based command-injection test quirk) — both reproduce identically on `develop` without this change.

Claude-Session: https://claude.ai/code/session_01RyGDyZ7LsJGHS24AvjhYha