### PR TITLE
feat(sys-email): accept recipient as positional argument

### DIFF
--- a/docs/docs/command-docs/system/sys-email-test.md
+++ b/docs/docs/command-docs/system/sys-email-test.md
@@ -10,14 +10,15 @@ Sends a minimal test email through Magento's own mail transport, without creatin
 :::
 
 ```sh
-n98-magerun2.phar sys:email:test [--to=<email>] [--from=<email>] [--cc=<email>]... [--store=<code-or-id>]
+n98-magerun2.phar sys:email:test [<email>] [--to=<email>] [--from=<email>] [--cc=<email>]... [--store=<code-or-id>]
 ```
 
-If `--to` is omitted, you will be prompted for it interactively.
+If the email argument and `--to` are omitted, you will be prompted for the recipient interactively. If both are provided, the positional email argument takes precedence.
 
 ## Options
 
-- `--to` (required, prompted for interactively if omitted) - Recipient email address
+- `<email>` (optional, prompted for interactively if omitted) - Recipient email address
+- `--to` (optional, prompted for interactively if omitted) - Recipient email address; retained for compatibility
 - `--from` (optional) - Sender email address, defaults to the store's configured general contact email
 - `--cc` (optional, repeatable) - Additional cc email address, can be used multiple times
 - `--store` (optional) - Store code or id, defaults to the current store
@@ -26,6 +27,7 @@ If `--to` is omitted, you will be prompted for it interactively.
 
 ```sh
 n98-magerun2.phar sys:email:test
+n98-magerun2.phar sys:email:test you@example.com
 n98-magerun2.phar sys:email:test --to=you@example.com
 n98-magerun2.phar sys:email:test --to=you@example.com --store=2
 n98-magerun2.phar sys:email:test --to=you@example.com --from=sender@example.com --cc=cc1@example.com --cc=cc2@example.com

--- a/src/N98/Magento/Command/System/Email/TestCommand.php
+++ b/src/N98/Magento/Command/System/Email/TestCommand.php
@@ -21,6 +21,7 @@ use Magento\Store\Model\ScopeInterface;
 use Magento\Store\Model\StoreManagerInterface;
 use N98\Magento\Command\AbstractMagentoCommand;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -72,6 +73,7 @@ class TestCommand extends AbstractMagentoCommand
     {
         $this
             ->setName('sys:email:test')
+            ->addArgument('email', InputArgument::OPTIONAL, 'Recipient email address')
             ->addOption('to', null, InputOption::VALUE_REQUIRED, 'Recipient email address (prompted for if omitted)')
             ->addOption(
                 'from',
@@ -99,11 +101,12 @@ settings are correctly configured for a given store view.
 The email re-uses the "Contact Form" template shipped with Magento, since it does
 not require any additional data to be set up.
 
-If --to is omitted, you will be prompted for it interactively.
+If the email argument and --to are omitted, you will be prompted for the recipient interactively.
 
 Usage:
 
-    n98-magerun2 sys:email:test
+    n98-magerun2 sys:email:test [<email>]
+    n98-magerun2 sys:email:test you@example.com
     n98-magerun2 sys:email:test --to=you@example.com
     n98-magerun2 sys:email:test --to=you@example.com --store=2
     n98-magerun2 sys:email:test --to=you@example.com --from=sender@example.com --cc=cc1@example.com --cc=cc2@example.com
@@ -118,7 +121,7 @@ HELP
             return Command::FAILURE;
         }
 
-        $to = $input->getOption('to');
+        $to = $input->getArgument('email') ?: $input->getOption('to');
         if ($to === null || $to === '') {
             $to = text(
                 '<question>Recipient email address:</question>',

--- a/tests/N98/Magento/Command/System/Email/TestCommandTest.php
+++ b/tests/N98/Magento/Command/System/Email/TestCommandTest.php
@@ -101,7 +101,7 @@ class TestCommandTest extends TestCase
         $tester = new CommandTester($command);
         $status = $tester->execute([
             'command' => 'sys:email:test',
-            '--to' => 'recipient@example.com',
+            'email' => 'recipient@example.com',
             '--cc' => ['copy@example.com'],
         ]);
 
@@ -128,6 +128,14 @@ class TestCommandTest extends TestCase
     {
         $this->assertDisplayContains(
             ['command' => 'sys:email:test', '--to' => 'not-an-email'],
+            'Please provide a valid recipient email address with --to'
+        );
+    }
+
+    public function testInvalidEmailArgumentFails()
+    {
+        $this->assertDisplayContains(
+            ['command' => 'sys:email:test', 'email' => 'not-an-email'],
             'Please provide a valid recipient email address with --to'
         );
     }


### PR DESCRIPTION
Thank you for contributing to n98-magerun2! 🚀

Before you submit your pull request, please review the checklist below:

- [x] This pull request targets the `develop` branch (if not, please close and re-open against it)
- [x] Documentation in the `docs/docs` directory reflects any relevant changes *(do not update the README.md for documentation)*
- [x] All tests pass, including the phar functional test (`tests/phar-test.sh`)
- [x] I have read and followed the [Contribution Guide](https://netz98.github.io/n98-magerun2/contributing/) (highly recommended for all contributors!)

---

## Related Issue(s)

#2149 

## Summary

Added an optional positional recipient email argument to `sys:email:test`, while preserving the existing `--to` option. Added validation coverage and updated command documentation.

## Additional Notes

Focused PHPUnit execution is blocked without the Magento test environment. PHP syntax and PHP-CS-Fixer checks pass.